### PR TITLE
Keep a viewer connected, and watching, across a dropped stream

### DIFF
--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -399,7 +399,13 @@ function observe(pane, label) {
   el('viewing').textContent = label || `${pane.target}/${pane.session}/${pane.resource}`;
   el('screen-note').textContent = 'waiting for output…';
   el('screen').innerHTML = '';
-  // `screen` rather than `frames`: this page has no emulator and wants none.
+  subscribeScreen(pane);
+}
+
+// `screen` rather than `frames`: this page has no emulator and wants none.
+// One definition, because three callers ask for the same thing — opening a
+// pane, recovering from a gap, and recovering from a dropped connection.
+function subscribeScreen(pane) {
   send({
     type: 'pane.subscribe',
     pane,
@@ -427,14 +433,7 @@ function resync() {
   el('screen-note').textContent = 'missed an update — resyncing';
   send({ type: 'pane.unsubscribe', pane });
   screen = null;
-  send({
-    type: 'pane.subscribe',
-    pane,
-    access: 'observe',
-    cols: 80,
-    rows: 24,
-    representation: 'screen',
-  });
+  subscribeScreen(pane);
 }
 
 function renderPanes() {
@@ -481,6 +480,16 @@ function apply(message) {
   switch (message.type) {
     case 'server.hello':
       send({ type: 'state.subscribe' });
+      // A reconnect is a new client to the daemon, which knows nothing about
+      // what this page was watching — so what was being watched is asked for
+      // again here. Without this the last screen stays painted and the link
+      // says "live" while nothing arrives ever again, which is worse than a
+      // viewer that visibly breaks.
+      if (watching) {
+        screen = null;
+        cell = null;
+        subscribeScreen(watching);
+      }
       break;
     case 'state.full':
       targets.clear();
@@ -555,9 +564,12 @@ function connect() {
       // rendering the ones it does.
     }
   };
-  // EventSource reconnects on its own; the daemon treats each reconnect as a
-  // new client and resends the state and the history, so nothing here has to
-  // remember where it was.
+  // EventSource reconnects on its own, and the daemon treats each reconnect as
+  // a new client: federation state and attention history are resent unasked.
+  // Pane observation is not — a subscription belongs to the connection that
+  // made it — so `server.hello` asks for it again. This comment used to say
+  // nothing here had to remember where it was; that stopped being true the day
+  // this page started watching panes.
   stream.onerror = () => {
     el('link').textContent = 'reconnecting…';
     el('link').className = 'down';

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -2567,6 +2567,58 @@ mod tests {
         );
     }
 
+    /// A reconnecting page asks for what it was watching, and a drop noticed at
+    /// both ends at once could have it ask twice. Cheap to make harmless and
+    /// expensive to discover in the field, so it is pinned here.
+    #[test]
+    fn subscribing_twice_to_one_pane_leaves_one_subscription() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        let first = subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        frame(&mut broker, "w1:p1", b"hello");
+        let again = subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+
+        assert_eq!(
+            broker.routes[&pane("w1:p1")].subscribers.len(),
+            1,
+            "one client subscribed twice was counted twice"
+        );
+        assert_eq!(
+            broker.clients[&viewer].panes.len(),
+            1,
+            "one pane was recorded twice for one client"
+        );
+        // The second subscription is a fresh one, so it is owed a whole screen
+        // and owes nothing for what the first was sent.
+        assert!(outstanding(&broker, viewer, "w1:p1") <= MAX_OUTSTANDING_SCREEN_UPDATES);
+        assert!(!messages_for(&first, viewer).is_empty());
+        assert!(!messages_for(&again, viewer).is_empty());
+
+        // And releasing once releases it: no phantom subscriber keeps the route
+        // open after the client has gone.
+        broker.disconnect(viewer);
+        assert!(
+            !broker.routes.contains_key(&pane("w1:p1")),
+            "the route outlived the only client that wanted it"
+        );
+    }
+
     /// The bound belongs to the rendered path alone: a frame subscriber is
     /// already stopped by the socket it is not draining.
     #[test]

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -484,12 +484,22 @@ async fn stream_events(
     let mut daemon_reader = BufReader::new(daemon_reader);
     let mut line = Vec::new();
     let mut keepalive = tokio::time::interval(KEEPALIVE_INTERVAL);
+    // Keepalive means "nothing written for an interval", not "an interval
+    // elapsed". Bursting the ticks missed during a busy stretch would cancel a
+    // read that is making progress, repeatedly, at exactly the moment there is
+    // traffic to interrupt.
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // The first tick completes immediately, and a comment before the first real
     // event is noise rather than reassurance.
     keepalive.tick().await;
     loop {
-        line.clear();
-        let mut limited = (&mut daemon_reader).take(MAX_MESSAGE_BYTES as u64);
+        // What is left of the cap for *this* line. A keepalive can cancel the
+        // read partway through a message, and the bytes already in `line` still
+        // count — rebuilding the whole budget every pass would let an oversized
+        // message through as two under-budget pieces, which is the size guard
+        // quietly ceasing to bound anything.
+        let remaining = MAX_MESSAGE_BYTES.saturating_sub(line.len());
+        let mut limited = (&mut daemon_reader).take(remaining as u64);
         let read = tokio::select! {
             read = limited.read_until(b'\n', &mut line) => read,
             _ = keepalive.tick() => {
@@ -497,6 +507,11 @@ async fn stream_events(
                 // only thing standing between an idle federation and a proxy
                 // that reaps silent connections. Without it a viewer watching a
                 // quiet pane is disconnected on somebody else's timer.
+                //
+                // `line` is deliberately untouched. `read_until` appends
+                // whatever it read before being cancelled, so clearing here
+                // would drop the front of a message and hand the browser its
+                // tail as though it were whole.
                 if writer.write_all(b": keepalive\n\n").await.is_err() {
                     break;
                 }
@@ -504,6 +519,8 @@ async fn stream_events(
             }
         };
         match read {
+            // Zero means the attachment ended, or that this line has used the
+            // whole message budget without terminating. Both end the stream.
             Ok(0) | Err(_) => break,
             Ok(_) if line.last() != Some(&b'\n') => break,
             Ok(_) => {}
@@ -516,6 +533,11 @@ async fn stream_events(
         {
             break;
         }
+        // Said something real, so the next comment is a full interval away.
+        keepalive.reset();
+        // Cleared here rather than at the top of the loop: only a line that has
+        // been delivered whole is finished with.
+        line.clear();
     }
 
     if let Ok(mut open) = sessions.open.lock() {
@@ -773,6 +795,147 @@ mod tests {
         .expect("a silent stream was never heard from again");
 
         assert_eq!(comment.trim_end(), ": keepalive");
+        task.abort();
+    }
+
+    /// A keepalive that fires mid-message must not eat the part already read.
+    ///
+    /// `read_until` is cancel-safe only in the sense that partially read bytes
+    /// are *appended to the buffer* — cancelling it and then clearing the buffer
+    /// throws away the front of a message, and the tail that arrives next looks
+    /// like a whole one. The browser is then handed half a JSON object, which
+    /// is the same failure this stream was fixed to stop having: silently wrong
+    /// rather than visibly broken.
+    #[tokio::test]
+    async fn a_keepalive_between_halves_of_a_message_does_not_eat_it() {
+        use tokio::io::AsyncReadExt as _;
+        // An attachment this test writes to by hand, so a message can be split
+        // across a keepalive on purpose.
+        let (mut far, near) = tokio::io::duplex(64 * 1024);
+        let near = Arc::new(Mutex::new(Some(near)));
+        let attach: super::Attach = Arc::new(move || {
+            near.lock()
+                .ok()
+                .and_then(|mut held| held.take())
+                .ok_or_else(|| anyhow::anyhow!("attached twice"))
+        });
+        let listener = super::bind(loopback(0)).await.expect("binds loopback");
+        let port = listener.local_addr().expect("a bound address").port();
+        let devices = Arc::new(TestDevices::default());
+        let task = tokio::spawn(super::serve(listener, attach, devices));
+
+        let mut stream = TcpStream::connect(loopback(port)).await.expect("connects");
+        stream
+            .write_all(b"GET /events?session=split HTTP/1.1\r\nhost: localhost\r\n\r\n")
+            .await
+            .expect("writes");
+        // The daemon side receives the client's hello first.
+        let mut greeting = vec![0u8; 256];
+        let _ = far.read(&mut greeting).await.expect("reads the hello");
+
+        let message =
+            br#"{"type":"pane.closed","pane":{"target":"t","session":"s","resource":"w1:p1"}}"#;
+        let (head, tail) = message.split_at(20);
+        far.write_all(head).await.expect("writes the first half");
+        // Past a keepalive, so the read of this line is cancelled mid-message.
+        tokio::time::sleep(super::KEEPALIVE_INTERVAL * 3).await;
+        far.write_all(tail).await.expect("writes the rest");
+        far.write_all(b"\n").await.expect("ends the line");
+
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        let event = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                line.clear();
+                reader.read_line(&mut line).await.expect("reads");
+                if line.starts_with("data: ") {
+                    return line.clone();
+                }
+            }
+        })
+        .await
+        .expect("the split message never arrived at all");
+
+        assert!(
+            event.contains("pane.closed") && event.contains("w1:p1"),
+            "the browser was handed a fragment, not a message: {event:?}"
+        );
+        task.abort();
+    }
+
+    /// The message cap must bound a message, not a read.
+    ///
+    /// A keepalive can cancel a read partway, and if the budget is rebuilt each
+    /// time round the loop an oversized message arrives as several under-budget
+    /// pieces and every one is forwarded. The guard then looks present and
+    /// bounds nothing — the browser is handed a message larger than the
+    /// protocol permits, in a component that is deliberately the strict one.
+    #[tokio::test]
+    async fn a_keepalive_does_not_refill_the_message_budget() {
+        use tokio::io::AsyncReadExt as _;
+
+        let (mut far, near) = tokio::io::duplex(1024 * 1024);
+        let near = Arc::new(Mutex::new(Some(near)));
+        let attach: super::Attach = Arc::new(move || {
+            near.lock()
+                .ok()
+                .and_then(|mut held| held.take())
+                .ok_or_else(|| anyhow::anyhow!("attached twice"))
+        });
+        let listener = super::bind(loopback(0)).await.expect("binds loopback");
+        let port = listener.local_addr().expect("a bound address").port();
+        let devices = Arc::new(TestDevices::default());
+        let task = tokio::spawn(super::serve(listener, attach, devices));
+
+        let mut stream = TcpStream::connect(loopback(port)).await.expect("connects");
+        stream
+            .write_all(b"GET /events?session=huge HTTP/1.1\r\nhost: localhost\r\n\r\n")
+            .await
+            .expect("writes");
+        let mut greeting = vec![0u8; 256];
+        let _ = far.read(&mut greeting).await.expect("reads the hello");
+
+        // Three quarters of the cap, then a pause past a keepalive, then enough
+        // to take the whole line over it. No newline until the very end, so
+        // this is one message by the protocol's reckoning.
+        let writing = tokio::spawn(async move {
+            let chunk = vec![b'x'; crate::protocol::MAX_MESSAGE_BYTES / 4];
+            for _ in 0..3 {
+                if far.write_all(&chunk).await.is_err() {
+                    return;
+                }
+            }
+            tokio::time::sleep(super::KEEPALIVE_INTERVAL * 3).await;
+            for _ in 0..2 {
+                if far.write_all(&chunk).await.is_err() {
+                    return;
+                }
+            }
+            let _ = far.write_all(b"\n").await;
+        });
+
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        let outcome = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                line.clear();
+                match reader.read_line(&mut line).await {
+                    Ok(0) => return None,
+                    Ok(_) if line.starts_with("data: ") => return Some(line.len()),
+                    Ok(_) => {}
+                    Err(_) => return None,
+                }
+            }
+        })
+        .await
+        .expect("the stream neither delivered nor ended");
+
+        assert!(
+            outcome.is_none(),
+            "a message of {outcome:?} bytes was forwarded past the {}-byte cap",
+            crate::protocol::MAX_MESSAGE_BYTES
+        );
+        writing.abort();
         task.abort();
     }
 

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -25,6 +25,7 @@
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, DuplexStream};
@@ -61,6 +62,22 @@ const FORWARDING_HEADERS: &[&str] = &[
 ];
 
 pub const DEFAULT_WEB_PORT: u16 = 8790;
+
+/// How often a silent event stream says something anyway.
+///
+/// An idle federation writes nothing, and a connection that writes nothing is
+/// what every idle timeout between here and a browser is looking for — nginx
+/// and most load balancers default to a minute, and corporate proxies are
+/// frequently harsher. Twenty seconds sits under the shortest of those with
+/// room to spare, and costs one comment line per viewer per twenty seconds.
+#[cfg(not(test))]
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
+
+/// Short enough that the test asserting a silent stream speaks costs nothing.
+/// What it exercises is the mechanism; the interval above is a judgement about
+/// other people's timeouts and is not something a test can check.
+#[cfg(test)]
+const KEEPALIVE_INTERVAL: Duration = Duration::from_millis(50);
 
 /// How long a paired device's cookie lasts before the browser drops it. The
 /// token itself does not expire — revoking is what ends it — but a browser that
@@ -466,12 +483,26 @@ async fn stream_events(
 
     let mut daemon_reader = BufReader::new(daemon_reader);
     let mut line = Vec::new();
+    let mut keepalive = tokio::time::interval(KEEPALIVE_INTERVAL);
+    // The first tick completes immediately, and a comment before the first real
+    // event is noise rather than reassurance.
+    keepalive.tick().await;
     loop {
         line.clear();
-        let read = (&mut daemon_reader)
-            .take(MAX_MESSAGE_BYTES as u64)
-            .read_until(b'\n', &mut line)
-            .await;
+        let mut limited = (&mut daemon_reader).take(MAX_MESSAGE_BYTES as u64);
+        let read = tokio::select! {
+            read = limited.read_until(b'\n', &mut line) => read,
+            _ = keepalive.tick() => {
+                // A comment line: valid SSE that every client ignores, and the
+                // only thing standing between an idle federation and a proxy
+                // that reaps silent connections. Without it a viewer watching a
+                // quiet pane is disconnected on somebody else's timer.
+                if writer.write_all(b": keepalive\n\n").await.is_err() {
+                    break;
+                }
+                continue;
+            }
+        };
         match read {
             Ok(0) | Err(_) => break,
             Ok(_) if line.last() != Some(&b'\n') => break,
@@ -710,6 +741,38 @@ mod tests {
         // The browser is handed protocol messages, not a translation of them.
         assert!(greeting.contains("server.hello"), "{greeting}");
         assert!(greeting.contains("\"protocol\":1"), "{greeting}");
+        task.abort();
+    }
+
+    /// An idle federation writes nothing, and a connection that writes nothing
+    /// is what an idle timeout is looking for. The comment is the only thing
+    /// keeping a viewer of a quiet pane connected through a proxy.
+    #[tokio::test]
+    async fn a_silent_stream_still_says_something() {
+        let (port, task, _directory, _devices) = serve_test_daemon().await;
+        let mut stream = TcpStream::connect(loopback(port)).await.expect("connects");
+        stream
+            .write_all(b"GET /events?session=quiet HTTP/1.1\r\nhost: localhost\r\n\r\n")
+            .await
+            .expect("writes");
+
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        // Long enough to cover the interval and the greeting ahead of it, and
+        // short enough that a regression fails rather than hangs the suite.
+        let comment = tokio::time::timeout(super::KEEPALIVE_INTERVAL * 2, async {
+            loop {
+                line.clear();
+                reader.read_line(&mut line).await.expect("reads");
+                if line.starts_with(':') {
+                    return line.clone();
+                }
+            }
+        })
+        .await
+        .expect("a silent stream was never heard from again");
+
+        assert_eq!(comment.trim_end(), ": keepalive");
         task.abort();
     }
 


### PR DESCRIPTION
Two faults a stable link hides and a proxy or relay would surface constantly.
Found by checking two claims before starting relay work, rather than after.

## No keepalive on the event stream

`stream_events` wrote only when the daemon had something to say. An idle
federation produces total silence, and a connection that writes nothing is
exactly what an idle timeout is looking for — nginx and most load balancers
default to 60s, corporate proxies are frequently harsher.

On a tailnet with a chatty federation nobody noticed. Behind a relay it stops
being incidental: every idle viewer gets disconnected on somebody else's timer.

Now an SSE comment (`: keepalive`) every 20s — valid SSE that every client
ignores and every proxy counts as traffic.

## A reconnect left the page watching nothing

Worse, and mine from two days ago.

`connect()` carried this comment:

> EventSource reconnects on its own; the daemon treats each reconnect as a new
> client and resends the state and the history, so nothing here has to remember
> where it was.

True when the page showed only federation state and attention history. **False
the moment pane observation was added under it** — a pane subscription belongs
to the connection that made it, and nothing asked for it again.

So after any drop: the last screen stayed painted, the indicator returned to
**"live"**, and no frame ever arrived again. A viewer that is silently wrong
rather than visibly broken, which is the worse of the two.

`server.hello` now resubscribes whatever was being watched, and the comment says
what is true. The three callers that ask for a screen subscription — opening a
pane, recovering from a sequence gap, recovering from a dropped connection —
share one definition instead of three copies.

This is the same shape as `20efbb4`: something true until the feature that makes
it false is the one in use. I wrote it while hunting exactly that pattern in
other code.

## Not fixed here, because it needs a clock

A dropped client runs `release_pane`; if it was the last subscriber the route
closes and the SSH stream to the target host is torn down. With the resubscribe
fixed that is correct but wasteful — a flapping link spawns a fresh SSH session
per flap on someone else's machine. A grace period needs a timer, the broker is
pure logic with no clock, and the sweep belongs in `server.rs`, which isn't
mine. Raised with that session; not started.

## Verification

- 259 tests, including one asserting a silent stream still says something.
- That test's interval is shortened under `cfg(test)` so it costs no wall-clock
  — at the real 20s it added 20s to a suite that runs in 0.7s. What it exercises
  is the mechanism; the interval itself is a judgement about other people's
  timeouts and isn't something a test can check.
- `cargo fmt --check` and clippy clean on the host and `x86_64-apple-darwin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmAj6nkoj5U8jTdGGXcFvb