### PR TITLE
Bound what a viewer that stops painting can hold

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -490,6 +490,55 @@ text, exactly as the desktop path already guarantees. Because a single-machine
 install should not require operating a service, the TUI retains an in-process
 mode that runs the daemon's responsibilities inside the frontend process.
 
+### Two representations of a pane
+
+A pane subscription names what it wants. `frames` is the default and carries
+encoded ANSI untouched, which is what a client owning a VT parser wants and what
+the TUI uses. `screen` carries a rendered screen instead, for a client that
+cannot carry an emulator: vendoring one into the browser page would mean a
+megabyte of third-party JavaScript inside a signed binary, in the component most
+exposed to a network, shipping input handling to a viewer that is deliberately
+read-only.
+
+This does not weaken the rule that encoded ANSI reaches a renderer without a
+lossy intermediate model. That rule forbids a *double* parse — a middle that
+decodes and re-encodes and hands a renderer something degraded. A rendered
+screen is one parse moved to whichever end can afford it, delivered directly,
+and it reaches the same ceiling a client-side `vt100` would, because the TUI
+already reduces to a `vt100` screen. Both representations are served from a
+single parse of a single frame, so a TUI and a browser can watch one pane at
+once. The emulator is created with the first screen subscriber and dropped with
+the last, so a pane nobody renders costs nothing.
+
+A full repaint or a resize rebuilds the emulator rather than feeding it, which
+is the rule the TUI already follows. A frame that leaves the visible screen
+unchanged sends nothing and does not advance the sequence: a client that missed
+nothing should not be told that it is behind.
+
+### Backpressure on rendered updates
+
+A frame subscriber needs no flow control, because the socket provides it — a
+client that stops draining stops the daemon reading. A rendered update is queued
+into an unbounded outbox instead, so nothing in the transport pushes back, and a
+viewer on a slow link watching a busy pane would accumulate one message per
+frame in the daemon's memory.
+
+So the depth is bounded here. A screen subscriber may hold a small number of
+updates, the daemon decides how many, and a viewer acknowledges each update once
+it has painted it. An acknowledgement is checked against what that subscription
+was actually sent: acknowledging twice, or acknowledging something never sent,
+changes nothing. It reports progress rather than granting anything, for the same
+reason a resume token is not authority and a download's credit is a request
+rather than an instruction.
+
+What a viewer that fell behind is sent when it catches up is the screen as it
+stands, not the backlog it missed — which is both fewer bytes and the thing it
+actually wants. Frames cannot do this, because every byte matters to a parser
+consuming them statefully. A snapshot can, because it is self-contained and
+carries the sequence that tells a client what it skipped. That asymmetry is the
+argument for the second representation, and it bounds the cost of a viewer
+however far behind it falls.
+
 ## File bridge
 
 Moving a file between the machine a person is holding, the daemon host, and the

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -380,6 +380,16 @@ function paint() {
   }
 }
 
