### PR TITLE
Report that nobody is watching a pane, rather than closing it

### DIFF
--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -420,8 +420,15 @@ function stopWatching(why) {
   if (watching) send({ type: 'pane.unsubscribe', pane: watching });
   watching = null;
   screen = null;
-  el('viewer').hidden = true;
-  el('screen-note').textContent = text(why);
+  cell = null;
+  el('screen').innerHTML = '';
+  const reason = text(why);
+  // The reason lives inside the viewer, so hiding the viewer would write an
+  // explanation into something nobody can read — a pane that closed under
+  // somebody would simply vanish. Only a person choosing to stop takes the
+  // panel away; a viewer that stopped on its own stays up to say why.
+  el('viewer').hidden = !reason;
+  el('screen-note').textContent = reason;
   renderPanes();
 }
 

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -58,6 +58,18 @@ pub enum Effect {
     CloseRoute {
         pane: PaneId,
     },
+    /// Nobody is watching this pane any more.
+    ///
+    /// Not a request to close it. The route is kept, and whoever holds a clock
+    /// decides how long to keep it: a client that drops its connection and
+    /// comes straight back would otherwise pay for a fresh SSH session on
+    /// somebody else's host every time a link flaps. Ask
+    /// [`Broker::close_if_unclaimed`] when the wait is over; it answers
+    /// whether the pane is still unwanted, so a resubscribe inside the window
+    /// silently keeps the route it already had.
+    RouteUnclaimed {
+        pane: PaneId,
+    },
     RouteInput {
         pane: PaneId,
         bytes: Vec<u8>,
@@ -200,6 +212,9 @@ struct Route {
     rows: u16,
     control: Option<ClientId>,
     subscribers: BTreeSet<ClientId>,
+    /// True once the last subscriber left and nobody has come back. The route
+    /// is still open; it is waiting to find out whether it is wanted again.
+    unclaimed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -878,6 +893,23 @@ impl Broker {
         }
     }
 
+    /// Close a pane's route if it is still unwanted, or say nothing if it is
+    /// not.
+    ///
+    /// Asked by whoever has been holding the wait. The answer is decided here
+    /// rather than there, because whether a route is wanted is a fact about
+    /// subscribers and this is where they live — a caller that remembered
+    /// "unclaimed at the time I started waiting" would close a route somebody
+    /// is watching by the time it acts.
+    pub fn close_if_unclaimed(&mut self, pane: &PaneId) -> Vec<Effect> {
+        if !self.routes.get(pane).is_some_and(|route| route.unclaimed) {
+            return Vec::new();
+        }
+        self.routes.remove(pane);
+        self.screens.remove(pane);
+        vec![Effect::CloseRoute { pane: pane.clone() }]
+    }
+
     /// The route's own stream ended. Subscribers keep their subscription
     /// records only until they are told, so no client is left waiting on a
     /// stream that no longer exists.
@@ -1003,6 +1035,11 @@ impl Broker {
 
         let granted = match self.routes.get_mut(&pane) {
             Some(route) => {
+                // Somebody came back before the wait was over, so the route
+                // this client would have paid to reopen is the one it already
+                // has. Nothing is signalled: the far side never learned it was
+                // going away.
+                route.unclaimed = false;
                 route.subscribers.insert(client);
                 if access == TerminalAccess::Control && route.control.is_none() {
                     route.control = Some(client);
@@ -1024,6 +1061,7 @@ impl Broker {
                         rows,
                         control,
                         subscribers: BTreeSet::from([client]),
+                        unclaimed: false,
                     },
                 );
                 effects.push(Effect::OpenRoute {
@@ -1168,9 +1206,21 @@ impl Broker {
         let emptied = route.subscribers.is_empty();
         let held_control = route.control == Some(client);
         if emptied {
-            self.routes.remove(pane);
-            self.screens.remove(pane);
-            effects.push(Effect::CloseRoute { pane: pane.clone() });
+            // Kept rather than closed. Whether it is worth keeping, and for how
+            // long, is a question for whoever has a clock — this only reports
+            // that nobody is watching.
+            route.unclaimed = true;
+            route.control = None;
+            // The rendered screen stays with the route. Reusing a route removes
+            // the repaint that reopening one used to provide, and a viewer
+            // returning to an idle pane has nothing else to prompt the far side
+            // with — its stream never stopped, so no frame is coming. Dropping
+            // the screen here would leave exactly that viewer looking at
+            // nothing, which is the case this window exists to serve. It goes
+            // when the route goes, in `close_if_unclaimed` and
+            // `pane_route_closed`, and a busy pane drops it in `pane_frame`
+            // anyway once nobody is rendering.
+            effects.push(Effect::RouteUnclaimed { pane: pane.clone() });
             return;
         }
         // The one leaving may have been the last watching this pane as a
@@ -1911,9 +1961,153 @@ mod tests {
                 pane: pane("w1:p1"),
             },
         );
-        assert!(last.contains(&Effect::CloseRoute {
+        // The last one leaving does not close the route: it reports that
+        // nobody is watching, and something with a clock decides how long to
+        // wait for somebody to come back.
+        assert!(last.contains(&Effect::RouteUnclaimed {
             pane: pane("w1:p1")
         }));
+        assert!(
+            !last
+                .iter()
+                .any(|effect| matches!(effect, Effect::CloseRoute { .. }))
+        );
+
+        // And when the wait is over, it closes.
+        assert_eq!(
+            broker.close_if_unclaimed(&pane("w1:p1")),
+            vec![Effect::CloseRoute {
+                pane: pane("w1:p1")
+            }]
+        );
+    }
+
+    /// Reusing a route removes the repaint that reopening one used to provide.
+    ///
+    /// A viewer that comes back to an idle pane has nothing to prompt the far
+    /// side with — its stream never stopped, so no frame is coming — and if the
+    /// rendered screen was dropped when the route was released there is nothing
+    /// to send it either. It would sit on an empty viewer for as long as the
+    /// pane stayed quiet, which is the exact case the grace window exists for.
+    #[test]
+    fn a_viewer_returning_to_an_idle_pane_is_sent_the_screen_it_left() {
+        let mut broker = broker();
+        let viewer = greet(&mut broker);
+        subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+        frame(&mut broker, "w1:p1", b"still here\r\n");
+        broker.handle(
+            viewer,
+            ClientMessage::UnsubscribePane {
+                pane: pane("w1:p1"),
+            },
+        );
+
+        let returning = subscribe_as(
+            &mut broker,
+            viewer,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+            PaneRepresentation::Screen,
+        );
+
+        let messages = messages_for(&returning, viewer);
+        let screen = messages.iter().find_map(|message| match message {
+            ServerMessage::PaneScreen { screen, .. } => Some(screen.clone()),
+            _ => None,
+        });
+        let screen = screen.unwrap_or_else(|| {
+            panic!("a returning viewer was sent no screen and no frame is coming: {messages:?}")
+        });
+        assert_eq!(row_text(&screen, 0), "still here");
+
+        // And it is not kept for ever: when the route really goes, so does it.
+        broker.handle(
+            viewer,
+            ClientMessage::UnsubscribePane {
+                pane: pane("w1:p1"),
+            },
+        );
+        broker.close_if_unclaimed(&pane("w1:p1"));
+        assert!(
+            broker.screens.is_empty(),
+            "the rendered screen outlived the route it belonged to"
+        );
+    }
+
+    /// The point of keeping an unclaimed route: a client that drops and comes
+    /// straight back gets the stream it already had, rather than paying for a
+    /// fresh SSH session on somebody else's host every time a link flaps.
+    #[test]
+    fn a_route_reclaimed_before_the_wait_is_over_is_never_closed() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+        subscribe(
+            &mut broker,
+            client,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+        );
+        broker.handle(
+            client,
+            ClientMessage::UnsubscribePane {
+                pane: pane("w1:p1"),
+            },
+        );
+
+        // Back before anybody asked whether it was still unwanted.
+        let returning = subscribe(
+            &mut broker,
+            client,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+        );
+        assert!(
+            !returning
+                .iter()
+                .any(|effect| matches!(effect, Effect::OpenRoute { .. })),
+            "the route was reopened rather than reused"
+        );
+
+        assert!(
+            broker.close_if_unclaimed(&pane("w1:p1")).is_empty(),
+            "a route somebody is watching was closed by a stale wait"
+        );
+        assert!(broker.routes.contains_key(&pane("w1:p1")));
+    }
+
+    /// Asking twice settles it once. The sweep runs on a timer and a pane can
+    /// be swept after it has already gone.
+    #[test]
+    fn closing_an_unclaimed_route_twice_says_nothing_the_second_time() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+        subscribe(
+            &mut broker,
+            client,
+            "w1:p1",
+            TerminalAccess::Observe,
+            80,
+            24,
+        );
+        broker.disconnect(client);
+
+        assert_eq!(broker.close_if_unclaimed(&pane("w1:p1")).len(), 1);
+        assert!(broker.close_if_unclaimed(&pane("w1:p1")).is_empty());
+        assert!(broker.close_if_unclaimed(&pane("never-existed")).is_empty());
     }
 
     #[test]
@@ -2611,8 +2805,9 @@ mod tests {
         assert!(!messages_for(&again, viewer).is_empty());
 
         // And releasing once releases it: no phantom subscriber keeps the route
-        // open after the client has gone.
+        // claimed after the client has gone.
         broker.disconnect(viewer);
+        broker.close_if_unclaimed(&pane("w1:p1"));
         assert!(
             !broker.routes.contains_key(&pane("w1:p1")),
             "the route outlived the only client that wanted it"
@@ -3040,12 +3235,22 @@ mod tests {
 
         let effects = broker.disconnect(client);
 
-        assert!(effects.contains(&Effect::CloseRoute {
+        // Released, not closed — the routes are held for whoever is deciding
+        // how long to wait.
+        assert!(effects.contains(&Effect::RouteUnclaimed {
             pane: pane("w1:p1")
         }));
-        assert!(effects.contains(&Effect::CloseRoute {
+        assert!(effects.contains(&Effect::RouteUnclaimed {
             pane: pane("w1:p2")
         }));
         assert!(broker.disconnect(client).is_empty());
+        for resource in ["w1:p1", "w1:p2"] {
+            assert_eq!(
+                broker.close_if_unclaimed(&pane(resource)),
+                vec![Effect::CloseRoute {
+                    pane: pane(resource)
+                }]
+            );
+        }
     }
 }

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -1495,6 +1495,13 @@ impl Daemon {
                     cols,
                     rows,
                 } => self.open_route(pane, access, cols, rows),
+                Effect::RouteUnclaimed { pane } => {
+                    // Nothing waits yet, so a pane nobody is watching is closed
+                    // in the same pass — which is exactly what happened before
+                    // this effect existed. The wait belongs to whoever holds a
+                    // clock and arrives separately.
+                    pending.extend(self.broker.close_if_unclaimed(&pane));
+                }
                 Effect::CloseRoute { pane } => {
                     if let Some(route) = self.routes.remove(&pane) {
                         route.shutdown();


### PR DESCRIPTION
Half of the pane grace window. This half changes no behaviour; the session that
owns `server.rs` builds the wait on top of it.

## Why

A route closed the moment its last subscriber left. Right until a link flaps —
then a client that drops and comes straight back pays for a fresh SSH session on
somebody else's host, every time, for a gap it never noticed.

## Shape

Deciding how long to wait needs a clock and the broker has none, deliberately.
So the last subscriber leaving emits `RouteUnclaimed` — a fact, not a request —
and `close_if_unclaimed(&pane)` answers whether the pane is still unwanted when
something with a clock asks.

The decision stays with the state on purpose: a caller that remembered
"unclaimed when I started waiting" would close a route somebody is watching by
the time it acted, and that is a race nobody would reproduce. Being asked about
a pane whose route is already gone, or asked twice, answers with nothing and
does not panic — a sweep on a timer does both.

The one arm added to the effect loop closes in the same pass, which is exactly
what happened before, and it goes through the queue every other effect goes
through rather than closing a route directly. One dispatch path, so the two
cannot drift. That is the whole of the diff to `server.rs`: seven lines.

## The regression this nearly shipped with

Reuse removed the repaint that reopening a route used to provide — and nothing
named that dependency, so removing the teardown silently removed the repaint
too. A viewer returning to an **idle** pane would have sat on an empty screen
indefinitely: no `OpenRoute` fires by design, and its stream never stopped, so
no frame is coming either. Exactly the case the window exists to serve.

The rendered screen now stays with the route. Covered from both sides: dropping
the cache on release fails the returning-viewer test, and never clearing it on
close fails the same test's second half, so a later "keep it a bit longer"
cannot quietly make it permanent.

Found in review by the session that owns the other half of this daemon.

## And one found by running the page instead of reading it

`stopWatching` wrote the reason a viewer closed into `#screen-note` and hid
`#viewer` in the same breath — and `#screen-note` is inside `#viewer`. A pane
that closed under somebody removed the panel and left no explanation anywhere,
which reads as the page breaking rather than the pane ending.

I had traced that path twice and reported it twice as working. Every file was
correct on its own; the defect existed only where two of them met. It surfaced
when the page's real script was driven under a stub DOM.

The missing distinction is *who* stopped it: a person pressing Stop already
knows, so the panel goes; a viewer that stopped on its own is the only thing
that can say why, so it stays up and says it.

## Verification

- 269 tests.
- Mutations, each restored from a copy: dropping the reclaim leaves a returning
  client's route to be closed underneath it; closing regardless of the flag
  closes a claimed route; turning the lookup into an index panics on a pane
  with no route.
- Three existing tests changed, because the contract changed and they asserted
  the old one. They now assert released-then-closed, which is more precise.
- `cargo fmt --check` and clippy clean on the host and `x86_64-apple-darwin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmAj6nkoj5U8jTdGGXcFvb