### PR TITLE
Settle a rendered update by name, not by counting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -524,12 +524,22 @@ viewer on a slow link watching a busy pane would accumulate one message per
 frame in the daemon's memory.
 
 So the depth is bounded here. A screen subscriber may hold a small number of
-updates, the daemon decides how many, and a viewer acknowledges each update once
-it has painted it. An acknowledgement is checked against what that subscription
-was actually sent: acknowledging twice, or acknowledging something never sent,
-changes nothing. It reports progress rather than granting anything, for the same
-reason a resume token is not authority and a download's credit is a request
-rather than an instruction.
+updates, the daemon decides how many, and a viewer acknowledges an update once
+it has painted it. What is held is the sequences themselves rather than a count
+of them, so one acknowledgement settles the update it names and every earlier
+one still outstanding: a viewer that paints four and reports only the newest is
+telling the truth about all four, and a viewer that drops an acknowledgement is
+repaired by the next rather than losing a slot for ever. Counting would have
+made both permanent, and would have made the protocol depend on a client
+acknowledging exactly once per update without anywhere saying so.
+
+An acknowledgement must name an update that subscription was actually sent.
+That is membership in the outstanding queue, not merely a sequence below the
+newest one: the queue has gaps, because a viewer at its limit is skipped and
+what it missed was never outstanding, and without membership a client could
+clear those gaps by naming updates it never received. It reports progress rather
+than granting anything, for the same reason a resume token is not authority and
+a download's credit is a request rather than an instruction.
 
 What a viewer that fell behind is sent when it catches up is the screen as it
 stands, not the backlog it missed — which is both fewer bytes and the thing it

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -19,7 +19,7 @@
 //! so an observer on a phone cannot reshape a pane someone is working in, and
 //! the route is resized when the lease moves to a client of a different size.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 
 use crate::attention::AttentionEvent;
