### PR TITLE
Stop the attention history shadowing the browser's

### DIFF
--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -141,7 +141,11 @@ const session = (crypto.randomUUID && crypto.randomUUID() || String(Math.random(
 // The daemon's own vocabulary, mirrored here. Nothing is derived locally: the
 // federation and the attention history are what the daemon last said they were.
 const targets = new Map();
-let history = [];
+// Named for what it holds, and not `history`: a top-level `let history` shadows
+// `window.history` for the whole script, and the code that clears a scanned
+// pairing code out of the address bar calls `history.replaceState`. That threw,
+// and it threw before the page had rendered anything.
+let attention = [];
 
 const el = id => document.getElementById(id);
 const text = value => String(value == null ? '' : value);
@@ -202,7 +206,7 @@ function renderWaiting() {
 function renderHistory() {
   const list = el('history');
   list.innerHTML = '';
-  const recent = history.slice(-40).reverse();
+  const recent = attention.slice(-40).reverse();
   if (!recent.length) {
     list.innerHTML = '<li class="empty">no transitions yet</li>';
     return;
@@ -547,11 +551,13 @@ function apply(message) {
       if (sameId(message.pane, watching)) stopWatching('the pane closed');
       break;
     case 'attention.history':
-      history = message.events;
+      attention = message.events;
       renderHistory();
       break;
     case 'attention.event':
-      history = history.filter(held => held.id !== message.event.id).concat(message.event);
+      attention = attention
+        .filter(held => held.id !== message.event.id)
+        .concat(message.event);
       renderHistory();
       break;
   }


### PR DESCRIPTION
**The QR pairing flow has never worked.** A scanned code opens a blank page.

## What happens

`let history = []` — the attention history — is declared at the top of the page
script, which shadows `window.history` for the entire script.

`codeFromFragment` calls `history.replaceState` to strip a scanned pairing code
out of the address bar. That resolves to the array:

```
TypeError: history.replaceState is not a function
    at codeFromFragment
    at start
```

`start()` calls it first thing, so nothing renders. No pairing form, no error,
no explanation.

## Why nothing caught it

`codeFromFragment` returns early when there is no fragment, before it touches
`history`. So the page works perfectly every way a person opens it by hand, and
fails only the way a scanned QR opens it. The daemon side is correct throughout
— pairing, the URL, the fragment format, the validation — so nothing on that
side could have revealed it.

And nothing in the build executes a line of this file. It is embedded in the
binary and served; a syntax check is all it gets, and a syntax check cannot see
a shadowed global.

## The fix

The array is renamed for what it holds. Qualifying the call as
`window.history.replaceState` would have worked and would have left the trap in
place for whoever writes the next line reaching for a global this script happens
to shadow.

## How it was found

By executing the page under a stub DOM — the same harness that found the
`stopWatching` defect in `e6541f6`. Two real bugs, neither visible to reading:
readers saw `let history` and `history.replaceState` as unrelated identifiers,
twice.

Verified after the change: a fragment-bearing load calls the real
`replaceState`, the address is cleaned, and the code comes back as `ABCD-2345`.
`attention.history` and `attention.event` still apply without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmAj6nkoj5U8jTdGGXcFvb