### PR TITLE
Observe a pane from a client that cannot carry an emulator

### DIFF
--- a/examples/qualify-upload.rs
+++ b/examples/qualify-upload.rs
@@ -274,6 +274,9 @@ async fn relay(
             access: super_herdr::terminal::TerminalAccess::Control,
             cols: 80,
             rows: 24,
+            // This harness drives an upload, not a viewer; it wants the lease,
+            // not a rendered screen.
+            representation: super_herdr::protocol::PaneRepresentation::Frames,
         })?)
         .await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,7 +25,8 @@ use crate::daemon::server::DaemonHandle;
 use crate::model::PaneId;
 use crate::operation::Operation;
 use crate::protocol::{
-    ClientMessage, MAX_MESSAGE_BYTES, PROTOCOL_VERSION, ServerMessage, decode, encode,
+    ClientMessage, MAX_MESSAGE_BYTES, PROTOCOL_VERSION, PaneRepresentation, ServerMessage, decode,
+    encode,
 };
 use crate::state::FederationState;
 use crate::terminal::{TerminalAccess, TerminalScrollDirection};
@@ -209,12 +210,30 @@ impl ClientCommands {
         self.send(ClientMessage::SubscribeState);
     }
 
+    /// Subscribe for encoded frames, which is what a client with its own
+    /// emulator wants and what every caller here wants today.
     pub fn subscribe_pane(&self, pane: PaneId, access: TerminalAccess, cols: u16, rows: u16) {
+        self.subscribe_pane_as(pane, access, cols, rows, PaneRepresentation::Frames);
+    }
+
+    /// Subscribe naming the representation. Separate from `subscribe_pane`
+    /// rather than a fifth argument on it: the emulator-owning case is the
+    /// common one, and making every caller restate it would obscure the rare
+    /// client that genuinely cannot parse.
+    pub fn subscribe_pane_as(
+        &self,
+        pane: PaneId,
+        access: TerminalAccess,
+        cols: u16,
+        rows: u16,
+        representation: PaneRepresentation,
+    ) {
         self.send(ClientMessage::SubscribePane {
             pane,
             access,
             cols,
             rows,
+            representation,
         });
     }
 

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -72,6 +72,21 @@
   }
   #code { text-transform: uppercase; letter-spacing: .12em; font-family: ui-monospace, monospace; }
   #pair-error { color: var(--wait); min-height: 1.2em; }
+  /* The screen keeps a terminal's own dark ground in either colour scheme: a
+     program chose its colours against black, and re-grounding them on white
+     would misreport what the pane looks like. */
+  .screen {
+    position: relative; overflow-x: auto; background: #0b0d12; color: #d6dae4;
+    border: 1px solid var(--line); border-radius: .7rem; padding: .6rem .7rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    line-height: 1.25; white-space: pre; font-size: 13px;
+  }
+  .screen .line { min-height: 1.25em; }
+  .screen .cursor {
+    position: absolute; background: var(--accent); opacity: .6; pointer-events: none;
+  }
+  #viewing { font-family: ui-monospace, monospace; text-transform: none; letter-spacing: 0; }
+  #screen-note { align-self: center; }
 </style>
 
 <header>
@@ -99,6 +114,18 @@
   <h2>Recent</h2>
   <ul id="history"><li class="empty">no transitions yet</li></ul>
   <div class="actions"><button id="mark">Mark all read</button></div>
+
+  <h2>Panes</h2>
+  <ul id="panes"><li class="empty">no panes</li></ul>
+
+  <section id="viewer" hidden>
+    <h2><span id="viewing"></span></h2>
+    <div id="screen" class="screen"></div>
+    <div class="actions">
+      <button id="stop">Stop watching</button>
+      <span class="note" id="screen-note"></span>
+    </div>
+  </section>
 
   <h2>Federation</h2>
   <ul id="targets"><li class="empty">no targets</li></ul>
@@ -233,6 +260,213 @@ function renderTargets() {
   }
 }
 