@@ -166,14 +166,18 @@ struct PaneSubscription {
     /// sent nothing yet and must receive a whole screen before a diff can mean
     /// anything to it.
     sent: Option<u64>,
-    /// The last update this client said it painted.
-    acked: Option<u64>,
-    /// Updates sent and not yet acknowledged.
+    /// The sequences sent to this client and not yet acknowledged, oldest
+    /// first, at most `MAX_OUTSTANDING_SCREEN_UPDATES` of them.
     ///
-    /// Counted rather than derived from the sequences, because a whole screen
-    /// sent to a client that fell behind advances the sequence by more than one
-    /// while being a single update.
-    outstanding: u32,
+    /// The sequences themselves rather than a count of them, so that one
+    /// acknowledgement can settle every update at or below it. A viewer that
+    /// paints four and reports only the newest is then telling the truth about
+    /// all four, and a client that never acknowledges an update it painted
+    /// costs itself nothing beyond that update — the next acknowledgement
+    /// repairs it. Counting would have made both of those permanent, and would
+    /// have made the protocol depend on a client acknowledging exactly once per
+    /// update without anywhere saying so.
+    outstanding: VecDeque<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -210,7 +214,7 @@ impl Client {
 /// slow link watching a busy pane would accumulate without limit in this
 /// process. The daemon chooses the depth; an acknowledgement reports progress
 /// against what was actually sent and cannot ask for more than this.
-const MAX_OUTSTANDING_SCREEN_UPDATES: u32 = 4;
+const MAX_OUTSTANDING_SCREEN_UPDATES: usize = 4;
 
 /// One pane's rendered screen, kept only while somebody is watching it that
 /// way.
@@ -748,13 +752,13 @@ impl Broker {
             // update is not queued behind the others and not remembered: when
             // it catches up it is sent the screen as it stands then, which is
             // what it wants and is bounded however far behind it fell.
-            if subscription.outstanding >= MAX_OUTSTANDING_SCREEN_UPDATES {
+            if subscription.outstanding.len() >= MAX_OUTSTANDING_SCREEN_UPDATES {
                 continue;
             }
 
             let message = Self::update_for(subscription, pane, &rendered);
             subscription.sent = Some(rendered.screen.sequence);
-            subscription.outstanding += 1;
+            subscription.outstanding.push_back(rendered.screen.sequence);
             effects.push(Effect::Send { client, message });
         }
         effects
@@ -803,13 +807,27 @@ impl Broker {
         else {
             return;
         };
-        if subscription.sent.is_none_or(|sent| sequence > sent)
-            || subscription.acked.is_some_and(|acked| sequence <= acked)
-        {
+        // The sequence must be one this subscription is actually waiting on,
+        // not merely one below the newest thing sent. The queue has gaps in it
+        // — a viewer at its limit is skipped, so the updates it missed are
+        // never in here — and settling everything below an arbitrary number
+        // would let a client clear those gaps by naming an update that was
+        // never sent to it. Membership is what makes "checked against what was
+        // actually sent" a promise rather than a description of the common
+        // case; it also makes acknowledging twice a no-op, since the second
+        // acknowledgement names something no longer held.
+        if !subscription.outstanding.contains(&sequence) {
             return;
         }
-        subscription.acked = Some(sequence);
-        subscription.outstanding = subscription.outstanding.saturating_sub(1);
+        // Painting is in order, so an acknowledgement settles everything the
+        // client was sent before this one as well.
+        while subscription
+            .outstanding
+            .front()
+            .is_some_and(|held| *held <= sequence)
+        {
+            subscription.outstanding.pop_front();
+        }
 
         // Caught up enough to be sent something, and behind what the pane now
         // shows. A pane that has gone quiet produces no further frame, so
@@ -819,7 +837,7 @@ impl Broker {
             return;
         };
         if subscription.sent == Some(state.last.sequence)
-            || subscription.outstanding >= MAX_OUTSTANDING_SCREEN_UPDATES
+            || subscription.outstanding.len() >= MAX_OUTSTANDING_SCREEN_UPDATES
         {
             return;
         }
@@ -830,7 +848,7 @@ impl Broker {
         };
         let message = Self::update_for(subscription, pane, &rendered);
         subscription.sent = Some(state.last.sequence);
-        subscription.outstanding += 1;
+        subscription.outstanding.push_back(state.last.sequence);
         effects.push(Effect::Send { client, message });
     }
 
@@ -966,8 +984,7 @@ impl Broker {
                 rows,
                 representation,
                 sent: None,
-                acked: None,
-                outstanding: 0,
+                outstanding: VecDeque::new(),
             },
         );
 
@@ -1017,7 +1034,7 @@ impl Broker {
                 && let Some(subscription) = session.panes.get_mut(&pane)
             {
                 subscription.sent = Some(screen.sequence);
-                subscription.outstanding += 1;
+                subscription.outstanding.push_back(screen.sequence);
             }
             effects.push(Effect::Send {
                 client,
@@ -1219,6 +1236,8 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
+    use std::collections::VecDeque;
+
     use super::{
         Broker, ClientId, Effect, MAX_OUTSTANDING_SCREEN_UPDATES, PaneSubscription, Rendered,
     };
@@ -1320,6 +1339,29 @@ mod tests {
         row_text(&broker.screens[&pane(resource)].last, row)
     }
 
+    fn sequence_of(message: &ServerMessage) -> u64 {
+        match message {
+            ServerMessage::PaneScreen { screen, .. } => screen.sequence,
+            ServerMessage::PaneScreenDiff { diff, .. } => diff.sequence,
+            other => panic!("not a rendered update: {other:?}"),
+        }
+    }
+
+    fn outstanding_sequences(broker: &Broker, client: ClientId, resource: &str) -> Vec<u64> {
+        broker.clients[&client].panes[&pane(resource)]
+            .outstanding
+            .iter()
+            .copied()
+            .collect()
+    }
+
+    fn newest_outstanding(broker: &Broker, client: ClientId, resource: &str) -> u64 {
+        *broker.clients[&client].panes[&pane(resource)]
+            .outstanding
+            .back()
+            .expect("the subscription was sent nothing")
+    }
+
     fn ack(broker: &mut Broker, client: ClientId, resource: &str, sequence: u64) -> Vec<Effect> {
         broker.handle(
             client,
@@ -1330,14 +1372,19 @@ mod tests {
         )
     }
 
-    /// The first update this subscription was sent, which is what a viewer
-    /// painting in order acknowledges first.
+    /// The oldest update this subscription is still waiting to hear about,
+    /// which is what a viewer painting in order acknowledges first.
     fn first_sequence(broker: &Broker, client: ClientId, resource: &str) -> u64 {
-        let subscription = &broker.clients[&client].panes[&pane(resource)];
-        subscription
-            .sent
+        *broker.clients[&client].panes[&pane(resource)]
+            .outstanding
+            .front()
             .expect("the subscription was sent nothing")
-            - u64::from(MAX_OUTSTANDING_SCREEN_UPDATES - 1)
+    }
+
+    fn outstanding(broker: &Broker, client: ClientId, resource: &str) -> usize {
+        broker.clients[&client].panes[&pane(resource)]
+            .outstanding
+            .len()
     }
 
     fn row_text(screen: &Snapshot, row: usize) -> String {
@@ -2213,7 +2260,7 @@ mod tests {
         }
 
         assert_eq!(
-            sent, MAX_OUTSTANDING_SCREEN_UPDATES as usize,
+            sent, MAX_OUTSTANDING_SCREEN_UPDATES,
             "twenty frames reached a viewer that acknowledged none of them"
         );
     }
@@ -2336,8 +2383,7 @@ mod tests {
             rows: 24,
             representation: PaneRepresentation::Screen,
             sent,
-            acked: None,
-            outstanding: 0,
+            outstanding: VecDeque::new(),
         };
         let mut parser = vt100::Parser::new(4, 20, 0);
         parser.process(b"before");
@@ -2366,6 +2412,146 @@ mod tests {
                 "a subscriber holding {held:?} was sent a diff it cannot apply"
             );
         }
+    }
+
+    /// The case whose answer is not in question, written first so that a wrong
+    /// harness shows up here rather than as a finding three tests later: a
+    /// viewer that acknowledges everything it is sent falls behind by nothing.
+    #[test]
+    fn a_viewer_that_acknowledges_everything_holds_nothing_outstanding() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+
+        for index in 0..20 {
+            let effects = frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+            for message in messages_for(&effects, viewer) {
+                ack(&mut broker, viewer, "w1:p1", sequence_of(&message));
+            }
+        }
+
+        assert_eq!(
+            outstanding(&broker, viewer, "w1:p1"),
+            0,
+            "a viewer keeping up should be waiting on nothing"
+        );
+    }
+
+    /// The reason the queue holds sequences rather than a count. A viewer that
+    /// paints four and reports only the newest is telling the truth about all
+    /// four, and counting would have called it three behind for ever.
+    #[test]
+    fn acknowledging_the_newest_settles_everything_below_it() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        for index in 0..20 {
+            frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+        }
+        assert_eq!(
+            outstanding(&broker, viewer, "w1:p1"),
+            MAX_OUTSTANDING_SCREEN_UPDATES
+        );
+
+        let newest = newest_outstanding(&broker, viewer, "w1:p1");
+        let effects = ack(&mut broker, viewer, "w1:p1", newest);
+
+        // One acknowledgement settled all four, so the catch-up update is the
+        // only thing now outstanding.
+        assert_eq!(
+            outstanding(&broker, viewer, "w1:p1"),
+            1,
+            "acknowledging the newest of four left updates outstanding"
+        );
+        assert!(!messages_for(&effects, viewer).is_empty());
+    }
+
+    /// A dropped acknowledgement costs that update and nothing more: the next
+    /// one settles it. Counting made a missed acknowledgement permanent, which
+    /// is a thing a client could trip over without ever being told the rule.
+    #[test]
+    fn a_missed_acknowledgement_is_repaired_by_the_next_one() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        for index in 0..20 {
+            frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+        }
+
+        let held: Vec<u64> = outstanding_sequences(&broker, viewer, "w1:p1");
+        // Skip the first entirely, as a viewer that dropped one would.
+        ack(&mut broker, viewer, "w1:p1", held[1]);
+
+        assert_eq!(
+            outstanding(&broker, viewer, "w1:p1"),
+            MAX_OUTSTANDING_SCREEN_UPDATES - 2 + 1,
+            "the skipped update was not settled by the one after it"
+        );
+    }
+
+    /// An acknowledgement names an update this subscription was sent. The queue
+    /// has gaps — a viewer at its limit is skipped, so what it missed was never
+    /// in it — and without membership a client could clear those gaps by naming
+    /// an update it never received.
+    #[test]
+    fn an_update_that_was_never_sent_settles_nothing() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        for index in 0..20 {
+            frame(&mut broker, "w1:p1", format!("line {index}\r\n").as_bytes());
+        }
+        // Settle one, so the catch-up update leaves a gap behind it.
+        let first = first_sequence(&broker, viewer, "w1:p1");
+        ack(&mut broker, viewer, "w1:p1", first);
+
+        let held = outstanding_sequences(&broker, viewer, "w1:p1");
+        let never_sent = held[held.len() - 1] - 1;
+        assert!(!held.contains(&never_sent), "the fixture needs a real gap");
+
+        let effects = ack(&mut broker, viewer, "w1:p1", never_sent);
+
+        assert_eq!(
+            outstanding_sequences(&broker, viewer, "w1:p1"),
+            held,
+            "a sequence that was never sent settled updates that were"
+        );
+        assert!(
+            messages_for(&effects, viewer).is_empty(),
+            "an update that was never sent bought a slot"
+        );
     }
 
     /// The bound belongs to the rendered path alone: a frame subscriber is

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -177,6 +177,19 @@ struct PaneSubscription {
     /// repairs it. Counting would have made both of those permanent, and would
     /// have made the protocol depend on a client acknowledging exactly once per
     /// update without anywhere saying so.
+    ///
+    /// These sequences mean something only within one [`ScreenState`]. A pane's
+    /// emulator is dropped when nobody is watching it as a screen and rebuilt
+    /// at sequence zero for the next viewer, so the numbers here can be higher
+    /// than anything the pane will issue again. What keeps that harmless is
+    /// that `subscribe_pane` replaces the whole `PaneSubscription`, queue
+    /// included, so no queue outlives the sequence space that filled it.
+    ///
+    /// Anything that changes subscribing to update a subscription in place —
+    /// keeping `sent` across a resize to spare a viewer a whole screen would be
+    /// a reasonable reason to try — has to clear this queue as well. A stale
+    /// queue against a restarted sequence space never drains: it is full, so
+    /// nothing new is sent, and no acknowledgement names anything in it.
     outstanding: VecDeque<u64>,
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -108,9 +108,17 @@ pub enum ClientMessage {
     /// the socket, but a rendered update is queued for a client that may be
     /// draining it far more slowly than a pane produces it.
     ///
-    /// The sequence is checked against what was actually sent rather than
-    /// believed, so acknowledging an update twice, or one that was never sent,
-    /// buys a client nothing. It reports progress; it does not grant anything.
+    /// One acknowledgement settles the update it names and every earlier one
+    /// still outstanding, so a viewer that painted several and reports only the
+    /// newest is understood to have painted all of them, and a viewer that
+    /// failed to report one is repaired by the next rather than penalised for
+    /// ever.
+    ///
+    /// The sequence must name an update this subscription was actually sent.
+    /// Acknowledging one twice, or one that was never sent, settles nothing —
+    /// which matters because a viewer at its limit is skipped, so the updates
+    /// it missed were never outstanding and cannot be cleared by naming them.
+    /// It reports progress; it does not grant anything.
     #[serde(rename = "pane.screen_ack")]
     AckPaneScreen { pane: PaneId, sequence: u64 },
     #[serde(rename = "pane.unsubscribe")]


### PR DESCRIPTION
Follow-up to #7, closing a contract that change introduced and did not state.

## The problem

A screen subscriber's outstanding depth was a counter, decremented once per
acknowledgement. That is exact only for a client acknowledging exactly once per
update it receives — and nothing said so.

Measured, not reasoned about. A client that acknowledges only the newest of each
batch:

```
round 0: delivered=5  outstanding=4
round 1: delivered=6  outstanding=4
...
round 5: delivered=10 outstanding=4
```

It stays correct and current, because a catch-up delivery always carries the
screen as it stands — but it loses the four-deep pipelining permanently and pays
a round trip per update. A viewer that dropped a *single* acknowledgement lost
that slot for as long as it stayed subscribed.

## The change

Hold the sequences rather than a count. An acknowledgement settles the update it
names **and every earlier one still outstanding**, so reporting the newest of
four is understood as painting all four, and a dropped acknowledgement is
repaired by the next rather than being permanent. Same bound, so nothing about
the memory this protects changes.

This deletes the contract instead of documenting it, which matters because the
next client will be written by somebody who wasn't in this conversation.

## Membership, not a range

An acknowledgement must name an update this subscription was *actually sent*.
The queue has gaps — a viewer at its limit is skipped, so what it missed was
never outstanding — and a check that merely rejected sequences above the newest
would let a client settle those gaps by naming updates it never received.

Measured before fixing: with a range check and a queue of `[2, 3, 4, 10]`,
acknowledging `9` freed **three** slots at once.

Membership is what makes "checked against what was actually sent" a promise
rather than a description of the common case. It also makes acknowledging twice
a no-op for free, since the second names something no longer held — idempotence
from the structure rather than from a check that has to be kept true.

## Verification

- 249 tests.
- Two mutations, each restored from a copy: reverting membership to a range
  check fails the never-sent test; settling only the named update fails two.
- `cargo fmt --check` and clippy clean on the host and `x86_64-apple-darwin`.
- Tests ordered so the calibration case comes first — a viewer that
  acknowledges everything ends up waiting on nothing. A wrong harness fails
  there, rather than three tests later where it would look like a finding about
  the code. That ordering is why the never-sent hole was found before this was
  written rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmAj6nkoj5U8jTdGGXcFvb