### PR TITLE
Build portable Linux release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            use_cross: false
+            use_cross: true
             strip: strip
 
           - os: ubuntu-latest
@@ -93,13 +93,18 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install Linux ARM64 build tools
+      - name: Install cross
         if: matrix.use_cross
+        shell: bash
+        run: |
+          cargo install cross --locked --version 0.2.5 --jobs 4
+
+      - name: Install Linux ARM64 strip tool
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
         shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install --yes binutils-aarch64-linux-gnu
-          cargo install cross --locked --version 0.2.5 --jobs 4
 
       - name: Build
         shell: bash
@@ -108,6 +113,18 @@ jobs:
             cross build --release --locked --jobs 4 --target "${{ matrix.target }}"
           else
             cargo build --release --locked --jobs 4 --target "${{ matrix.target }}"
+          fi
+
+      - name: Verify Linux GLIBC baseline
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          binary="target/${{ matrix.target }}/release/super-herdr"
+          highest="$(readelf --version-info "${binary}" | sed -n 's/.*Name: \(GLIBC_[0-9.]*\).*/\1/p' | sort -V | tail -n 1)"
+          baseline="GLIBC_2.28"
+          if [[ -z "${highest}" ]] || [[ "$(printf '%s\n' "${highest}" "${baseline}" | sort -V | tail -n 1)" != "${baseline}" ]]; then
+            echo "${{ matrix.target }} requires ${highest:-an unknown GLIBC version}; maximum supported is ${baseline}" >&2
+            exit 1
           fi
 
       - name: Strip binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "super-herdr"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-herdr"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 publish = false
 description = "A multi-host federation client for Herdr sessions"

--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ archive matching your platform:
 - `x86_64-unknown-linux-gnu` — Linux x86_64
 - `aarch64-unknown-linux-gnu` — Linux ARM64
 
+Linux release binaries are built with `cross` and CI rejects artifacts requiring
+newer than GLIBC 2.28.
+
 ```sh
 # Set these to an available release and one of the targets listed above.
-tag=v0.2.0
+tag=v0.2.1
 target=aarch64-apple-darwin
 archive="super-herdr-${tag}-${target}.tar.gz"
 release_url="https://github.com/mikro-design/super-herdr/releases/download/${tag}"
@@ -103,8 +106,8 @@ Install into any directory on your `PATH`; `~/.cargo/bin` matches what
 
 Pull requests and manual workflow runs execute the quality gates and build all
 four archives without publishing a release. To publish, push a `v<version>` tag
-whose version exactly matches `Cargo.toml`; for example, package version `0.2.0`
-must be tagged `v0.2.0`.
+whose version exactly matches `Cargo.toml`; for example, package version `0.2.1`
+must be tagged `v0.2.1`.
 
 ### macOS
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -18,7 +18,8 @@ Automated coverage must include qualified multi-host IDs, target failure
 isolation, atomic configuration writes, session discovery, terminal control and
 observe routing, mouse encoding, multipage selection, clipboard size/integrity
 checks, persisted UI selection, and sidebar overflow with offset-aware mouse
-targets.
+targets. Linux release jobs must reject binaries whose highest required GLIBC
+symbol version exceeds 2.28.
 
 ## Manual desktop matrix
 


### PR DESCRIPTION
## What changed

- build both Linux GNU targets through pinned `cross` tooling
- install the ARM64 strip tool only for the ARM64 matrix entry
- reject Linux artifacts whose highest required GLIBC symbol exceeds 2.28
- bump the corrected release version to `0.2.1`
- document and test the Linux ABI baseline

## Why

The published `v0.2.0` Linux x86-64 binary was built natively on `ubuntu-latest` and requires `GLIBC_2.39`. It does not run on the project's GLIBC 2.35 validation host. The ARM64 artifact already has a portable `GLIBC_2.18` floor because it used `cross`.

This fix keeps the existing release tag immutable and prepares a non-destructive corrected `v0.2.1` release.

## Validation

- workflow YAML parsed locally
- `cargo fmt --check`
- `cargo test --locked --jobs 4` (65 passed)
- `cargo clippy --locked --jobs 4 -- -D warnings`
- after CI, the x86-64 artifact will be downloaded and executed on GLIBC 2.35 before merge