### PR TITLE
Bound what a scanned fragment may be, rather than shaping it

### DIFF
--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -590,10 +590,18 @@ function codeFromFragment() {
   } catch (_) {
     return '';
   }
-  // Shaped like a code or ignored. A fragment is attacker-supplied in the sense
-  // that anything can link here, and this value is about to be typed into a
-  // form field.
-  return /^[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$/.test(decoded) ? decoded.toUpperCase() : '';
+  // Bounded, not shaped. Anything can link to this page, so the fragment is
+  // attacker-supplied and this value goes straight into a form field — a length
+  // and character bound is what that needs.
+  //
+  // It deliberately does not encode what a code looks like. The daemon defines
+  // that, in one place, and already accepts a code however it was typed:
+  // `normalize_code` treats case and separators as presentation. A pattern here
+  // would be a second definition with nothing holding the two together, and the
+  // day they disagreed every scan would quietly degrade to typing with no error
+  // anywhere and a person debugging it from a phone. Whether a code is right is
+  // the daemon's to answer, and it answers in constant time.
+  return /^[A-Za-z0-9-]{1,32}$/.test(decoded) ? decoded.toUpperCase() : '';
 }
 
 // A guess the person can correct, so a device that pairs by scanning still ends


### PR DESCRIPTION
Follow-up to #9, from the peer session's post-merge review.

## The coupling

The page checked a scanned code against `/^[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$/` —
which is exactly what `pairing.rs` produces from `CODE_CHARACTERS = 8`, split
four and four. Two definitions of one format in two files, with nothing holding
them together. Change the length to ten or the grouping to three-three-three and
the page silently stops matching: every scan degrades to typing, no error
anywhere, and whoever debugs it is looking at a phone.

Same shape as the configured-versus-resolved paste bug in `20efbb4` — two things
equal until the day they aren't, failing in the direction of "the feature just
doesn't work".

## It was already wrong, not merely fragile

`pairing.rs:63` says it plainly:

> Accept a code however it was typed: case and separators are presentation.

`normalize_code` strips non-alphanumerics and uppercases. So the daemon accepts
`ABCD2345`, and the page refused to carry it. The page was stricter than the
authority it defers to.

## Why loosening rather than a test

The strictness bought nothing. That value goes into a form field and is posted;
the daemon compares it against the pending code in constant time, and an
arbitrary string is a wrong code and nothing else. The alternative — a test
asserting `pairing_code()` matches the page's pattern — would put the format in
a *third* place.

So: a length and character bound, `/^[A-Za-z0-9-]{1,32}$/`, which is what an
attacker-supplied fragment going into a form field actually needs, and what a
code *is* stays with the one place that defines it.

## Verification

Behaviour checked case by case against the old pattern rather than reasoned
about:

```
"ABCD-2345"    now=true  was=true   the canonical form
"abcd-2345"    now=true  was=true   lowercase, which the daemon uppercases
"ABCD2345"     now=true  was=false  unhyphenated — separators are presentation
"ABCDE-23456"  now=true  was=false  a longer code, if the format ever changes
"ABC-DEF-GHI"  now=true  was=false  a regrouped code, likewise
""             now=false was=false  empty
"<script>x"    now=false was=false  markup
"A" x64        now=false was=false  over the bound
"ABCD 2345"    now=false was=false  a space, which no QR would carry
```

255 tests, `cargo fmt --check` and clippy clean.

Found by the peer session reviewing #9 after it merged — a review it asked for
before the merge and did not get, which was my sequencing error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmAj6nkoj5U8jTdGGXcFvb