### PR TITLE
Pair a device by scanning instead of typing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1426,7 @@ dependencies = [
  "base64",
  "clap",
  "crossterm",
+ "qrcode",
  "ratatui",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,14 @@ anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
+# Rendering a pairing code as a QR. Taken rather than written because the parts
+# that are easy to get subtly wrong — Reed-Solomon and mask selection — fail by
+# producing a code that scans on one phone and not another, which looks like
+# working software to whoever holds the phone that works. Zero transitive
+# dependencies, with defaults or without; `default-features = false` drops the
+# image, svg and pic renderers, which are the only things here that would ever
+# grow a tree.
+qrcode = { version = "0.14.1", default-features = false }
 ratatui = "0.30"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/examples/qualify-upload.rs
+++ b/examples/qualify-upload.rs
@@ -218,6 +218,7 @@ async fn relay(
             refresh_interval: std::time::Duration::from_secs(3600),
             web_port: None,
             web_address: None,
+            web_url: None,
         },
     );
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -501,6 +501,7 @@ mod tests {
             refresh_interval: Duration::from_secs(3600),
             web_port: None,
             web_address: None,
+            web_url: None,
         };
         (spawn_in_process(config, None, options), directory)
     }

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -574,9 +574,43 @@ window.addEventListener('resize', () => {
   paint();
 });
 