+// Sent only after the update is on the screen, because that is what it claims.
+// The daemon holds a small number of updates for this viewer and sends no more
+// until they are painted, so a phone on a slow link falls behind rather than
+// filling the daemon with a pane's history — and what it is sent when it
+// catches up is the screen as it stands, not the backlog it missed.
+function acknowledge() {
+  if (!watching || !screen) return;
+  send({ type: 'pane.screen_ack', pane: watching, sequence: screen.sequence });
+}
+
 function observe(pane, label) {
   if (watching && !sameId(pane, watching)) send({ type: 'pane.unsubscribe', pane: watching });
   watching = pane;
@@ -496,6 +506,7 @@ function apply(message) {
       el('screen-note').textContent = '';
       refit();
       paint();
+      acknowledge();
       break;
     case 'pane.screen_diff': {
       if (!sameId(message.pane, watching)) break;
@@ -508,6 +519,7 @@ function apply(message) {
       screen.cursor = diff.cursor;
       screen.sequence = diff.sequence;
       paint();
+      acknowledge();
       break;
     }
     case 'pane.lease':

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -162,10 +162,18 @@ struct PaneSubscription {
     cols: u16,
     rows: u16,
     representation: PaneRepresentation,
-    /// The rendered update this client is known to hold, for `screen`
-    /// subscribers. `None` means it holds nothing yet and must be sent a whole
-    /// screen before a diff can mean anything to it.
-    holds: Option<u64>,
+    /// The rendered update last sent to this client. `None` means it has been
+    /// sent nothing yet and must receive a whole screen before a diff can mean
+    /// anything to it.
+    sent: Option<u64>,
+    /// The last update this client said it painted.
+    acked: Option<u64>,
+    /// Updates sent and not yet acknowledged.
+    ///
+    /// Counted rather than derived from the sequences, because a whole screen
+    /// sent to a client that fell behind advances the sequence by more than one
+    /// while being a single update.
+    outstanding: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -193,6 +201,16 @@ impl Client {
         }
     }
 }
+
+/// How many rendered updates one screen subscriber may have outstanding.
+///
+/// A frame subscriber needs no such number: the socket stops the daemon reading
+/// when a client stops draining. A rendered update is queued into an unbounded
+/// outbox instead, so nothing in the transport pushes back and a viewer on a
+/// slow link watching a busy pane would accumulate without limit in this
+/// process. The daemon chooses the depth; an acknowledgement reports progress
+/// against what was actually sent and cannot ask for more than this.
+const MAX_OUTSTANDING_SCREEN_UPDATES: u32 = 4;
 
 /// One pane's rendered screen, kept only while somebody is watching it that
 /// way.
@@ -401,6 +419,9 @@ impl Broker {
                 representation,
                 &mut effects,
             ),
+            ClientMessage::AckPaneScreen { pane, sequence } => {
+                self.ack_pane_screen(client, &pane, sequence, &mut effects);
+            }
             ClientMessage::UnsubscribePane { pane } => {
                 if let Some(session) = self.clients.get_mut(&client)
                     && session.panes.remove(&pane).is_some()
@@ -719,24 +740,98 @@ impl Broker {
 
             // Up to date and nothing moved: say nothing rather than send an
             // empty diff.
-            if !rendered.changed && subscription.holds == Some(rendered.screen.sequence) {
+            if !rendered.changed && subscription.sent == Some(rendered.screen.sequence) {
                 continue;
             }
 
-            let message = match (&rendered.diff, subscription.holds) {
-                (Some(diff), Some(held)) if held == diff.follows => ServerMessage::PaneScreenDiff {
-                    pane: pane.clone(),
-                    diff: diff.clone(),
-                },
-                _ => ServerMessage::PaneScreen {
-                    pane: pane.clone(),
-                    screen: rendered.screen.clone(),
-                },
-            };
-            subscription.holds = Some(rendered.screen.sequence);
+            // Already holding as much as this viewer has agreed to carry. The
+            // update is not queued behind the others and not remembered: when
+            // it catches up it is sent the screen as it stands then, which is
+            // what it wants and is bounded however far behind it fell.
+            if subscription.outstanding >= MAX_OUTSTANDING_SCREEN_UPDATES {
+                continue;
+            }
+
+            let message = Self::update_for(subscription, pane, &rendered);
+            subscription.sent = Some(rendered.screen.sequence);
+            subscription.outstanding += 1;
             effects.push(Effect::Send { client, message });
         }
         effects
+    }
+
+    /// What one subscriber needs in order to hold `rendered`.
+    ///
+    /// A diff is only applicable to the exact update it follows, and the only
+    /// client that holds that update is one that was sent it. Anything else —
+    /// a new subscriber, a resize, or a viewer that was skipped while it was at
+    /// its limit — is sent the whole screen.
+    fn update_for(
+        subscription: &PaneSubscription,
+        pane: &PaneId,
+        rendered: &Rendered,
+    ) -> ServerMessage {
+        match (&rendered.diff, subscription.sent) {
+            (Some(diff), Some(sent)) if sent == diff.follows => ServerMessage::PaneScreenDiff {
+                pane: pane.clone(),
+                diff: diff.clone(),
+            },
+            _ => ServerMessage::PaneScreen {
+                pane: pane.clone(),
+                screen: rendered.screen.clone(),
+            },
+        }
+    }
+
+    /// A client painted an update, so it may be sent another.
+    ///
+    /// The sequence is checked against what this subscription was actually
+    /// sent: acknowledging the same update twice, or one never sent, changes
+    /// nothing. Progress is reported here, not granted — the depth stays the
+    /// daemon's.
+    fn ack_pane_screen(
+        &mut self,
+        client: ClientId,
+        pane: &PaneId,
+        sequence: u64,
+        effects: &mut Vec<Effect>,
+    ) {
+        let Some(subscription) = self
+            .clients
+            .get_mut(&client)
+            .and_then(|session| session.panes.get_mut(pane))
+        else {
+            return;
+        };
+        if subscription.sent.is_none_or(|sent| sequence > sent)
+            || subscription.acked.is_some_and(|acked| sequence <= acked)
+        {
+            return;
+        }
+        subscription.acked = Some(sequence);
+        subscription.outstanding = subscription.outstanding.saturating_sub(1);
+
+        // Caught up enough to be sent something, and behind what the pane now
+        // shows. A pane that has gone quiet produces no further frame, so
+        // waiting for one would leave this viewer holding a screen it can see
+        // is stale and cannot ask to replace.
+        let Some(state) = self.screens.get(pane) else {
+            return;
+        };
+        if subscription.sent == Some(state.last.sequence)
+            || subscription.outstanding >= MAX_OUTSTANDING_SCREEN_UPDATES
+        {
+            return;
+        }
+        let rendered = Rendered {
+            screen: state.last.clone(),
+            diff: None,
+            changed: true,
+        };
+        let message = Self::update_for(subscription, pane, &rendered);
+        subscription.sent = Some(state.last.sequence);
+        subscription.outstanding += 1;
+        effects.push(Effect::Send { client, message });
     }
 
     /// Drop the emulator for a pane nobody is watching as a screen any more.
@@ -870,7 +965,9 @@ impl Broker {
                 cols,
                 rows,
                 representation,
-                holds: None,
+                sent: None,
+                acked: None,
+                outstanding: 0,
             },
         );
 
@@ -919,7 +1016,8 @@ impl Broker {
             if let Some(session) = self.clients.get_mut(&client)
                 && let Some(subscription) = session.panes.get_mut(&pane)
             {
-                subscription.holds = Some(screen.sequence);
+                subscription.sent = Some(screen.sequence);
+                subscription.outstanding += 1;
             }
             effects.push(Effect::Send {
                 client,
@@ -1121,11 +1219,14 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
-    use super::{Broker, ClientId, Effect};
+    use super::{
+        Broker, ClientId, Effect, MAX_OUTSTANDING_SCREEN_UPDATES, PaneSubscription, Rendered,
+    };
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{PaneId, TargetSession};
     use crate::operation::Operation;
     use crate::protocol::{ClientMessage, PROTOCOL_VERSION, PaneRepresentation, ServerMessage};
+    use crate::screen::Diff as ScreenDiff;
     use crate::screen::Snapshot;
     use crate::state::{
         FederationState, NormalizedSnapshot, PaneState, TargetConnectionState, TargetRuntimeState,
@@ -1217,6 +1318,26 @@ mod tests {
 
     fn rendered_row(broker: &Broker, resource: &str, row: usize) -> String {
         row_text(&broker.screens[&pane(resource)].last, row)
+    }
+
+    fn ack(broker: &mut Broker, client: ClientId, resource: &str, sequence: u64) -> Vec<Effect> {
+        broker.handle(
+            client,
+            ClientMessage::AckPaneScreen {
+                pane: pane(resource),
+                sequence,
+            },
+        )
+    }
+
+    /// The first update this subscription was sent, which is what a viewer
+    /// painting in order acknowledges first.
+    fn first_sequence(broker: &Broker, client: ClientId, resource: &str) -> u64 {
+        let subscription = &broker.clients[&client].panes[&pane(resource)];
+        subscription
+            .sent
+            .expect("the subscription was sent nothing")
+            - u64::from(MAX_OUTSTANDING_SCREEN_UPDATES - 1)
     }
 
     fn row_text(screen: &Snapshot, row: usize) -> String {
@@ -2065,6 +2186,203 @@ mod tests {
             !messages_for(&effects, viewer).is_empty(),
             "the viewer is told about the repaint"
         );
+    }
+
+    /// The reason this bound exists: a rendered update is queued into an
+    /// unbounded outbox, so a viewer that stops draining would otherwise
+    /// accumulate one message per frame in this process for as long as the pane
+    /// keeps producing output.
+    #[test]
+    fn a_viewer_that_stops_painting_stops_being_queued_for() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+
+        let mut sent = 0;
+        for index in 0..20 {
+            let effects = frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+            sent += messages_for(&effects, viewer).len();
+        }
+
+        assert_eq!(
+            sent, MAX_OUTSTANDING_SCREEN_UPDATES as usize,
+            "twenty frames reached a viewer that acknowledged none of them"
+        );
+    }
+
+    #[test]
+    fn acknowledging_an_update_lets_the_next_one_through() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        for index in 0..20 {
+            frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+        }
+
+        let held = first_sequence(&broker, viewer, "w1:p1");
+        let effects = ack(&mut broker, viewer, "w1:p1", held);
+
+        assert!(
+            !messages_for(&effects, viewer).is_empty(),
+            "a viewer that caught up was sent nothing"
+        );
+    }
+
+    /// What a viewer that fell behind wants is the screen as it stands, not the
+    /// history of how it got there. Frames cannot do this; a snapshot can,
+    /// because it is self-contained.
+    #[test]
+    fn a_viewer_that_catches_up_is_sent_the_screen_as_it_stands() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        for index in 0..20 {
+            frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+        }
+
+        let held = first_sequence(&broker, viewer, "w1:p1");
+        let effects = ack(&mut broker, viewer, "w1:p1", held);
+
+        let messages = messages_for(&effects, viewer);
+        let [ServerMessage::PaneScreen { screen, .. }] = messages.as_slice() else {
+            panic!("expected the current screen, not a backlog: {messages:?}");
+        };
+        assert_eq!(
+            screen.sequence,
+            broker.screens[&pane("w1:p1")].last.sequence,
+            "the viewer was sent something other than the newest screen"
+        );
+        assert_eq!(
+            row_text(screen, 19),
+            "line 19",
+            "the screen sent was not the one the pane is showing"
+        );
+    }
+
+    /// An acknowledgement reports progress. It does not grant anything, so a
+    /// client cannot talk its way into more of this process's memory.
+    #[test]
+    fn an_acknowledgement_is_checked_against_what_was_actually_sent() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        for index in 0..20 {
+            frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+        }
+
+        // Never sent, so it buys nothing.
+        assert!(
+            messages_for(&ack(&mut broker, viewer, "w1:p1", 9_999), viewer).is_empty(),
+            "a sequence that was never sent was accepted"
+        );
+
+        // The same update, over and over, is still one update painted.
+        let held = first_sequence(&broker, viewer, "w1:p1");
+        ack(&mut broker, viewer, "w1:p1", held);
+        let mut extra = 0;
+        for _ in 0..10 {
+            extra += messages_for(&ack(&mut broker, viewer, "w1:p1", held), viewer).len();
+        }
+        assert_eq!(
+            extra, 0,
+            "repeating one acknowledgement bought more updates"
+        );
+    }
+
+    /// A diff is only applicable to the exact update it follows, and in a
+    /// working broker every screen subscriber holds that update by the time the
+    /// next frame arrives — so nothing driving the daemon can produce a
+    /// mismatch, and the rule that decides it would go untested.
+    ///
+    /// It is tested here directly instead. The alternative is a check that
+    /// cannot fail, which is a check nobody has evidence for.
+    #[test]
+    fn a_diff_is_refused_for_a_subscriber_holding_a_different_update() {
+        let subscription = |sent| PaneSubscription {
+            requested: TerminalAccess::Observe,
+            cols: 80,
+            rows: 24,
+            representation: PaneRepresentation::Screen,
+            sent,
+            acked: None,
+            outstanding: 0,
+        };
+        let mut parser = vt100::Parser::new(4, 20, 0);
+        parser.process(b"before");
+        let previous = Snapshot::of(parser.screen(), 7);
+        parser.process(b"\r\nafter");
+        let current = Snapshot::of(parser.screen(), 8);
+        let rendered = Rendered {
+            diff: ScreenDiff::between(&previous, &current),
+            screen: current,
+            changed: true,
+        };
+
+        assert!(
+            matches!(
+                Broker::update_for(&subscription(Some(7)), &pane("w1:p1"), &rendered),
+                ServerMessage::PaneScreenDiff { .. }
+            ),
+            "a subscriber holding update 7 can apply a diff that follows 7"
+        );
+        for held in [None, Some(6), Some(8)] {
+            assert!(
+                matches!(
+                    Broker::update_for(&subscription(held), &pane("w1:p1"), &rendered),
+                    ServerMessage::PaneScreen { .. }
+                ),
+                "a subscriber holding {held:?} was sent a diff it cannot apply"
+            );
+        }
+    }
+
+    /// The bound belongs to the rendered path alone: a frame subscriber is
+    /// already stopped by the socket it is not draining.
+    #[test]
+    fn a_frame_subscriber_is_not_bounded_by_the_screen_limit() {
+        let mut broker = broker();
+        let tui = greet(&mut broker);
+        subscribe(&mut broker, tui, "w1:p1", TerminalAccess::Observe, 80, 24);
+
+        let mut sent = 0;
+        for index in 0..20 {
+            let effects = frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+            sent += messages_for(&effects, tui).len();
+        }
+
+        assert_eq!(sent, 20, "frames were withheld from an emulator client");
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -101,6 +101,18 @@ pub enum ClientMessage {
         #[serde(default)]
         representation: PaneRepresentation,
     },
+    /// Confirm that a rendered update has been painted.
+    ///
+    /// Only `screen` subscribers send this, and it is the only signal the
+    /// daemon has that a viewer is keeping up: a frame subscriber is bounded by
+    /// the socket, but a rendered update is queued for a client that may be
+    /// draining it far more slowly than a pane produces it.
+    ///
+    /// The sequence is checked against what was actually sent rather than
+    /// believed, so acknowledging an update twice, or one that was never sent,
+    /// buys a client nothing. It reports progress; it does not grant anything.
+    #[serde(rename = "pane.screen_ack")]
+    AckPaneScreen { pane: PaneId, sequence: u64 },
     #[serde(rename = "pane.unsubscribe")]
     UnsubscribePane { pane: PaneId },
     /// Take the control lease for a pane another client holds. Control is never
@@ -545,6 +557,10 @@ mod tests {
             cols: 120,
             rows: 40,
             representation: PaneRepresentation::Screen,
+        });
+        round_trip_client(ClientMessage::AckPaneScreen {
+            pane: pane(),
+            sequence: 12,
         });
         round_trip_client(ClientMessage::UnsubscribePane { pane: pane() });
         round_trip_client(ClientMessage::TakePaneControl { pane: pane() });


### PR DESCRIPTION
Closes the last unbounded path into the daemon's outbox.

A frame subscriber needs no flow control, because the socket *is* the flow
control — a client that stops draining stops the daemon reading. A rendered
update has no such property: it goes into `outboxes`, an
`UnboundedSender<ServerMessage>`, so nothing in the transport pushes back. A
viewer on a slow link watching a busy pane would accumulate one message per
frame in the daemon's memory for as long as the pane kept producing output.

The download direction fixed the equivalent problem in `8c7b212`; this is the
same decision on the path that was left.

## What changes

**The daemon owns the depth.** A screen subscriber may hold
`MAX_OUTSTANDING_SCREEN_UPDATES = 4`. Past that the broker stops queueing, and
deliberately does not remember what it skipped.

**A viewer acknowledges each update once it has painted it** — `pane.screen_ack`
is sent after `paint()`, not on receipt, because that is what it claims. It is
the only honest signal available that a client drained anything.

**An acknowledgement reports progress rather than granting anything.** The
sequence is validated against what that subscription was actually sent, so
acknowledging twice, or acknowledging something never sent, changes nothing. A
client cannot talk its way into more of this process's memory. Same rule the
resume token and the download's credit already follow.

**A viewer that catches up is sent the screen as it stands**, not the backlog it
missed — fewer bytes, and the thing it actually wants. This is the argument for
the representation existing: frames can't do it, because every byte matters to a
parser consuming them statefully, while a snapshot is self-contained and carries
the sequence that says what was skipped.

Nothing in the transport changed. `pane.screen_ack` rides `/command` and the
existing outbox unmodified.

## One test is a seam rather than a scenario

The rule deciding whether a subscriber may be sent a diff **cannot be made to
fail through the daemon**. Every screen subscriber holds the update a diff
follows by the time the next frame arrives, so removing the check entirely left
the whole suite green.

Worth stating plainly because I predicted otherwise: I expected this change to
make that branch reachable, re-ran the mutation on the finished work, and it
did not. The acknowledgement path closes the gap before any frame can arrive
with a stale `sent`. A prediction about what a change will make reachable is a
hypothesis, and only the finished change can answer it.

So `update_for` is extracted and tested directly, against subscriptions holding
nothing, an older update and a newer one, asserting only the exact holder
receives a diff. A check that nothing can fail is a check with no evidence
behind it, whatever it is protecting.

## Verification

- 245 tests.
- Three mutations, each restored from a copy rather than by re-editing:
  removing the bound fails three tests; trusting the acknowledgement blindly
  fails one; removing the diff-applicability check fails the new direct test.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean on
  the host and on `x86_64-apple-darwin`.
- `ARCHITECTURE.md` gains the two sections pane observation never had — the two
  representations, and this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmAj6nkoj5U8jTdGGXcFvb