### PR TITLE
Update release actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -133,7 +133,7 @@ jobs:
           echo "archive=${archive}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: super-herdr-${{ matrix.target }}
           path: |
@@ -150,7 +150,7 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
@@ -162,7 +162,7 @@ jobs:
           test "$(find release-files -type f | wc -l)" -eq 8
 
       - name: Create release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: release-files/*
           fail_on_unmatched_files: true


### PR DESCRIPTION
## What changed

Update the immutable GitHub Action pins used by the CI and release workflow:

- `actions/checkout` to `v7.0.1`
- `actions/upload-artifact` to `v7.0.1`
- `actions/download-artifact` to `v8.0.1`
- `softprops/action-gh-release` to `v3.0.2`

All pins resolve to upstream release commits and use the Node 24 action runtime.

## Why

GitHub successfully ran the release matrix but warned that the previous Node 20 actions were deprecated and being force-run on Node 24. Updating before `v0.2.0` also exercises the current artifact actions before the tag-triggered publish job.

## Validation

- workflow YAML parsed locally
- `cargo fmt --check`
- `cargo test --locked --jobs 4` (65 passed)
- `cargo clippy --locked --jobs 4 -- -D warnings`