+// A scanned pairing code arrives in the fragment, never in a query string. A
+// fragment is not sent to the server, so the code stays out of request lines,
+// out of any access log, and out of a reverse proxy that would otherwise see
+// every pairing attempt in clear. It is stripped from the address before
+// anything else runs, so a bookmark, a shared link or the back button cannot
+// carry a live credential.
+function codeFromFragment() {
+  const raw = (location.hash || '').replace(/^#/, '');
+  if (!raw) return '';
+  history.replaceState(null, '', location.pathname + location.search);
+  let decoded = '';
+  try {
+    decoded = decodeURIComponent(raw).trim();
+  } catch (_) {
+    return '';
+  }
+  // Shaped like a code or ignored. A fragment is attacker-supplied in the sense
+  // that anything can link here, and this value is about to be typed into a
+  // form field.
+  return /^[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$/.test(decoded) ? decoded.toUpperCase() : '';
+}
+
+// A guess the person can correct, so a device that pairs by scanning still ends
+// up with a name worth seeing in `device list` rather than an empty one.
+function suggestedName() {
+  const agent = navigator.userAgent || '';
+  if (/iPad|Tablet/i.test(agent)) return 'iPad';
+  if (/Android|iPhone|Mobile/i.test(agent)) return 'phone';
+  return 'browser';
+}
+
 // The version of the daemon, not of this page: the page ships inside that
 // binary, so a stale daemon is otherwise invisible from here.
 async function start() {
+  // Read first, and unconditionally, so the address is cleaned even when the
+  // device turns out to be paired already.
+  const scanned = codeFromFragment();
   let session_state = { paired: true, version: '' };
   try {
     session_state = await (await fetch('/session')).json();
@@ -587,6 +621,15 @@ async function start() {
   el('version').textContent = session_state.version ? `daemon ${session_state.version}` : '';
   if (!session_state.paired) {
     el('pairing').hidden = false;
+    if (scanned) {
+      // The code is the part worth not retyping on a phone. The name is left
+      // for a person, because a device nobody named is one nobody can revoke
+      // with any confidence later.
+      el('code').value = scanned;
+      el('name').value = el('name').value || suggestedName();
+      el('name').focus();
+      el('name').select();
+    }
     return;
   }
   document.querySelector('main').hidden = false;

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -72,6 +72,16 @@ pub struct DaemonOptions {
     pub web_port: Option<u16>,
     /// Where the browser client listens. `None` is loopback.
     pub web_address: Option<std::net::IpAddr>,
+    /// The address a device outside this machine reaches the browser client on.
+    ///
+    /// It cannot be derived from the bind, and a daemon that tried would be
+    /// confidently wrong: this process binds loopback, while a phone needs
+    /// whatever host, port and scheme the proxy in front of it terminates —
+    /// `https://host.tailnet.ts.net:8790` against a `127.0.0.1:8795` listener.
+    /// Deriving one from the other produces a perfectly valid QR of an
+    /// unreachable address, which is worse than no QR at all, so it is told
+    /// rather than guessed and `None` means a client shows the code alone.
+    pub web_url: Option<String>,
 }
 
 impl DaemonOptions {
@@ -94,6 +104,7 @@ impl DaemonOptions {
             refresh_interval: CONFIG_REFRESH_INTERVAL,
             web_port: None,
             web_address: None,
+            web_url: None,
         })
     }
 }
@@ -677,6 +688,9 @@ struct Daemon {
     /// pipe nobody is emptying.
     downloads: BTreeMap<(ClientId, u64), Download>,
     pending_pairing: Arc<Mutex<Option<PendingPairing>>>,
+    /// Where a device outside this machine reaches the browser client, when
+    /// somebody told the daemon. Never derived: see `DaemonOptions::web_url`.
+    web_url: Option<String>,
     /// Panes whose route opened with less access than was asked for, drained
     /// into the broker on the next pass.
     downgraded: Vec<PaneId>,
@@ -882,6 +896,7 @@ async fn run(
     let attention_cursor = attention.events().next_back().map(|event| event.id);
     let mut daemon = Daemon {
         broker: Broker::new(env!("CARGO_PKG_VERSION"), vec!["terminal".to_owned()]),
+        web_url: options.web_url.clone(),
         outboxes: BTreeMap::new(),
         routes: BTreeMap::new(),
         targets: target_map(&active),
@@ -1754,6 +1769,7 @@ impl Daemon {
                     request,
                     code,
                     expires_in_seconds,
+                    url: self.web_url.clone(),
                 }
             }
             Err(error) => ServerMessage::Error {
@@ -2634,6 +2650,7 @@ mod tests {
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
                 web_address: None,
+                web_url: None,
             };
             let (stop, stopped) = tokio::sync::oneshot::channel::<()>();
             let server = tokio::spawn(serve_until(config, None, options, async move {
@@ -2884,6 +2901,7 @@ mod tests {
                 refresh_interval: Duration::from_millis(50),
                 web_port: None,
                 web_address: None,
+                web_url: None,
             },
         ));
 
@@ -3156,6 +3174,7 @@ mod tests {
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
                 web_address: None,
+                web_url: None,
             },
         ));
 
@@ -3496,6 +3515,70 @@ mod tests {
         // documents, and the test cleans up after it rather than pretending it
         // does not exist.
         discard_staged(&last);
+    }
+
+    /// What the daemon was told is what a client is offered, and nothing is
+    /// invented when it was told nothing.
+    ///
+    /// The whole point of the flag: a URL cannot be derived from the loopback
+    /// address this process binds, so it either arrives from configuration or
+    /// it is absent. A daemon that filled the gap with its own bind would hand
+    /// a client a perfectly valid QR of somewhere no phone can reach.
+    #[tokio::test]
+    async fn a_pairing_code_carries_the_url_the_daemon_was_told_and_no_other() {
+        for told in [Some("https://host.example:8790".to_owned()), None] {
+            let directory = tempfile::tempdir().expect("a temporary directory");
+            let socket = directory.path().join("daemon.sock");
+            let (stop, stopped) = tokio::sync::oneshot::channel::<()>();
+            let server = tokio::spawn(serve_until(
+                empty_config(),
+                None,
+                DaemonOptions {
+                    socket: socket.clone(),
+                    attention_state: Some(directory.path().join("attention.json")),
+                    refresh_interval: Duration::from_secs(3600),
+                    web_port: None,
+                    web_address: None,
+                    web_url: told.clone(),
+                },
+                async move {
+                    let _ = stopped.await;
+                },
+            ));
+
+            let mut connection = None;
+            for _ in 0..200 {
+                if let Ok(stream) = UnixStream::connect(&socket).await {
+                    connection = Some(Connection {
+                        reader: BufReader::new(stream),
+                    });
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            let mut connection = connection.expect("the daemon accepts a connection");
+            connection.hello().await;
+            connection
+                .send(ClientMessage::RequestPairingCode { request: 1 })
+                .await;
+
+            let issued = loop {
+                match connection.receive().await.expect("the daemon answers") {
+                    message @ (ServerMessage::PairingCode { .. } | ServerMessage::Error { .. }) => {
+                        break message;
+                    }
+                    _ => continue,
+                }
+            };
+            let ServerMessage::PairingCode { code, url, .. } = &issued else {
+                panic!("no pairing code was issued: {issued:?}");
+            };
+            assert!(!code.is_empty(), "a code is issued either way");
+            assert_eq!(url, &told, "the daemon offered a URL it was not given");
+
+            let _ = stop.send(());
+            let _ = tokio::time::timeout(Duration::from_secs(10), server).await;
+        }
     }
 
     /// A caller's name reaches the host, and a bad one never leaves the daemon.
@@ -4011,6 +4094,7 @@ mod tests {
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
                 web_address: None,
+                web_url: None,
             },
             async move {
                 let _ = stopped.await;
@@ -4087,6 +4171,7 @@ mod tests {
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
                 web_address: None,
+                web_url: None,
             },
             async move {
                 let _ = stopped.await;
@@ -4125,6 +4210,7 @@ mod tests {
             refresh_interval: Duration::from_secs(3600),
             web_port: None,
             web_address: None,
+            web_url: None,
         };
         let error = serve(empty_config(), None, options)
             .await
@@ -4150,6 +4236,7 @@ mod tests {
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
                 web_address: None,
+                web_url: None,
             },
         ));
 

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -595,6 +595,7 @@ mod tests {
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
                 web_address: None,
+                web_url: None,
             },
         );
         // Port zero so tests never collide with a daemon somebody is running.

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,15 @@ enum Commands {
         /// not encrypt.
         #[arg(long, value_name = "ADDRESS", requires = "web")]
         web_address: Option<std::net::IpAddr>,
+        /// Where a device outside this machine reaches the browser client, so
+        /// a pairing code can be offered as something scannable. This cannot
+        /// be worked out from the address above: behind a proxy that
+        /// terminates TLS, such as `tailscale serve`, the host, port and
+        /// scheme a phone needs are all different from what this process
+        /// binds. Without it a pairing code is shown to be typed, which is
+        /// what happens today.
+        #[arg(long, value_name = "URL", requires = "web")]
+        web_url: Option<String>,
     },
     /// Inspect clipboard copy and paste capabilities without reading clipboard contents.
     Clipboard {
@@ -362,6 +371,7 @@ async fn run() -> Result<ExitCode> {
             socket,
             web,
             web_address,
+            web_url,
         } => {
             let mut options = DaemonOptions::discover()?;
             if let Some(socket) = socket {
@@ -369,6 +379,9 @@ async fn run() -> Result<ExitCode> {
             }
             options.web_port = web;
             options.web_address = web_address;
+            options.web_url = web_url
+                .map(|url| super_herdr::pairing::pairing_url(&url))
+                .transpose()?;
             // The daemon announces itself once it is actually listening; a
             // line printed here would be a claim rather than a report.
             serve(config, Some(path), options).await?;

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -16,7 +16,7 @@ use std::fs::File;
 use std::io::Read;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use sha2::{Digest, Sha256};
 
 /// A pairing code is read off one screen and typed into another, so it avoids
@@ -74,6 +74,44 @@ pub fn fingerprint(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
     hex(&hasher.finalize())
+}
+
+/// Check a URL a pairing code can be offered at, and hand back its base.
+///
+/// Refused at the flag rather than at the screen, because everything after this
+/// point produces something that looks right. A QR of an unreachable address
+/// scans perfectly and fails at the far end, where the person holding the phone
+/// cannot tell a wrong address from a bad camera, poor light, or a daemon that
+/// is not running. A refusal here names the problem while somebody is still
+/// looking at a terminal.
+///
+/// What is checked is what this can know: a scheme it makes sense to open, a
+/// host that is not empty, and no fragment — the code becomes the fragment, and
+/// one already there would be silently replaced. Whether the host resolves and
+/// whether a certificate validates are not knowable from here and are not
+/// pretended at.
+pub fn pairing_url(url: &str) -> Result<String> {
+    let trimmed = url.trim();
+    let (scheme, rest) = trimmed
+        .split_once("://")
+        .context("a pairing URL needs a scheme, as in https://host.example:8790")?;
+    if !matches!(scheme, "http" | "https") {
+        bail!("a pairing URL must be http or https; {scheme:?} is neither");
+    }
+    if scheme == "http" && !rest.starts_with("127.0.0.1") && !rest.starts_with("localhost") {
+        // A token authenticates a device and encrypts nothing, which is why the
+        // listener refuses a public address. Offering one over plain HTTP would
+        // put the pairing code itself on the wire.
+        bail!("a pairing URL over http would carry the code in clear; use https");
+    }
+    let host = rest.split(['/', '?', '#']).next().unwrap_or_default();
+    if host.is_empty() {
+        bail!("a pairing URL needs a host");
+    }
+    if trimmed.contains('#') {
+        bail!("a pairing URL cannot carry a fragment; the code is the fragment");
+    }
+    Ok(trimmed.trim_end_matches('/').to_owned())
 }
 
 /// Compare without revealing where two values first differ.
@@ -172,6 +210,45 @@ mod tests {
         CODE_ALPHABET, CODE_LIFETIME, PendingPairing, fingerprint, matches, normalize_code,
         pairing_code, token,
     };
+
+    #[test]
+    fn a_pairing_url_is_refused_while_somebody_is_still_looking_at_a_terminal() {
+        // The whole point of checking here: everything downstream of this
+        // produces something that looks right. A QR of an unreachable address
+        // scans perfectly and fails where nobody can diagnose it.
+        for url in [
+            "https://onio-ws01.tail15b0b2.ts.net:8790",
+            "https://host.example",
+            // Loopback over http is the one plain case that is not on a wire.
+            "http://127.0.0.1:8790",
+            "http://localhost:8790",
+        ] {
+            assert!(super::pairing_url(url).is_ok(), "{url} should be accepted");
+        }
+
+        for (url, expected) in [
+            ("host.example:8790", "scheme"),
+            ("ftp://host.example", "http or https"),
+            // A token authenticates and encrypts nothing, so plain http off
+            // this machine would put the code itself on the wire.
+            ("http://host.example:8790", "clear"),
+            ("https://", "host"),
+            // The code becomes the fragment; one already there would vanish.
+            ("https://host.example/#already", "fragment"),
+        ] {
+            let error = super::pairing_url(url)
+                .expect_err(&format!("{url} should be refused"))
+                .to_string();
+            assert!(error.contains(expected), "{url}: {error}");
+        }
+
+        // A trailing slash would otherwise become a double slash before the
+        // fragment.
+        assert_eq!(
+            super::pairing_url("https://host.example:8790/").unwrap(),
+            "https://host.example:8790"
+        );
+    }
 
     #[test]
     fn a_token_is_unpredictable_and_stored_only_as_a_digest() {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -366,6 +366,25 @@ pub enum ServerMessage {
         request: u64,
         code: String,
         expires_in_seconds: u64,
+        /// Where a device outside the daemon's machine reaches the browser
+        /// client, when somebody told the daemon. Absent means nobody did, and
+        /// a client shows the code to be typed.
+        ///
+        /// It is never derived from what the daemon bound. Behind a proxy that
+        /// terminates TLS the host, port and scheme a phone needs are all
+        /// different from the loopback address this process listens on, and a
+        /// guess would produce a perfectly valid QR of somewhere unreachable —
+        /// which fails where the person holding the phone cannot tell a wrong
+        /// address from a bad camera.
+        ///
+        /// A client joins this to the code as `{url}#{code}`. The fragment is
+        /// deliberate: it is never sent to a server, so the code stays out of
+        /// request lines, out of the daemon's own path, and out of any proxy in
+        /// front of it. The daemon refuses a URL that already carries one,
+        /// because the code replacing it would fail like a bad code rather than
+        /// like a bad URL.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        url: Option<String>,
     },
     /// A transfer may proceed, and this is where to send from.
     ///
@@ -693,6 +712,14 @@ mod tests {
             request: 9,
             code: "ABCD-2345".to_owned(),
             expires_in_seconds: 300,
+            url: Some("https://host.example:8790".to_owned()),
+        });
+        round_trip_server(ServerMessage::PairingCode {
+            request: 8,
+            code: "ABCD-EFGH".to_owned(),
+            expires_in_seconds: 120,
+            // What a daemon nobody told sends: a code to be typed.
+            url: None,
         });
         round_trip_server(ServerMessage::Error {
             request: Some(7),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,8 +11,9 @@ use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
+use qrcode::{EcLevel, QrCode};
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Layout, Margin, Position, Rect};
+use ratatui::layout::{Alignment, Constraint, Layout, Margin, Position, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
@@ -796,6 +797,7 @@ struct App {
     target_test_sender: Option<mpsc::UnboundedSender<TargetTestEvent>>,
     next_target_test_request: u64,
     agent_navigator: Option<AgentNavigator>,
+    pairing: Option<PairingOffer>,
     attention: AttentionIndex,
     attention_center: Option<AttentionCenter>,
     notification_queue: NotificationQueue,
@@ -844,6 +846,7 @@ impl Default for App {
             target_test_sender: None,
             next_target_test_request: 1,
             agent_navigator: None,
+            pairing: None,
             attention: AttentionIndex::default(),
             attention_center: None,
             notification_queue: NotificationQueue::default(),
@@ -1264,6 +1267,7 @@ async fn handle_decoded_input(
             if app.mode != InputMode::Terminal
                 || app.target_manager.is_some()
                 || app.agent_navigator.is_some()
+                || app.pairing.is_some()
                 || app.attention_center.is_some()
                 || app.command_palette.is_some()
                 || app.context_menu.is_some()
@@ -1318,6 +1322,7 @@ async fn handle_mouse(
     }
     if app.mode != InputMode::Terminal
         || app.agent_navigator.is_some()
+        || app.pairing.is_some()
         || app.attention_center.is_some()
         || app.command_palette.is_some()
         || app.text_prompt.is_some()
@@ -2010,6 +2015,15 @@ async fn handle_input(
     }
     if app.target_manager.is_some() {
         return handle_target_manager_input(key, transport_config, app);
+    }
+    if app.pairing.is_some() {
+        // A live pairing code is on screen; any key takes it down. There is
+        // nothing to navigate, and leaving a credential up because a keystroke
+        // was not one of a handful this screen recognised would be the wrong
+        // default for the one overlay that displays one.
+        let _ = key;
+        app.pairing = None;
+        return Ok(false);
     }
     if app.agent_navigator.is_some() {
         return handle_agent_navigator_input(key, state, app);
@@ -4382,12 +4396,18 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
         ServerMessage::PairingCode {
             code,
             expires_in_seconds,
+            url,
             ..
         } => {
             let minutes = expires_in_seconds / 60;
             app.message = Some(format!(
-                "pairing code {code} — enter it in the browser client within {minutes} minutes"
+                "pairing code {code} — expires in {minutes} minutes; any key closes the screen"
             ));
+            app.pairing = Some(PairingOffer {
+                code,
+                url,
+                expires_in_seconds,
+            });
         }
         ServerMessage::Error { request, message } => {
             // A refusal ends whatever asked for it, so a failed transfer does
@@ -4487,7 +4507,9 @@ fn render(frame: &mut Frame, state: &FederationState, app: &App) {
     }
     render_tabs(frame, state, app, tab_area);
     render_terminal_surfaces(frame, state, app, terminal_area);
-    if let Some(manager) = app.target_manager.as_ref() {
+    if let Some(offer) = app.pairing.as_ref() {
+        render_pairing(frame, offer);
+    } else if let Some(manager) = app.target_manager.as_ref() {
         render_target_manager(frame, manager);
     } else if let Some(navigator) = app.agent_navigator.as_ref() {
         render_agent_navigator(frame, state, navigator);
@@ -5078,6 +5100,161 @@ fn centered_popup(area: Rect, maximum_width: u16, maximum_height: u16) -> Rect {
         width,
         height,
     )
+}
+
+/// A pairing code the daemon has just issued, and where to take it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PairingOffer {
+    code: String,
+    /// Absent unless the daemon was told its public address. Nothing derives
+    /// one: the daemon binds loopback, and what a phone must reach is usually a
+    /// different host, port and scheme.
+    url: Option<String>,
+    expires_in_seconds: u64,
+}
+
+impl PairingOffer {
+    /// What a scanner should be sent to.
+    ///
+    /// The code rides in the fragment rather than a query parameter, so it is
+    /// never sent to the server: it stays out of request lines, out of access
+    /// logs, and out of any reverse proxy in front. `None` when there is no
+    /// address to send anyone to.
+    fn scan_target(&self) -> Option<String> {
+        let url = self.url.as_ref()?.trim_end_matches('#');
+        Some(format!("{url}#{}", self.code))
+    }
+}
+
+/// One QR, drawn two module rows to a text row.
+///
+/// Half blocks rather than two spaces per module: a terminal cell is about
+/// twice as tall as it is wide, so stacking two modules in one cell keeps them
+/// square, and a square module is what a scanner is looking for.
+///
+/// `None` when it will not fit. That refusal is the point of this returning an
+/// option at all — a clipped QR is still a rectangle of black squares, and the
+/// person holding the phone cannot tell a truncated code from a bad angle or
+/// poor light. Text they can read; half a QR they can only fail at.
+fn qr_rows(payload: &str, available: Rect) -> Option<Vec<String>> {
+    let code = QrCode::with_error_correction_level(payload.as_bytes(), EcLevel::M).ok()?;
+    let width = code.width();
+    // Four modules of quiet zone on every side, which the specification
+    // requires and scanners genuinely rely on against a busy terminal.
+    let quiet = 4usize;
+    let span = width + quiet * 2;
+    let needed_columns = u16::try_from(span).ok()?;
+    let needed_rows = u16::try_from(span.div_ceil(2)).ok()?;
+    if needed_columns > available.width || needed_rows > available.height {
+        return None;
+    }
+
+    let dark = code.to_colors();
+    let is_dark = |x: usize, y: usize| -> bool {
+        if x < quiet || y < quiet || x >= quiet + width || y >= quiet + width {
+            return false;
+        }
+        dark[(y - quiet) * width + (x - quiet)] == qrcode::Color::Dark
+    };
+
+    let mut rows = Vec::with_capacity(span.div_ceil(2));
+    for pair in (0..span).step_by(2) {
+        let mut row = String::with_capacity(span);
+        for x in 0..span {
+            let upper = is_dark(x, pair);
+            let lower = pair + 1 < span && is_dark(x, pair + 1);
+            // Dark modules are drawn as the terminal's foreground, so this
+            // inverts: a block character is a light module.
+            row.push(match (upper, lower) {
+                (true, true) => ' ',
+                (true, false) => '\u{2584}',
+                (false, true) => '\u{2580}',
+                (false, false) => '\u{2588}',
+            });
+        }
+        rows.push(row);
+    }
+    Some(rows)
+}
+
+fn render_pairing(frame: &mut Frame, offer: &PairingOffer) {
+    let area = centered_popup(frame.area(), 60, 34);
+    frame.render_widget(Clear, area);
+    let block = Block::default()
+        .title(Span::styled(" pair a device ", Style::default().bold()))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Blue))
+        .padding(Padding::horizontal(1));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let minutes = offer.expires_in_seconds / 60;
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // A QR is drawn on a white field with dark modules, whatever the terminal's
+    // own colours are. A scanner needs the contrast to be this way round, and a
+    // dark-themed terminal would otherwise invert it.
+    let paper = Style::default().fg(Color::Black).bg(Color::White);
+    match offer.scan_target() {
+        Some(target) => match qr_rows(&target, inner) {
+            Some(rows) => {
+                for row in rows {
+                    lines.push(Line::styled(row, paper));
+                }
+                lines.push(Line::raw(""));
+                lines.push(Line::styled(
+                    format!("code {}", offer.code),
+                    Style::default().bold(),
+                ));
+                lines.push(Line::styled(
+                    format!("expires in {minutes} min · any key closes"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            None => {
+                // Too small to draw honestly, so it is not drawn at all.
+                lines.push(Line::styled(
+                    "terminal too small for a scannable code",
+                    Style::default().fg(Color::Yellow),
+                ));
+                lines.push(Line::raw(""));
+                lines.push(Line::styled(target, Style::default().fg(Color::Blue)));
+                lines.push(Line::raw(""));
+                lines.push(Line::styled(
+                    format!("code {}", offer.code),
+                    Style::default().bold(),
+                ));
+                lines.push(Line::styled(
+                    format!("expires in {minutes} min · any key closes"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+        },
+        None => {
+            lines.push(Line::styled(
+                format!("code {}", offer.code),
+                Style::default().bold(),
+            ));
+            lines.push(Line::raw(""));
+            lines.push(Line::styled(
+                "enter it in the browser client",
+                Style::default().fg(Color::DarkGray),
+            ));
+            lines.push(Line::raw(""));
+            // Said plainly, because the absence of a QR looks like a missing
+            // feature rather than a daemon that was never told where it is.
+            lines.push(Line::styled(
+                "no scannable address: start the daemon with --web-url",
+                Style::default().fg(Color::DarkGray),
+            ));
+            lines.push(Line::styled(
+                format!("expires in {minutes} min · any key closes"),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
 }
 
 fn render_agent_navigator(frame: &mut Frame, state: &FederationState, navigator: &AgentNavigator) {
@@ -6202,6 +6379,93 @@ mod tests {
     use std::fs;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
+
+    /// A QR that will not fit is not drawn at all.
+    ///
+    /// This is the whole reason `qr_rows` returns an option. A clipped code is
+    /// still a rectangle of squares, and the person holding the phone cannot
+    /// tell a truncated code from a bad angle or poor light — they only know it
+    /// does not work. Text in the same space is legible.
+    #[test]
+    fn a_code_that_would_be_clipped_is_refused_rather_than_drawn() {
+        let target = "https://onio-ws01.tail15b0b2.ts.net:8790#ABCD-2345";
+        let roomy = super::qr_rows(target, super::Rect::new(0, 0, 80, 40))
+            .expect("80x40 has room for this payload");
+
+        // Square once the two-modules-per-cell packing is undone. The span is
+        // odd for most versions, so the final row carries one module rather
+        // than two — hence the ceiling rather than a doubling.
+        let span = roomy[0].chars().count();
+        assert_eq!(roomy.len(), span.div_ceil(2));
+        for narrow in [
+            super::Rect::new(0, 0, 20, 40),
+            super::Rect::new(0, 0, 80, 6),
+            super::Rect::new(0, 0, 1, 1),
+        ] {
+            assert!(
+                super::qr_rows(target, narrow).is_none(),
+                "a code was drawn into {narrow:?}, where it cannot be scanned"
+            );
+        }
+    }
+
+    /// Dark modules must render dark against a light field. Inverting them
+    /// produces a code that some scanners accept and others silently do not,
+    /// which is the worst failure available here: it looks like it works.
+    #[test]
+    fn the_quiet_zone_is_light_and_the_finder_pattern_is_not() {
+        let rows = super::qr_rows(
+            "https://example.test:8790#ABCD-2345",
+            super::Rect::new(0, 0, 80, 40),
+        )
+        .expect("room for this payload");
+
+        // Four modules of quiet zone is two rows of full blocks, top and bottom.
+        assert!(
+            rows[0].chars().all(|cell| cell == '\u{2588}'),
+            "the quiet zone is not light: {:?}",
+            rows[0]
+        );
+        assert!(
+            rows[rows.len() - 1].chars().all(|cell| cell == '\u{2588}'),
+            "the trailing quiet zone is not light"
+        );
+
+        // The top-left finder centre sits four modules in past the quiet zone.
+        let finder = &rows[3];
+        assert!(
+            finder.chars().any(|cell| cell != '\u{2588}'),
+            "the finder pattern rendered as empty space: {finder:?}"
+        );
+    }
+
+    #[test]
+    fn a_scan_target_carries_the_code_in_the_fragment() {
+        let offer = super::PairingOffer {
+            code: "ABCD-2345".to_owned(),
+            url: Some("https://host.tail0.ts.net:8790".to_owned()),
+            expires_in_seconds: 300,
+        };
+
+        assert_eq!(
+            offer.scan_target().as_deref(),
+            Some("https://host.tail0.ts.net:8790#ABCD-2345"),
+            "the code must ride in the fragment, never in a query"
+        );
+    }
+
+    /// A daemon that was never told its public address offers nothing to scan,
+    /// rather than a QR pointing at the loopback it happens to have bound.
+    #[test]
+    fn without_a_configured_address_there_is_nothing_to_scan() {
+        let offer = super::PairingOffer {
+            code: "ABCD-2345".to_owned(),
+            url: None,
+            expires_in_seconds: 300,
+        };
+
+        assert!(offer.scan_target().is_none());
+    }
 
     /// A target whose socket comes from discovery can still take an atomic
     /// paste.


### PR DESCRIPTION
Two halves, written by two sessions, neither of which compiles without the
other — so they land together.

- `01e6c08` **Tell the daemon where a phone reaches it** — `--web-url`, its
  validation, and `PairingCode` carrying the URL.
- `b50a6e0` **Show a pairing code as something a phone can scan** — the QR
  screen and the page reading the code from the fragment.

## Why the daemon has to be told

It binds loopback. What a phone must reach here is
`https://onio-ws01.tail15b0b2.ts.net:8790` — different host, port and scheme,
because `tailscale serve` terminates TLS in front. Anything derived from the
bind would encode a perfectly valid QR of somewhere unreachable, and that fails
where the person holding the phone cannot tell a wrong address from a bad
camera. So it is configured, absent when nobody configured it, and the screen
shows a code to type instead.

## Why the fragment

The code travels as `{url}#{code}`. A fragment is never sent to a server, so it
stays out of request lines, out of the daemon's own path, and out of the reverse
proxy that this deployment puts in front. A query parameter would be a small
convenience and would put a live credential in two more places.

The page strips it with `replaceState` before anything else runs, so a bookmark,
a shared link or the back button cannot carry one, and accepts it only in the
shape of a code — anything can link to this page.

The daemon refuses a URL that already carries a fragment, because the code
replacing it would fail like a bad code rather than like a bad URL.

## Refusing to draw

`qr_rows` returns an `Option`, and the refusal is the reason it does. A clipped
QR is still a rectangle of black squares; the person scanning cannot distinguish
it from bad light. Too small, or no URL, and the screen shows the address and
code as text — legible in the same space.

Modules are drawn two per cell as half blocks, since a terminal cell is roughly
twice as tall as it is wide and a scanner wants squares.

## Verification

- 255 tests. Four are new and one is the one that matters: the quiet zone must
  render light and the finder pattern must not. Inverted modules scan on one
  phone and not another — the failure shape that argued against hand-writing an
  encoder, and it would be a shame to reintroduce it in the renderer.
- The URL validation exercised through the real CLI, not just unit tests:
  a fragment, cleartext to a non-loopback host, and a missing scheme are each
  refused with their own message; the real address is accepted.
- `qrcode` 0.14.1 with `default-features = false`. Zero transitive
  dependencies, measured in a scratch crate both with and without default
  features rather than assumed.
- `cargo fmt --check` and clippy clean on the host and `x86_64-apple-darwin`.

One test caught its author rather than the code: the row count was asserted to
be exactly half the module span, and the span is odd, so the last row carries
one module. The assertion was wrong, not the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmAj6nkoj5U8jTdGGXcFvb