+// The pane being watched, and the screen the daemon last described. Nothing is
+// derived locally: a diff that does not follow the update we hold is refused
+// rather than guessed at, because a grid painted from a missed update stays
+// wrong forever and says nothing about it.
+let watching = null;
+let screen = null;
+let cell = null;
+
+function sameId(left, right) {
+  return left && right
+    && left.target === right.target
+    && left.session === right.session
+    && left.resource === right.resource;
+}
+
+// This page's own default pair, kept in step with `.screen` in the stylesheet.
+// Inverse over defaults is resolved against these.
+const SCREEN_BG = '#0b0d12';
+const SCREEN_FG = '#d6dae4';
+
+// The sixteen the terminal names, as most terminals draw them.
+const BASE = [
+  '#000000', '#cd3131', '#0dbc79', '#e5e510', '#2472c8', '#bc3fbc', '#11a8cd', '#e5e5e5',
+  '#666666', '#f14c4c', '#23d18b', '#f5f543', '#3b8eea', '#d670d6', '#29b8db', '#ffffff',
+];
+
+// Indexed colours arrive indexed rather than resolved, because the palette
+// belongs to whoever displays them. This is that decision, made here.
+function colour(value) {
+  if (!value || value.kind === 'default') return null;
+  if (value.kind === 'rgb') return `rgb(${value.red} ${value.green} ${value.blue})`;
+  const index = value.index;
+  if (index < 16) return BASE[index];
+  if (index < 232) {
+    const level = step => (step === 0 ? 0 : 55 + step * 40);
+    const offset = index - 16;
+    return `rgb(${level(Math.floor(offset / 36))} `
+      + `${level(Math.floor(offset / 6) % 6)} ${level(offset % 6)})`;
+  }
+  const grey = 8 + (index - 232) * 10;
+  return `rgb(${grey} ${grey} ${grey})`;
+}
+
+function runStyle(style) {
+  if (!style) return '';
+  const parts = [];
+  let fg = colour(style.foreground);
+  let bg = colour(style.background);
+  // Inverse that a colour swap could not express: both sides were the
+  // terminal's defaults, so the daemon sent the flag instead of two colours
+  // that would have cancelled out. Exchanging our own defaults needs no palette
+  // knowledge, which is exactly why it was left to us.
+  if (style.inverse) {
+    fg = bg || SCREEN_BG;
+    bg = SCREEN_FG;
+  }
+  if (fg) parts.push(`color:${fg}`);
+  if (bg) parts.push(`background:${bg}`);
+  if (style.bold) parts.push('font-weight:700');
+  if (style.dim) parts.push('opacity:.65');
+  if (style.italic) parts.push('font-style:italic');
+  if (style.underline) parts.push('text-decoration:underline');
+  return parts.join(';');
+}
+
+function measure() {
+  const host = el('screen');
+  const probe = document.createElement('span');
+  probe.textContent = 'M'.repeat(20);
+  probe.style.cssText = 'position:absolute;visibility:hidden';
+  host.append(probe);
+  const width = probe.getBoundingClientRect().width / 20;
+  probe.remove();
+  return { width, height: parseFloat(getComputedStyle(host).lineHeight) };
+}
+
+// Fit the pane's own width to the viewport rather than resizing the pane: this
+// is an observer, and a viewer that reshaped what it is watching would change
+// the thing for everyone else looking at it.
+function refit() {
+  const host = el('screen');
+  if (!screen || !host.clientWidth) return;
+  host.style.fontSize = '13px';
+  const reference = measure().width;
+  const room = host.clientWidth - 2 * 0.7 * parseFloat(getComputedStyle(document.body).fontSize);
+  const wanted = 13 * (room / screen.width) / reference;
+  host.style.fontSize = `${Math.max(7, Math.min(15, wanted))}px`;
+  cell = measure();
+}
+
+function paint() {
+  const host = el('screen');
+  host.innerHTML = '';
+  if (!screen) return;
+  for (const runs of screen.rows) {
+    const line = document.createElement('div');
+    line.className = 'line';
+    for (const run of runs) {
+      const span = document.createElement('span');
+      // textContent, never innerHTML: this is output from someone's terminal.
+      span.textContent = run.text;
+      const css = runStyle(run.style);
+      if (css) span.setAttribute('style', css);
+      line.append(span);
+    }
+    host.append(line);
+  }
+  if (!cell) cell = measure();
+  // Absent when the program asked for no cursor, and then none is drawn.
+  if (screen.cursor) {
+    const mark = document.createElement('div');
+    mark.className = 'cursor';
+    mark.style.width = `${cell.width}px`;
+    mark.style.height = `${cell.height}px`;
+    mark.style.left = `calc(.7rem + ${screen.cursor.column * cell.width}px)`;
+    mark.style.top = `calc(.6rem + ${screen.cursor.row * cell.height}px)`;
+    host.append(mark);
+  }
+}
+
+function observe(pane, label) {
+  if (watching && !sameId(pane, watching)) send({ type: 'pane.unsubscribe', pane: watching });
+  watching = pane;
+  screen = null;
+  cell = null;
+  el('viewer').hidden = false;
+  el('viewing').textContent = label || `${pane.target}/${pane.session}/${pane.resource}`;
+  el('screen-note').textContent = 'waiting for output…';
+  el('screen').innerHTML = '';
+  // `screen` rather than `frames`: this page has no emulator and wants none.
+  send({
+    type: 'pane.subscribe',
+    pane,
+    access: 'observe',
+    cols: 80,
+    rows: 24,
+    representation: 'screen',
+  });
+}
+
+function stopWatching(why) {
+  if (watching) send({ type: 'pane.unsubscribe', pane: watching });
+  watching = null;
+  screen = null;
+  el('viewer').hidden = true;
+  el('screen-note').textContent = text(why);
+  renderPanes();
+}
+
+// A gap in the sequence means an update was missed. Resubscribing is the
+// recovery, because it yields a whole screen.
+function resync() {
+  if (!watching) return;
+  const pane = watching;
+  el('screen-note').textContent = 'missed an update — resyncing';
+  send({ type: 'pane.unsubscribe', pane });
+  screen = null;
+  send({
+    type: 'pane.subscribe',
+    pane,
+    access: 'observe',
+    cols: 80,
+    rows: 24,
+    representation: 'screen',
+  });
+}
+
+function renderPanes() {
+  const list = el('panes');
+  const rows = [];
+  for (const runtime of targets.values()) {
+    const snapshot = runtime.snapshot;
+    if (!snapshot) continue;
+    for (const pane of snapshot.panes || []) {
+      rows.push({ pane, snapshot });
+    }
+  }
+  list.innerHTML = '';
+  if (!rows.length) {
+    list.innerHTML = '<li class="empty">no panes</li>';
+    return;
+  }
+  for (const row of rows) {
+    const id = row.pane.id;
+    const item = document.createElement('li');
+    item.className = 'tap';
+    item.innerHTML = `<div class="row">
+        <span class="name"></span>
+        <span class="badge"></span>
+        <span class="where"></span>
+      </div>`;
+    const label = row.pane.label || id.resource;
+    item.querySelector('.name').textContent = label;
+    const badge = item.querySelector('.badge');
+    if (row.pane.agent_status) {
+      badge.textContent = row.pane.agent_status;
+      badge.classList.add(phase(row.pane.agent_status));
+    } else {
+      badge.remove();
+    }
+    item.querySelector('.where').textContent = qualify(id);
+    if (sameId(id, watching)) item.classList.add('unread');
+    item.addEventListener('click', () => observe(id, `${qualify(id)}/${label}`));
+    list.append(item);
+  }
+}
+
 function apply(message) {
   switch (message.type) {
     case 'server.hello':
@@ -245,6 +479,7 @@ function apply(message) {
       }
       renderTargets();
       renderWaiting();
+      renderPanes();
       break;
     case 'state.target': {
       const key = `${message.target.target}/${message.target.session}`;
@@ -252,8 +487,37 @@ function apply(message) {
       else targets.delete(key);
       renderTargets();
       renderWaiting();
+      renderPanes();
       break;
     }
+    case 'pane.screen':
+      if (!sameId(message.pane, watching)) break;
+      screen = message.screen;
+      el('screen-note').textContent = '';
+      refit();
+      paint();
+      break;
+    case 'pane.screen_diff': {
+      if (!sameId(message.pane, watching)) break;
+      const diff = message.diff;
+      if (!screen || diff.follows !== screen.sequence) {
+        resync();
+        break;
+      }
+      for (const update of diff.rows) screen.rows[update.row] = update.runs;
+      screen.cursor = diff.cursor;
+      screen.sequence = diff.sequence;
+      paint();
+      break;
+    }
+    case 'pane.lease':
+      if (sameId(message.pane, watching) && message.access !== 'observe') {
+        el('screen-note').textContent = `holding ${message.access}`;
+      }
+      break;
+    case 'pane.closed':
+      if (sameId(message.pane, watching)) stopWatching('the pane closed');
+      break;
     case 'attention.history':
       history = message.events;
       renderHistory();
@@ -289,6 +553,14 @@ function connect() {
 }
 
 el('mark').onclick = () => send({ type: 'attention.mark_all_seen' });
+el('stop').onclick = () => stopWatching('');
+
+// A rotation or a resize changes how much of the pane fits, not the pane.
+window.addEventListener('resize', () => {
+  if (!screen) return;
+  refit();
+  paint();
+});
 
 // The version of the daemon, not of this page: the page ships inside that
 // binary, so a stale daemon is otherwise invisible from here.

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -25,7 +25,8 @@ use std::sync::Arc;
 use crate::attention::AttentionEvent;
 use crate::model::PaneId;
 use crate::operation::Operation;
-use crate::protocol::{ClientMessage, PROTOCOL_VERSION, ServerMessage};
+use crate::protocol::{ClientMessage, PROTOCOL_VERSION, PaneRepresentation, ServerMessage};
+use crate::screen::{Diff as ScreenDiff, Snapshot};
 use crate::state::{FederationState, TargetConnectionState};
 use crate::terminal::{TerminalAccess, TerminalScrollDirection};
 
@@ -137,6 +138,11 @@ struct PaneSubscription {
     requested: TerminalAccess,
     cols: u16,
     rows: u16,
+    representation: PaneRepresentation,
+    /// The rendered update this client is known to hold, for `screen`
+    /// subscribers. `None` means it holds nothing yet and must be sent a whole
+    /// screen before a diff can mean anything to it.
+    holds: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -165,13 +171,85 @@ impl Client {
     }
 }
 
+/// One pane's rendered screen, kept only while somebody is watching it that
+/// way.
+///
+/// The emulator lives here rather than on `Route` because it is a rendering
+/// concern, not a routing one: a route exists as soon as anyone subscribes,
+/// while a parser should exist only for the panes actually being rendered.
+struct ScreenState {
+    parser: vt100::Parser,
+    /// The last screen anyone was told about. A diff is computed against this,
+    /// and its sequence is the one a diff says it follows.
+    last: Snapshot,
+}
+
+/// What one frame did to a rendered screen.
+struct Rendered {
+    screen: Snapshot,
+    /// Absent when a diff cannot express the change, which a resize guarantees.
+    diff: Option<ScreenDiff>,
+    /// False when the frame left the visible screen exactly as it was. Frames
+    /// that change nothing visible are common — a program writing a control
+    /// sequence, or output scrolled off the visible region — and sending an
+    /// empty diff for each would be traffic with nothing in it.
+    changed: bool,
+}
+
 pub struct Broker {
     server_version: String,
     features: Vec<String>,
     clients: BTreeMap<ClientId, Client>,
     routes: BTreeMap<PaneId, Route>,
+    screens: BTreeMap<PaneId, ScreenState>,
     state: FederationState,
     next_client: u64,
+}
+
+impl ScreenState {
+    fn new(width: u16, height: u16) -> Self {
+        // No scrollback: this renders the visible screen, and scrolling is
+        // routed through Herdr so the server owns the history a viewer sees.
+        let parser = vt100::Parser::new(height, width, 0);
+        let last = Snapshot::of(parser.screen(), 0);
+        Self { parser, last }
+    }
+
+    /// Feed one frame in and say what changed.
+    fn advance(&mut self, width: u16, height: u16, full: bool, bytes: &[u8]) -> Rendered {
+        let (rows, cols) = self.parser.screen().size();
+        // A full repaint restarts the program's idea of the screen, and a
+        // resize makes every cell describe something else. Both rebuild the
+        // emulator rather than feed it, which is the rule the TUI already
+        // follows for exactly the same reason.
+        if full || rows != height || cols != width {
+            self.parser = vt100::Parser::new(height, width, 0);
+        }
+        self.parser.process(bytes);
+
+        let candidate = Snapshot::of(self.parser.screen(), self.last.sequence + 1);
+        let unchanged = candidate.width == self.last.width
+            && candidate.height == self.last.height
+            && candidate.rows == self.last.rows
+            && candidate.cursor == self.last.cursor;
+        if unchanged {
+            // The sequence deliberately does not advance: a client that missed
+            // nothing should not be told it is behind.
+            return Rendered {
+                screen: self.last.clone(),
+                diff: None,
+                changed: false,
+            };
+        }
+
+        let diff = ScreenDiff::between(&self.last, &candidate);
+        self.last = candidate.clone();
+        Rendered {
+            screen: candidate,
+            diff,
+            changed: true,
+        }
+    }
 }
 
 impl Broker {
@@ -181,6 +259,7 @@ impl Broker {
             features,
             clients: BTreeMap::new(),
             routes: BTreeMap::new(),
+            screens: BTreeMap::new(),
             state: FederationState::default(),
             next_client: 0,
         }
@@ -289,7 +368,16 @@ impl Broker {
                 access,
                 cols,
                 rows,
-            } => self.subscribe_pane(client, pane, access, cols, rows, &mut effects),
+                representation,
+            } => self.subscribe_pane(
+                client,
+                pane,
+                access,
+                cols,
+                rows,
+                representation,
+                &mut effects,
+            ),
             ClientMessage::UnsubscribePane { pane } => {
                 if let Some(session) = self.clients.get_mut(&client)
                     && session.panes.remove(&pane).is_some()
@@ -474,11 +562,19 @@ impl Broker {
         let Some(route) = self.routes.get(pane) else {
             return Vec::new();
         };
-        route
-            .subscribers
-            .iter()
+
+        // One frame, two audiences. The choice is per subscriber rather than
+        // per daemon, so a TUI and a browser can watch the same pane at once
+        // and each gets the representation it can actually render.
+        let (screen_subscribers, frame_subscribers): (Vec<_>, Vec<_>) =
+            route.subscribers.iter().copied().partition(|client| {
+                self.representation_of(*client, pane) == PaneRepresentation::Screen
+            });
+
+        let mut effects: Vec<Effect> = frame_subscribers
+            .into_iter()
             .map(|client| Effect::Send {
-                client: *client,
+                client,
                 message: ServerMessage::PaneFrame {
                     pane: pane.clone(),
                     sequence,
@@ -490,7 +586,96 @@ impl Broker {
                     bytes: Arc::clone(&bytes),
                 },
             })
-            .collect()
+            .collect();
+
+        if screen_subscribers.is_empty() {
+            // Nobody is watching this pane as a screen, so nothing parses it.
+            // The parser is dropped rather than kept warm: a federation holds
+            // far more panes than anyone observes, and the cost should follow
+            // the watching.
+            self.screens.remove(pane);
+            return effects;
+        }
+
+        effects.extend(self.render_for(pane, width, height, full, &bytes, &screen_subscribers));
+        effects
+    }
+
+    fn representation_of(&self, client: ClientId, pane: &PaneId) -> PaneRepresentation {
+        self.clients
+            .get(&client)
+            .and_then(|session| session.panes.get(pane))
+            .map_or(PaneRepresentation::default(), |subscription| {
+                subscription.representation
+            })
+    }
+
+    /// Parse this frame into a screen and tell each screen subscriber what it
+    /// needs.
+    ///
+    /// A client that holds the update a diff follows gets the diff; anything
+    /// else gets a whole screen. "Anything else" is deliberately broad — a new
+    /// subscriber, a client that fell behind, a resize — because sending a diff
+    /// that cannot be applied is worse than sending more bytes than strictly
+    /// needed.
+    fn render_for(
+        &mut self,
+        pane: &PaneId,
+        width: u16,
+        height: u16,
+        full: bool,
+        bytes: &[u8],
+        subscribers: &[ClientId],
+    ) -> Vec<Effect> {
+        let rendered = self
+            .screens
+            .entry(pane.clone())
+            .or_insert_with(|| ScreenState::new(width, height))
+            .advance(width, height, full, bytes);
+
+        let mut effects = Vec::new();
+        for &client in subscribers {
+            let Some(subscription) = self
+                .clients
+                .get_mut(&client)
+                .and_then(|session| session.panes.get_mut(pane))
+            else {
+                continue;
+            };
+
+            // Up to date and nothing moved: say nothing rather than send an
+            // empty diff.
+            if !rendered.changed && subscription.holds == Some(rendered.screen.sequence) {
+                continue;
+            }
+
+            let message = match (&rendered.diff, subscription.holds) {
+                (Some(diff), Some(held)) if held == diff.follows => ServerMessage::PaneScreenDiff {
+                    pane: pane.clone(),
+                    diff: diff.clone(),
+                },
+                _ => ServerMessage::PaneScreen {
+                    pane: pane.clone(),
+                    screen: rendered.screen.clone(),
+                },
+            };
+            subscription.holds = Some(rendered.screen.sequence);
+            effects.push(Effect::Send { client, message });
+        }
+        effects
+    }
+
+    /// Drop the emulator for a pane nobody is watching as a screen any more.
+    fn release_screen_if_unwatched(&mut self, pane: &PaneId) {
+        let watched = self.routes.get(pane).is_some_and(|route| {
+            route
+                .subscribers
+                .iter()
+                .any(|client| self.representation_of(*client, pane) == PaneRepresentation::Screen)
+        });
+        if !watched {
+            self.screens.remove(pane);
+        }
     }
 
     /// The route's own stream ended. Subscribers keep their subscription
@@ -500,6 +685,7 @@ impl Broker {
         let Some(route) = self.routes.remove(pane) else {
             return Vec::new();
         };
+        self.screens.remove(pane);
         let mut effects = Vec::new();
         for client in route.subscribers {
             if let Some(session) = self.clients.get_mut(&client) {
@@ -589,6 +775,7 @@ impl Broker {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn subscribe_pane(
         &mut self,
         client: ClientId,
@@ -596,6 +783,7 @@ impl Broker {
         access: TerminalAccess,
         cols: u16,
         rows: u16,
+        representation: PaneRepresentation,
         effects: &mut Vec<Effect>,
     ) {
         let Some(session) = self.clients.get_mut(&client) else {
@@ -607,6 +795,8 @@ impl Broker {
                 requested: access,
                 cols,
                 rows,
+                representation,
+                holds: None,
             },
         );
 
@@ -644,6 +834,27 @@ impl Broker {
                 access
             }
         };
+
+        // A screen subscriber that arrives mid-stream would otherwise see
+        // nothing until the pane next produced output, which for an idle pane
+        // is indistinguishable from a broken viewer.
+        if representation == PaneRepresentation::Screen
+            && let Some(state) = self.screens.get(&pane)
+        {
+            let screen = state.last.clone();
+            if let Some(session) = self.clients.get_mut(&client)
+                && let Some(subscription) = session.panes.get_mut(&pane)
+            {
+                subscription.holds = Some(screen.sequence);
+            }
+            effects.push(Effect::Send {
+                client,
+                message: ServerMessage::PaneScreen {
+                    pane: pane.clone(),
+                    screen,
+                },
+            });
+        }
 
         effects.push(Effect::Send {
             client,
@@ -752,14 +963,23 @@ impl Broker {
             return;
         };
         route.subscribers.remove(&client);
-        if route.subscribers.is_empty() {
+        let emptied = route.subscribers.is_empty();
+        let held_control = route.control == Some(client);
+        if emptied {
             self.routes.remove(pane);
+            self.screens.remove(pane);
             effects.push(Effect::CloseRoute { pane: pane.clone() });
             return;
         }
-        if route.control != Some(client) {
+        // The one leaving may have been the last watching this pane as a
+        // screen, and the emulator should go with them.
+        self.release_screen_if_unwatched(pane);
+        if !held_control {
             return;
         }
+        let Some(route) = self.routes.get_mut(pane) else {
+            return;
+        };
 
         // The control holder left. The lease is not handed to an observer that
         // never asked for it; the route drops back to observation and the
@@ -831,7 +1051,8 @@ mod tests {
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{PaneId, TargetSession};
     use crate::operation::Operation;
-    use crate::protocol::{ClientMessage, PROTOCOL_VERSION, ServerMessage};
+    use crate::protocol::{ClientMessage, PROTOCOL_VERSION, PaneRepresentation, ServerMessage};
+    use crate::screen::Snapshot;
     use crate::state::{
         FederationState, NormalizedSnapshot, PaneState, TargetConnectionState, TargetRuntimeState,
         TargetUpdateMode,
@@ -916,6 +1137,21 @@ mod tests {
         }
     }
 
+    fn frame(broker: &mut Broker, resource: &str, bytes: &[u8]) -> Vec<Effect> {
+        broker.pane_frame(&pane(resource), 1, 80, 24, false, Arc::from(bytes.to_vec()))
+    }
+
+    fn rendered_row(broker: &Broker, resource: &str, row: usize) -> String {
+        row_text(&broker.screens[&pane(resource)].last, row)
+    }
+
+    fn row_text(screen: &Snapshot, row: usize) -> String {
+        screen.rows[row]
+            .iter()
+            .map(|run| run.text.as_str())
+            .collect()
+    }
+
     fn messages_for(effects: &[Effect], client: ClientId) -> Vec<ServerMessage> {
         effects
             .iter()
@@ -937,6 +1173,27 @@ mod tests {
         cols: u16,
         rows: u16,
     ) -> Vec<Effect> {
+        subscribe_as(
+            broker,
+            client,
+            resource,
+            access,
+            cols,
+            rows,
+            PaneRepresentation::Frames,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn subscribe_as(
+        broker: &mut Broker,
+        client: ClientId,
+        resource: &str,
+        access: TerminalAccess,
+        cols: u16,
+        rows: u16,
+        representation: PaneRepresentation,
+    ) -> Vec<Effect> {
         broker.handle(
             client,
             ClientMessage::SubscribePane {
@@ -944,6 +1201,7 @@ mod tests {
                 access,
                 cols,
                 rows,
+                representation,
             },
         )
     }
@@ -1547,6 +1805,272 @@ mod tests {
 
         assert_eq!(messages_for(&effects, watching).len(), 1);
         assert!(messages_for(&effects, elsewhere).is_empty());
+    }
+
+    /// The whole point of the second representation: one pane, two clients,
+    /// each rendering what it is able to.
+    #[test]
+    fn one_frame_serves_an_emulator_client_and_a_screen_client_at_once() {
+        let mut broker = broker();
+        let tui = greet(&mut broker);
+        let browser = greet(&mut broker);
+        subscribe(&mut broker, tui, "w1:p1", TerminalAccess::Observe, 80, 24);
+        subscribe_as(
+            &mut broker,
+            browser,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+
+        let effects = frame(&mut broker, "w1:p1", b"hello");
+
+        assert!(
+            matches!(
+                messages_for(&effects, tui).as_slice(),
+                [ServerMessage::PaneFrame { .. }]
+            ),
+            "the emulator client still receives untouched bytes"
+        );
+        let browser_messages = messages_for(&effects, browser);
+        let [ServerMessage::PaneScreen { screen, .. }] = browser_messages.as_slice() else {
+            panic!("expected one rendered screen, got {browser_messages:?}");
+        };
+        assert_eq!(row_text(screen, 0), "hello");
+    }
+
+    #[test]
+    fn a_screen_subscriber_is_sent_a_whole_screen_before_any_diff() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+
+        let effects = frame(&mut broker, "w1:p1", b"hello");
+
+        assert!(
+            matches!(
+                messages_for(&effects, viewer).as_slice(),
+                [ServerMessage::PaneScreen { .. }]
+            ),
+            "a client holding nothing cannot apply a diff"
+        );
+    }
+
+    #[test]
+    fn a_later_frame_reaches_a_screen_subscriber_as_a_diff_naming_what_it_follows() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+
+        let first = frame(&mut broker, "w1:p1", b"hello");
+        let held = match messages_for(&first, viewer).as_slice() {
+            [ServerMessage::PaneScreen { screen, .. }] => screen.sequence,
+            other => panic!("expected a whole screen, got {other:?}"),
+        };
+
+        let second = frame(&mut broker, "w1:p1", b"\r\nworld");
+        let messages = messages_for(&second, viewer);
+        let [ServerMessage::PaneScreenDiff { diff, .. }] = messages.as_slice() else {
+            panic!("expected a diff once the client holds a screen, got {messages:?}");
+        };
+        assert_eq!(
+            diff.follows, held,
+            "a diff must name the update it applies to"
+        );
+        assert!(
+            diff.rows.iter().any(|update| update.row == 1),
+            "the second line changed and the diff should say so: {:?}",
+            diff.rows
+        );
+    }
+
+    /// A terminal emits plenty that leaves the visible screen exactly as it
+    /// was. Sending an empty diff for each would be traffic carrying nothing.
+    #[test]
+    fn a_frame_that_changes_nothing_visible_is_not_sent_as_a_screen() {
+        let mut broker = broker();
+        let tui = greet(&mut broker);
+        let browser = greet(&mut broker);
+        subscribe(&mut broker, tui, "w1:p1", TerminalAccess::Observe, 80, 24);
+        subscribe_as(
+            &mut broker,
+            browser,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        frame(&mut broker, "w1:p1", b"hello");
+
+        // Setting attributes paints no cell and moves no cursor.
+        let effects = frame(&mut broker, "w1:p1", b"\x1b[0m");
+
+        assert!(
+            messages_for(&effects, browser).is_empty(),
+            "nothing visible changed, so the screen client hears nothing"
+        );
+        assert_eq!(
+            messages_for(&effects, tui).len(),
+            1,
+            "the frame itself is still delivered untouched to an emulator client"
+        );
+    }
+
+    #[test]
+    fn a_resize_sends_a_whole_screen_because_a_diff_cannot_express_it() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        frame(&mut broker, "w1:p1", b"hello");
+
+        let effects =
+            broker.pane_frame(&pane("w1:p1"), 9, 100, 30, false, Arc::from(b"!".to_vec()));
+
+        let messages = messages_for(&effects, viewer);
+        let [ServerMessage::PaneScreen { screen, .. }] = messages.as_slice() else {
+            panic!("a resized screen cannot arrive as a diff, got {messages:?}");
+        };
+        assert_eq!((screen.width, screen.height), (100, 30));
+    }
+
+    /// A full repaint restarts the program's idea of the screen, so the
+    /// emulator is rebuilt rather than fed. The two payloads differ in length
+    /// deliberately: an emulator that was appended to would leave the tail of
+    /// the old line visible past the end of the new one.
+    #[test]
+    fn a_full_frame_restarts_the_emulator_rather_than_writing_over_it() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        frame(&mut broker, "w1:p1", b"a long stale line");
+
+        let effects =
+            broker.pane_frame(&pane("w1:p1"), 9, 80, 24, true, Arc::from(b"new".to_vec()));
+
+        assert_eq!(
+            rendered_row(&broker, "w1:p1", 0),
+            "new",
+            "a full repaint must not leave the previous line's tail behind"
+        );
+        assert!(
+            !messages_for(&effects, viewer).is_empty(),
+            "the viewer is told about the repaint"
+        );
+    }
+
+    #[test]
+    fn nothing_is_parsed_for_a_pane_watched_only_as_frames() {
+        let mut broker = broker();
+        let tui = greet(&mut broker);
+        subscribe(&mut broker, tui, "w1:p1", TerminalAccess::Observe, 80, 24);
+
+        frame(&mut broker, "w1:p1", b"hello");
+
+        assert!(
+            broker.screens.is_empty(),
+            "a pane nobody renders should cost no emulator"
+        );
+    }
+
+    #[test]
+    fn the_emulator_is_dropped_when_the_last_screen_subscriber_leaves() {
+        let mut broker = broker();
+        let tui = greet(&mut broker);
+        let browser = greet(&mut broker);
+        subscribe(&mut broker, tui, "w1:p1", TerminalAccess::Observe, 80, 24);
+        subscribe_as(
+            &mut broker,
+            browser,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        frame(&mut broker, "w1:p1", b"hello");
+        assert!(broker.screens.contains_key(&pane("w1:p1")));
+
+        broker.handle(
+            browser,
+            ClientMessage::UnsubscribePane {
+                pane: pane("w1:p1"),
+            },
+        );
+
+        assert!(
+            broker.screens.is_empty(),
+            "the route outlives the viewer, but the emulator should not"
+        );
+    }
+
+    /// An idle pane produces no output, so a viewer that had to wait for the
+    /// next frame would be indistinguishable from a broken one.
+    #[test]
+    fn a_screen_subscriber_arriving_mid_stream_is_sent_the_screen_as_it_stands() {
+        let mut broker = broker();
+        let first = greet(&mut broker);
+        let second = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            first,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        frame(&mut broker, "w1:p1", b"already here");
+
+        let effects = subscribe_as(
+            &mut broker,
+            second,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+
+        let messages = messages_for(&effects, second);
+        let Some(ServerMessage::PaneScreen { screen, .. }) = messages.first() else {
+            panic!("expected the current screen on subscribing, got {messages:?}");
+        };
+        assert_eq!(row_text(screen, 0), "already here");
     }
 
     #[test]

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -2178,7 +2178,9 @@ mod tests {
     use super::{DaemonOptions, MAX_RETAINED_TRANSFERS, invalidated_routes, serve, serve_until};
     use crate::config::{Config, Target};
     use crate::model::PaneId;
-    use crate::protocol::{ClientMessage, PROTOCOL_VERSION, ServerMessage, decode, encode};
+    use crate::protocol::{
+        ClientMessage, PROTOCOL_VERSION, PaneRepresentation, ServerMessage, decode, encode,
+    };
     use crate::terminal::TerminalAccess;
 
     /// A federation with no targets exercises the whole I/O path without
@@ -2572,6 +2574,7 @@ mod tests {
                 access: TerminalAccess::Control,
                 cols: 80,
                 rows: 24,
+                representation: PaneRepresentation::Frames,
             })
             .await;
         pane
@@ -2709,6 +2712,7 @@ mod tests {
                 access: TerminalAccess::Control,
                 cols: 80,
                 rows: 24,
+                representation: PaneRepresentation::Frames,
             })
             .await;
         connection

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -16,9 +16,15 @@
 //!   material, a Herdr socket path, a `herdr` binary candidate, or any other
 //!   credential or transport detail, so a paired device cannot reach a host
 //!   except through the daemon's own routing.
-//! * Terminal payloads stay opaque. Frames and input are base64 byte strings
-//!   passed through untouched, preserving the rule that encoded ANSI reaches a
-//!   renderer without a lossy intermediate screen model.
+//! * Terminal payloads stay opaque on the frame path. Frames and input are
+//!   base64 byte strings passed through untouched, so encoded ANSI reaches a
+//!   renderer without a *double* parse: nothing here decodes it and re-encodes
+//!   it on the way, which is what would hand a renderer something degraded.
+//!   A client that cannot carry an emulator may ask for a rendered screen
+//!   instead (`PaneRepresentation::Screen`). That is one parse moved to the end
+//!   that can afford it, not a lossy middle, and it reaches the same fidelity
+//!   ceiling a client-side `vt100` would. The frame path is unchanged by it and
+//!   remains the primary one.
 //!
 //! Unknown fields are ignored rather than rejected: a newer daemon must be able
 //! to add a field without breaking an older client that negotiated the same
@@ -34,6 +40,7 @@ use serde::{Deserialize, Serialize};
 use crate::attention::AttentionEvent;
 use crate::model::{PaneId, TargetSession};
 use crate::operation::Operation;
+use crate::screen::{Diff as ScreenDiff, Snapshot};
 use crate::state::{FederationState, TargetRuntimeState};
 use crate::terminal::{TerminalAccess, TerminalScrollDirection};
 
@@ -48,6 +55,24 @@ pub const PROTOCOL_VERSION: u32 = 1;
 /// a third. This leaves room for both while keeping a peer from forcing
 /// unbounded buffering by never sending a newline.
 pub const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
+
+/// What a pane subscriber is sent for each frame.
+///
+/// Two representations of the same terminal, chosen per subscription rather
+/// than per daemon, because the right answer differs by client in the same
+/// federation: the TUI owns a parser and wants the bytes, a browser cannot
+/// carry one and wants the result. The daemon parses only for panes somebody is
+/// actually watching this way, which is the cost the TUI already pays per
+/// visible pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaneRepresentation {
+    /// Encoded terminal output, rendered by a client that owns an emulator.
+    #[default]
+    Frames,
+    /// A rendered screen, for a client that cannot.
+    Screen,
+}
 
 /// Sent by a client. Requests that report an outcome carry a `request`
 /// identifier the daemon echoes, so a client can correlate a result without
@@ -71,6 +96,10 @@ pub enum ClientMessage {
         access: TerminalAccess,
         cols: u16,
         rows: u16,
+        /// What this subscriber wants to receive. Absent means `frames`, so a
+        /// client written before this existed keeps the behaviour it had.
+        #[serde(default)]
+        representation: PaneRepresentation,
     },
     #[serde(rename = "pane.unsubscribe")]
     UnsubscribePane { pane: PaneId },
@@ -231,6 +260,20 @@ pub enum ServerMessage {
         #[serde(with = "base64_bytes")]
         bytes: Arc<[u8]>,
     },
+    /// A rendered screen, whole. Sent to a `screen` subscriber for its first
+    /// update, and again whenever a diff cannot express the change — a resize
+    /// makes every row describe different cells, and a full repaint restarts
+    /// the emulator, so in both cases a snapshot is the only honest answer.
+    #[serde(rename = "pane.screen")]
+    PaneScreen { pane: PaneId, screen: Snapshot },
+    /// The rows of a rendered screen that changed.
+    ///
+    /// `follows` names the update it applies to, so a client that missed one
+    /// refuses to paint instead of holding a grid that is wrong forever and
+    /// silent about it. The recovery is to resubscribe, which yields a fresh
+    /// `PaneScreen`.
+    #[serde(rename = "pane.screen_diff")]
+    PaneScreenDiff { pane: PaneId, diff: ScreenDiff },
     #[serde(rename = "pane.closed")]
     PaneClosed { pane: PaneId },
     /// The access a pane subscription actually holds. A control lease that is
@@ -373,7 +416,8 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        ClientMessage, MAX_MESSAGE_BYTES, PROTOCOL_VERSION, ServerMessage, decode, encode,
+        ClientMessage, MAX_MESSAGE_BYTES, PROTOCOL_VERSION, PaneRepresentation, ServerMessage,
+        decode, encode,
     };
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{PaneId, TargetSession, WorkspaceId};
@@ -415,6 +459,14 @@ mod tests {
             access: TerminalAccess::Control,
             cols: 120,
             rows: 40,
+            representation: PaneRepresentation::Frames,
+        });
+        round_trip_client(ClientMessage::SubscribePane {
+            pane: pane(),
+            access: TerminalAccess::Observe,
+            cols: 120,
+            rows: 40,
+            representation: PaneRepresentation::Screen,
         });
         round_trip_client(ClientMessage::UnsubscribePane { pane: pane() });
         round_trip_client(ClientMessage::TakePaneControl { pane: pane() });

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4277,6 +4277,10 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
                 };
             }
         }
+        // The TUI owns a `vt100` parser and subscribes for frames, so the daemon
+        // never renders on its behalf. Ignored rather than logged: arriving here
+        // would mean this client asked for screens, and it has no code that does.
+        ServerMessage::PaneScreen { .. } | ServerMessage::PaneScreenDiff { .. } => {}
         ServerMessage::PaneClosed { pane } => {
             app.routes.remove(&pane);
             // Wait before asking again, so a pane that cannot be opened does not


### PR DESCRIPTION
A browser cannot carry a VT emulator. Vendoring one means roughly a megabyte of
third-party JavaScript inside a signed binary, in the component most exposed to a
network, shipping input handling to a viewer that is deliberately read-only. So
the parse happens where a parser already exists — in the daemon, which has
`vt100` as a dependency and already parses per visible pane for the TUI.

This is the client half of the work `screen.rs` started: the protocol messages,
the rendering in the broker, and the painter in the page.

## What changes

**A subscription names what it wants.** `ClientMessage::SubscribePane` gains
`representation`. `frames` is the default and is unchanged, so a client written
before this keeps the behaviour it had; one that asks for `screen` is sent
`pane.screen` and `pane.screen_diff` instead. Both are served from a single
parse of a single frame, so a TUI and a browser can watch the same pane at once
and each gets what it can actually render.

**The emulator lives on the broker, not on `Route`.** A route exists as soon as
anyone subscribes, while a parser should exist only for panes someone is
actually rendering — so it is created with the first screen subscriber and
dropped with the last. A federation holds far more panes than anyone observes,
and the cost should follow the watching.

**Two rules are mirrored from the TUI** because they are the same rules: a full
repaint or a resize rebuilds the emulator rather than feeding it. One rule is
new here — a frame that leaves the visible screen unchanged sends nothing *and
does not advance the sequence*, because a client that missed nothing should not
be told that it is behind.

**The page paints a grid of styled spans**, with no escape handling and no
emulator. Indexed colours are resolved against a palette in the page, because
the palette belongs to whoever paints them. A diff that does not follow the
update the page holds is refused and the page resubscribes for a whole screen;
painting it would leave a grid that is wrong for as long as the pane stays open,
and silent about being wrong.

## An invariant is amended rather than explained away

`protocol.rs` said encoded ANSI must reach a renderer "without a lossy
intermediate screen model". That rule guards against a **double** parse, where a
middle decodes and re-encodes and hands a renderer something degraded. This is
one parse moved to the end that can afford it, delivered directly, and it
reaches the same fidelity ceiling a client-side `vt100` would — the TUI already
reduces to a `vt100` screen. The wording said more than it meant, so it now says
what it means.

## What this does not touch

`web.rs` needed **no change at all**: `/command` already forwards any client
message the protocol accepts and `/events` streams anything back, so the new
messages ride the existing transport. `server.rs` is untouched apart from three
test-only lines (a field on two `SubscribePane` literals and one test-module
import) that a struct-literal change makes unavoidable.

## Verification

- 225 tests, including nine covering the new behaviour: the two-audience case,
  snapshot-before-diff, a diff naming what it follows, the no-change skip, the
  resize and full-repaint paths, parser lifetime at both ends, and a late
  subscriber being sent the screen as it stands.
- Two of those were mutation-checked rather than trusted: removing the `full ||`
  emulator reset and disabling the no-change skip each fail the test that claims
  to cover them.
- The page was checked against the daemon's real output rather than an assumed
  shape — a `Snapshot` and `Diff` generated through the actual types, with the
  page's own colour and diff code run over that JSON. Indexed, the 6x6x6 cube,
  greyscale, RGB backgrounds, bold and diff application all agree.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean on
  the host and on `x86_64-apple-darwin`.

That cross-check is also what surfaced the inverse-video bug fixed separately in
`e3e89c5`: inverse over default colours was serializing as a plain run, so a
viewer painted ordinary text where the terminal showed a highlight. The painter
here honours the `inverse` flag that fix introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmAj6nkoj5U8jTdGGXcFvb