### PR TITLE
Add Herdr plugin actions across TUI and browser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
     id: herdr_version
     attributes:
       label: Herdr version and protocol
-      placeholder: herdr 0.8.0, protocol 19
+      placeholder: herdr 0.8.2, protocol 20
     validations:
       required: true
   - type: textarea

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,6 +48,10 @@ Snapshot parsing treats optional fields as capabilities. Event and terminal
 support will be enabled only after the target advertises or successfully probes
 the corresponding operation.
 
+Plugin actions require Herdr protocol 20 or newer. Their registries are fetched
+per target with bounded socket requests, cached for one minute, invalidated by a
+target connection generation change, and never allowed to stall another target.
+
 The live state loop reconciles snapshots independently for each target, retains
 the last known state during bounded reconnect backoff, and assigns a new
 connection generation after reconnect. A configured API socket enables one
@@ -170,6 +174,26 @@ workspace, tab, or pane under the pointer; it never reconstructs identity from a
 display label. Destructive workspace, tab, and pane actions must pass through
 the same qualified confirmation path.
 
+Enabled Herdr plugin actions use that routing model too. The daemon discovers
+them with `plugin.action.list`, removes their command arrays, qualifies each
+plugin/action pair with target and session, and exposes the remaining title,
+description, and supported contexts to the frontend. Invocation uses
+`plugin.action.invoke` only after the daemon hydrates the chosen resource through
+documented `workspace.get`, `tab.get`, `pane.get`, and `pane.list` calls. That
+prevents Herdr's own local focus from replacing the pane selected in
+Super-Herdr. Selection-only actions are not exposed, and terminal selection text
+is never carried as incidental plugin context.
+
+The browser asks for the same sanitized registry and renders the actions that
+support its currently viewed pane. An invocation returns only a qualified
+plugin log ID and `running`, `succeeded`, or `failed`; polling
+`plugin.log.list` is reduced to those fields before it crosses the daemon
+boundary, so command arguments, stdout, stderr, and plugin error payloads are
+discarded in the daemon and never reach a client. Federation updates reveal
+panes created after the action.
+The browser offers those panes as explicit links and never changes the pane
+being viewed or controlled automatically.
+
 Moving a workspace is a multi-request action inside one session. Super-Herdr
 reads each source tab's split tree through the documented layout export, reduces
 it to one anchor pane plus the ordered splits that rebuild it, and replays that
@@ -179,10 +203,10 @@ identifier encodes its workspace, each later split targets the identifier the
 previous move returned. The whole sequence runs in one task behind the same
 single-action guard and reports one result, and a partial failure leaves already
 moved tabs in the destination and the remainder in the source without closing
-anything. A session is a separate server process that owns its panes, and
-protocol 19 has no cross-session transfer, so destinations are restricted to the
-source session and cross-session recreation is not silently substituted for a
-move.
+anything. A session is a separate server process that owns its panes, and the
+documented API has no cross-session transfer, so destinations are restricted to
+the source session and cross-session recreation is not silently substituted for
+a move.
 
 Crossing a session boundary is a different operation with different guarantees,
 and the two are never conflated. Recreation reads the source workspace's tabs and

--- a/README.md
+++ b/README.md
@@ -127,12 +127,19 @@ cannot redirect the next byte you type.
 Common Herdr layout chords also work: use `Ctrl+B` followed by `h/j/k/l` to
 move between panes, `c` to create a tab, `v` or `-` to split, `z` to zoom, and
 `?` for help. Right-click a session, workspace, tab, or pane for actions scoped
-to that exact target and session.
+to that exact target and session. Actions from enabled Herdr plugins appear in
+the same right-click menus and searchable action palette. In the browser, open
+a pane to get the actions it supports as compact **Tools** buttons. Super-Herdr
+shows whether the plugin command is running, finished, or failed. If the action
+opens a picker, overlay, board, or another pane, an **Open** button appears;
+your current terminal never changes until you tap it.
 
 ## What is included
 
 - Concurrent discovery and supervision across local and SSH targets
 - A live, clickable TUI with tabs, split panes, search, and agent attention
+- Qualified plugin actions in the TUI and browser, with sanitized run status
+  and explicit routing to any newly opened pane
 - Explicit control leases: background panes and newly opened browser panes are
   read-only until control is granted
 - Desktop selection, clipboard paste, drag-and-drop, and verified uploads
@@ -146,7 +153,7 @@ payloads, credentials, and SSH material are never logged.
 
 ## Requirements
 
-- A compatible Herdr client on each target. Herdr 0.8.0 / protocol 19 is the
+- A compatible Herdr client on each target. Herdr 0.8.2 / protocol 20 is the
   currently tested combination.
 - OpenSSH for remote targets. Existing SSH configuration, keys, host checking,
   and proxy settings remain authoritative.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,10 @@ Work is ordered by dependency and product risk.
   and click-to-jump routing where the desktop reports actions.
 - Fuzzy-searchable action palette with qualified workspace, tab, and pane
   lifecycle operations.
+- Qualified Herdr 0.8.2 plugin actions in the TUI and browser, with
+  metadata-only lifecycle polling and an explicit, non-focus-stealing route to
+  newly opened plugin panes. Plugin commands, process output, and terminal
+  selection text are not forwarded.
 - Qualified mouse context menus for sessions, workspaces, tabs, and panes, backed
   by the shared resource-action and close-confirmation paths.
 - Dual MIT/Apache-2.0 licensing, so the project can accept outside contributions.
@@ -152,12 +156,12 @@ does not prove that the browser path is reliable.
   Transfers are initiated from the client until such an envelope exists;
   scraping pane output for markers is not an acceptable substitute.
 - Moving a workspace between sessions on one host with its processes intact.
-  Each session is its own server process, and protocol 19 has no cross-session
-  transfer. A true move needs a Herdr-side transfer that hands live PTYs to the
-  destination server, the way `server.live_handoff` already does across an
-  upgrade. Recreation ships as the client-side substitute and is presented as
-  such; it restarts every process and drops scrollback, so it does not close the
-  gap.
+  Each session is its own server process, and the documented API has no
+  cross-session transfer. A true move needs a Herdr-side transfer that hands
+  live PTYs to the destination server, the way `server.live_handoff` already
+  does across an upgrade. Recreation ships as the client-side substitute and is
+  presented as such; it restarts every process and drops scrollback, so it does
+  not close the gap.
 
 ## Later
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,8 +22,9 @@ use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
 use crate::daemon::server::DaemonHandle;
-use crate::model::PaneId;
+use crate::model::{PaneId, TargetSession};
 use crate::operation::Operation;
+use crate::plugin::PluginRunId;
 use crate::protocol::{
     ClientMessage, MAX_MESSAGE_BYTES, PROTOCOL_VERSION, PaneRepresentation, ServerMessage, decode,
     encode,
@@ -277,6 +278,18 @@ impl ClientCommands {
     pub fn run_operation(&self, operation: Operation) -> u64 {
         let request = self.next_request();
         self.send(ClientMessage::RunOperation { request, operation });
+        request
+    }
+
+    pub fn list_plugin_actions(&self, target: TargetSession) -> u64 {
+        let request = self.next_request();
+        self.send(ClientMessage::ListPluginActions { request, target });
+        request
+    }
+
+    pub fn get_plugin_run(&self, run: PluginRunId) -> u64 {
+        let request = self.next_request();
+        self.send(ClientMessage::GetPluginRun { request, run });
         request
     }
 

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -90,6 +90,7 @@
     border: 1px solid var(--line); border-radius: .55rem;
     padding: .35rem .7rem; cursor: pointer;
   }
+  button:disabled { color: var(--dim); cursor: default; opacity: .6; }
   .actions { display: flex; gap: .5rem; margin-top: .7rem; }
   #line {
     flex: 1; min-width: 0; padding: .5rem .6rem; font: inherit;
@@ -176,6 +177,15 @@
   .viewer-head #stop { margin-left: auto; flex: none; }
   .viewer-controls { min-width: 0; }
   .viewer-controls > .actions { margin: 0; align-items: center; }
+  #plugin-tools { min-width: 0; margin-bottom: .35rem; }
+  #plugin-tools[hidden] { display: none; }
+  .plugin-head { display: flex; align-items: baseline; gap: .5rem; min-width: 0; }
+  .plugin-head .note { margin-left: auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #plugin-actions { margin-top: .25rem; }
+  #plugin-actions button { color: var(--text); background: var(--bg); }
+  #plugin-results { display: flex; gap: .35rem; align-items: center; min-width: 0; margin-top: .25rem; }
+  #plugin-results:empty { display: none; }
+  #plugin-results .note { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   #keyboard { padding-top: .1rem; }
 
   @media (max-width: 640px) {
@@ -246,6 +256,11 @@
     </div>
     <div id="screen" class="screen"></div>
     <div class="viewer-controls">
+      <section id="plugin-tools" hidden aria-label="Plugin actions">
+        <div class="plugin-head"><strong>Tools</strong><span id="plugin-status" class="note"></span></div>
+        <div id="plugin-actions" class="control-strip"></div>
+        <div id="plugin-results"></div>
+      </section>
       <div class="actions"><button id="control">Take control &amp; type</button></div>
       <div id="keyboard" hidden>
         <form id="line-form" class="actions">
@@ -302,6 +317,16 @@ let attention = [];
 let attentionAutoOpened = false;
 const openTargets = new Set();
 const openSessions = new Set();
+
+// Plugin registries are server-local, so the browser caches one only beside
+// the exact target/session generation it came from. Runs are metadata-only;
+// commands and process output never arrive in this page.
+const pluginCatalogs = new Map();
+const pendingPluginCatalogs = new Map();
+const pendingPluginOperations = new Map();
+const pendingPluginPolls = new Map();
+let pluginActivity = null;
+let pluginPollTimer = null;
 
 const el = id => document.getElementById(id);
 const text = value => String(value == null ? '' : value);
@@ -506,7 +531,7 @@ let lease = 'observe';
 let requestingControl = false;
 let screen = null;
 let cell = null;
-let nextUploadRequest = 1;
+let nextCommandRequest = 1;
 let uploadBusy = false;
 const uploads = new Map();
 
@@ -550,6 +575,177 @@ function sameId(left, right) {
     && left.target === right.target
     && left.session === right.session
     && left.resource === right.resource;
+}
+
+function targetKey(id) {
+  return id && `${id.target}/${id.session}`;
+}
+
+function panesIn(target) {
+  const runtime = targets.get(targetKey(target));
+  return runtime && runtime.snapshot && runtime.snapshot.panes || [];
+}
+
+function paneKey(pane) {
+  return `${pane.target}/${pane.session}/${pane.resource}`;
+}
+
+function requestPluginCatalog(runtime) {
+  if (!runtime || runtime.connection !== 'live' || !runtime.snapshot
+      || Number(runtime.snapshot.protocol || 0) < 20) return;
+  const key = targetKey(runtime.key);
+  const generation = runtime.connection_generation || 0;
+  const held = pluginCatalogs.get(key);
+  if (held && held.generation === generation && Date.now() - held.loadedAt < 60_000) return;
+  for (const pending of pendingPluginCatalogs.values()) {
+    if (pending.key === key && pending.generation === generation) return;
+  }
+  const request = nextCommandRequest++;
+  pendingPluginCatalogs.set(request, { key, generation });
+  void postCommand({ type: 'plugin.actions.list', request, target: runtime.key }).catch(() => {
+    pendingPluginCatalogs.delete(request);
+    renderPluginTools();
+  });
+}
+
+function refreshPluginCatalogs() {
+  for (const runtime of targets.values()) requestPluginCatalog(runtime);
+}
+
+function supportsPane(action) {
+  const contexts = action.contexts || [];
+  if (!contexts.length) return true;
+  return contexts.some(context => ['global', 'workspace', 'tab', 'pane'].includes(context));
+}
+
+function actionsFor(pane) {
+  if (!pane) return [];
+  const runtime = targets.get(targetKey(pane));
+  const catalog = pluginCatalogs.get(targetKey(pane));
+  if (!runtime || runtime.connection !== 'live' || !catalog
+      || catalog.generation !== (runtime.connection_generation || 0)) return [];
+  return catalog.actions.filter(supportsPane);
+}
+
+function paneLabel(pane) {
+  const state = panesIn(pane).find(candidate => sameId(candidate.id, pane));
+  return state && state.label || pane.resource;
+}
+
+function updatePluginCandidates() {
+  if (!pluginActivity) return;
+  const candidates = panesIn(pluginActivity.source)
+    .filter(pane => !pluginActivity.baseline.has(paneKey(pane.id)))
+    .map(pane => pane.id);
+  pluginActivity.candidates = candidates;
+  renderPluginTools();
+}
+
+function renderPluginTools() {
+  const actions = actionsFor(watching);
+  const related = pluginActivity && watching
+    && targetKey(pluginActivity.source) === targetKey(watching);
+  const tools = el('plugin-tools');
+  tools.hidden = !actions.length && !related;
+  const buttons = el('plugin-actions');
+  buttons.innerHTML = '';
+  for (const action of actions) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = action.title;
+    button.title = [action.id.plugin_id, action.description].filter(Boolean).join(' · ');
+    button.disabled = Boolean(related && pluginActivity.state === 'starting'
+      && pluginActivity.actionKey === `${action.id.plugin_id}/${action.id.action_id}`);
+    button.onclick = () => startPluginAction(action);
+    buttons.append(button);
+  }
+
+  const status = el('plugin-status');
+  const results = el('plugin-results');
+  results.innerHTML = '';
+  if (!related) {
+    status.textContent = actions.length ? `${actions.length} available` : '';
+    return;
+  }
+  const labels = {
+    starting: 'starting…', running: 'running', succeeded: 'finished',
+    failed: 'failed', unknown: 'status unavailable',
+  };
+  status.textContent = `${pluginActivity.title} · ${labels[pluginActivity.state] || pluginActivity.state}`;
+  if (pluginActivity.detail && ['failed', 'unknown'].includes(pluginActivity.state)) {
+    const note = document.createElement('span');
+    note.className = 'note';
+    note.textContent = pluginActivity.detail;
+    results.append(note);
+  }
+  for (const pane of pluginActivity.candidates.slice(0, 3)) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = `Open ${paneLabel(pane)}`;
+    button.onclick = () => observe(pane, `${pane.target}/${pane.session}/${paneLabel(pane)}`);
+    results.append(button);
+  }
+  if (pluginActivity.candidates.length > 3) {
+    const note = document.createElement('span');
+    note.className = 'note';
+    note.textContent = `+${pluginActivity.candidates.length - 3} more new panes in the list`;
+    results.append(note);
+  }
+}
+
+function startPluginAction(action) {
+  if (!watching) return;
+  if (pluginPollTimer) clearTimeout(pluginPollTimer);
+  const request = nextCommandRequest++;
+  const source = { ...watching };
+  pluginActivity = {
+    request,
+    source,
+    title: action.title,
+    actionKey: `${action.id.plugin_id}/${action.id.action_id}`,
+    state: 'starting',
+    baseline: new Set(panesIn(source).map(pane => paneKey(pane.id))),
+    candidates: [],
+    run: null,
+  };
+  pendingPluginOperations.set(request, pluginActivity);
+  renderPluginTools();
+  void postCommand({
+    type: 'operation.run',
+    request,
+    operation: {
+      operation: 'invoke_plugin_action',
+      action: action.id,
+      context: { context: 'pane', pane: source },
+      title: action.title,
+    },
+  }).catch(error => {
+    const pending = pendingPluginOperations.get(request);
+    if (!pending) return;
+    pendingPluginOperations.delete(request);
+    pending.state = 'failed';
+    pending.detail = error instanceof Error ? error.message : 'the request did not reach the daemon';
+    renderPluginTools();
+  });
+}
+
+function schedulePluginPoll() {
+  if (pluginPollTimer) clearTimeout(pluginPollTimer);
+  if (!pluginActivity || !pluginActivity.run || pluginActivity.state !== 'running') return;
+  pluginPollTimer = setTimeout(() => {
+    if (!pluginActivity || !pluginActivity.run || pluginActivity.state !== 'running') return;
+    const request = nextCommandRequest++;
+    const logId = pluginActivity.run.id.log_id;
+    pendingPluginPolls.set(request, logId);
+    void postCommand({ type: 'plugin.run.get', request, run: pluginActivity.run.id }).catch(() => {
+      if (pendingPluginPolls.delete(request) && pluginActivity
+          && pluginActivity.run && pluginActivity.run.id.log_id === logId) {
+        pluginActivity.state = 'unknown';
+        pluginActivity.detail = 'The run status request did not reach the daemon.';
+        renderPluginTools();
+      }
+    });
+  }, 1000);
 }
 
 // This page's own default pair, kept in step with `.screen` in the stylesheet.
@@ -698,6 +894,7 @@ function observe(pane, label) {
   el('screen-note').textContent = 'waiting for output…';
   if (!uploadBusy) el('upload-note').textContent = DEFAULT_UPLOAD_NOTE;
   el('screen').innerHTML = '';
+  renderPluginTools();
   subscribeScreen(pane);
 }
 
@@ -802,7 +999,7 @@ async function uploadBrowserFile(file, pane) {
   if (buffer.byteLength !== file.size) throw new Error(`${file.name}: the file changed while reading`);
   const bytes = new Uint8Array(buffer);
   const digest = await sha256Hex(bytes);
-  const request = nextUploadRequest++;
+  const request = nextCommandRequest++;
   const upload = { request, pane, events: [], waiter: null };
   uploads.set(request, upload);
   let began = false;
@@ -914,6 +1111,7 @@ function stopWatching(why) {
   el('viewer').hidden = !reason;
   el('screen-note').textContent = reason;
   renderPanes();
+  renderPluginTools();
 }
 
 // A gap in the sequence means an update was missed. Resubscribing is the
@@ -1082,6 +1280,13 @@ function renderPanes() {
 function apply(message) {
   switch (message.type) {
     case 'server.hello':
+      pendingPluginCatalogs.clear();
+      pendingPluginPolls.clear();
+      if (pendingPluginOperations.size && pluginActivity && !pluginActivity.run) {
+        pluginActivity.state = 'unknown';
+        pluginActivity.detail = 'The connection changed before the daemon answered.';
+      }
+      pendingPluginOperations.clear();
       send({ type: 'state.subscribe' });
       // A reconnect is a new client to the daemon, which knows nothing about
       // what this page was watching — so what was being watched is asked for
@@ -1093,14 +1298,21 @@ function apply(message) {
         cell = null;
         subscribeScreen(watching);
       }
+      schedulePluginPoll();
       break;
     case 'state.full':
       targets.clear();
       for (const runtime of message.state.targets) {
         targets.set(`${runtime.key.target}/${runtime.key.session}`, runtime);
       }
+      for (const key of pluginCatalogs.keys()) {
+        if (!targets.has(key)) pluginCatalogs.delete(key);
+      }
       renderAttention();
       renderPanes();
+      refreshPluginCatalogs();
+      updatePluginCandidates();
+      renderPluginTools();
       break;
     case 'state.target': {
       const key = `${message.target.target}/${message.target.session}`;
@@ -1108,6 +1320,10 @@ function apply(message) {
       else targets.delete(key);
       renderAttention();
       renderPanes();
+      if (message.state) requestPluginCatalog(message.state);
+      else pluginCatalogs.delete(key);
+      updatePluginCandidates();
+      renderPluginTools();
       break;
     }
     case 'pane.screen':
@@ -1147,15 +1363,84 @@ function apply(message) {
     case 'pane.closed':
       if (sameId(message.pane, watching)) stopWatching('the pane closed');
       break;
+    case 'plugin.actions': {
+      const pending = pendingPluginCatalogs.get(message.request);
+      pendingPluginCatalogs.delete(message.request);
+      if (!pending || pending.key !== targetKey(message.target)
+          || pending.generation !== message.generation) break;
+      const runtime = targets.get(pending.key);
+      if (!runtime || runtime.connection !== 'live'
+          || (runtime.connection_generation || 0) !== message.generation) break;
+      pluginCatalogs.set(pending.key, {
+        generation: message.generation,
+        loadedAt: Date.now(),
+        actions: message.actions || [],
+      });
+      renderPluginTools();
+      break;
+    }
+    case 'operation.result': {
+      const activity = pendingPluginOperations.get(message.request);
+      if (!activity) break;
+      pendingPluginOperations.delete(message.request);
+      if (pluginActivity !== activity) break;
+      if (!message.applied) {
+        activity.state = 'failed';
+        activity.detail = message.message || 'the action was refused';
+      } else if (message.plugin_run) {
+        activity.run = message.plugin_run;
+        activity.state = message.plugin_run.status;
+      } else {
+        activity.state = 'succeeded';
+      }
+      updatePluginCandidates();
+      schedulePluginPoll();
+      break;
+    }
+    case 'plugin.run': {
+      const expected = pendingPluginPolls.get(message.request);
+      pendingPluginPolls.delete(message.request);
+      if (!expected || !pluginActivity || !pluginActivity.run
+          || expected !== message.run.id.log_id
+          || expected !== pluginActivity.run.id.log_id) break;
+      pluginActivity.run = message.run;
+      pluginActivity.state = message.run.status;
+      renderPluginTools();
+      schedulePluginPoll();
+      break;
+    }
     case 'upload.accepted':
     case 'upload.complete':
     case 'upload.interrupted':
       signalUpload(message);
       break;
     case 'error':
-      if (!signalUpload(message)) {
-        el('screen-note').textContent = message.message || 'daemon request failed';
+      if (pendingPluginCatalogs.delete(message.request)) {
+        renderPluginTools();
+        break;
       }
+      if (pendingPluginOperations.has(message.request)) {
+        const activity = pendingPluginOperations.get(message.request);
+        pendingPluginOperations.delete(message.request);
+        if (pluginActivity === activity) {
+          activity.state = 'failed';
+          activity.detail = message.message || 'the action was refused';
+          renderPluginTools();
+        }
+        break;
+      }
+      if (pendingPluginPolls.has(message.request)) {
+        const expected = pendingPluginPolls.get(message.request);
+        pendingPluginPolls.delete(message.request);
+        if (pluginActivity && pluginActivity.run
+            && pluginActivity.run.id.log_id === expected) {
+          pluginActivity.state = 'unknown';
+          pluginActivity.detail = 'Herdr stopped reporting this run.';
+          renderPluginTools();
+        }
+        break;
+      }
+      if (!signalUpload(message)) el('screen-note').textContent = message.message || 'daemon request failed';
       break;
     case 'attention.history':
       attention = message.events;

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -23,8 +23,9 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 
 use crate::attention::AttentionEvent;
-use crate::model::PaneId;
+use crate::model::{PaneId, TargetSession};
 use crate::operation::Operation;
+use crate::plugin::{PluginRun, PluginRunId};
 use crate::protocol::{ClientMessage, PROTOCOL_VERSION, PaneRepresentation, ServerMessage};
 use crate::screen::{Diff as ScreenDiff, Snapshot};
 use crate::state::{FederationState, TargetConnectionState};
@@ -91,6 +92,16 @@ pub enum Effect {
         client: ClientId,
         request: u64,
         operation: Operation,
+    },
+    ListPluginActions {
+        client: ClientId,
+        request: u64,
+        target: TargetSession,
+    },
+    GetPluginRun {
+        client: ClientId,
+        request: u64,
+        run: PluginRunId,
     },
     PastePaneText {
         client: ClientId,
@@ -515,6 +526,20 @@ impl Broker {
                     client,
                     request,
                     operation,
+                });
+            }
+            ClientMessage::ListPluginActions { request, target } => {
+                effects.push(Effect::ListPluginActions {
+                    client,
+                    request,
+                    target,
+                });
+            }
+            ClientMessage::GetPluginRun { request, run } => {
+                effects.push(Effect::GetPluginRun {
+                    client,
+                    request,
+                    run,
                 });
             }
             ClientMessage::PastePaneText {
@@ -1022,6 +1047,7 @@ impl Broker {
         request: u64,
         applied: bool,
         message: impl Into<String>,
+        plugin_run: Option<PluginRun>,
     ) -> Vec<Effect> {
         if !self.clients.contains_key(&client) {
             return Vec::new();
@@ -1032,6 +1058,7 @@ impl Broker {
                 request,
                 applied,
                 message: message.into(),
+                plugin_run,
             },
         }]
     }
@@ -1347,6 +1374,7 @@ mod tests {
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{PaneId, TargetSession};
     use crate::operation::Operation;
+    use crate::plugin::PluginRunId;
     use crate::protocol::{ClientMessage, PROTOCOL_VERSION, PaneRepresentation, ServerMessage};
     use crate::screen::Diff as ScreenDiff;
     use crate::screen::Snapshot;
@@ -3141,7 +3169,7 @@ mod tests {
             [Effect::RunOperation { request: 4, .. }]
         ));
 
-        let effects = broker.operation_completed(asking, 4, true, "created tab");
+        let effects = broker.operation_completed(asking, 4, true, "created tab", None);
         assert!(matches!(
             messages_for(&effects, asking).as_slice(),
             [ServerMessage::OperationResult {
@@ -3151,6 +3179,58 @@ mod tests {
             }]
         ));
         assert!(messages_for(&effects, other).is_empty());
+    }
+
+    #[test]
+    fn plugin_discovery_keeps_the_target_session_qualified() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+        let target = TargetSession::new("build", "work");
+
+        let effects = broker.handle(
+            client,
+            ClientMessage::ListPluginActions {
+                request: 9,
+                target: target.clone(),
+            },
+        );
+
+        assert_eq!(
+            effects,
+            vec![Effect::ListPluginActions {
+                client,
+                request: 9,
+                target,
+            }]
+        );
+    }
+
+    #[test]
+    fn plugin_run_polling_keeps_the_target_session_qualified() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+        let run = PluginRunId {
+            target: TargetSession::new("build", "work"),
+            plugin_id: "herdr-workflows".to_owned(),
+            log_id: "log-7".to_owned(),
+        };
+
+        let effects = broker.handle(
+            client,
+            ClientMessage::GetPluginRun {
+                request: 10,
+                run: run.clone(),
+            },
+        );
+
+        assert_eq!(
+            effects,
+            vec![Effect::GetPluginRun {
+                client,
+                request: 10,
+                run,
+            }]
+        );
     }
 
     #[test]
@@ -3170,7 +3250,7 @@ mod tests {
 
         assert!(
             broker
-                .operation_completed(client, 1, true, "done")
+                .operation_completed(client, 1, true, "done", None)
                 .is_empty()
         );
     }

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -43,6 +43,7 @@ use crate::daemon::web;
 use crate::model::{PaneId, TargetSession};
 use crate::operation::Operation;
 use crate::pairing::{self, PendingPairing};
+use crate::plugin;
 use crate::protocol::{ClientMessage, MAX_MESSAGE_BYTES, ServerMessage, decode, encode};
 use crate::state::{FederationState, FederationStore, SupervisorOptions, target_key};
 use crate::terminal::{
@@ -141,6 +142,7 @@ enum Input {
         request: u64,
         applied: bool,
         message: String,
+        plugin_run: Option<plugin::PluginRun>,
     },
     /// A transfer's chunks, handed over by the connection that will carry them.
     ///
@@ -964,7 +966,10 @@ async fn run(
         .unwrap_or_default();
     let attention_cursor = attention.events().next_back().map(|event| event.id);
     let mut daemon = Daemon {
-        broker: Broker::new(env!("CARGO_PKG_VERSION"), vec!["terminal".to_owned()]),
+        broker: Broker::new(
+            env!("CARGO_PKG_VERSION"),
+            vec!["terminal".to_owned(), "plugin_actions".to_owned()],
+        ),
         web_url: options.web_url.clone(),
         bridge_pairing: options.web_bridge.as_ref().map(|_| bridge_pairing.clone()),
         outboxes: BTreeMap::new(),
@@ -1511,9 +1516,10 @@ impl Daemon {
                 request,
                 applied,
                 message,
+                plugin_run,
             } => self
                 .broker
-                .operation_completed(client, request, applied, message),
+                .operation_completed(client, request, applied, message, plugin_run),
             Input::RelayFinished {
                 client,
                 request,
@@ -1669,6 +1675,16 @@ impl Daemon {
                     request,
                     operation,
                 } => self.run_operation(client, request, operation),
+                Effect::ListPluginActions {
+                    client,
+                    request,
+                    target,
+                } => self.list_plugin_actions(client, request, target),
+                Effect::GetPluginRun {
+                    client,
+                    request,
+                    run,
+                } => self.get_plugin_run(client, request, run),
                 Effect::PastePaneText {
                     client,
                     request,
@@ -2066,6 +2082,7 @@ impl Daemon {
                 request,
                 applied,
                 message,
+                plugin_run: None,
             });
         });
     }
@@ -2651,6 +2668,7 @@ impl Daemon {
                 request,
                 applied: false,
                 message: format!("{source_key} is not a configured target"),
+                plugin_run: None,
             });
             return;
         };
@@ -2660,6 +2678,7 @@ impl Daemon {
                 request,
                 applied: false,
                 message: format!("{destination_key} is not a configured target"),
+                plugin_run: None,
             });
             return;
         };
@@ -2682,16 +2701,82 @@ impl Daemon {
                 timeout,
             )
             .await;
-            let (applied, message) = match outcome {
-                Ok(detail) => (true, detail.unwrap_or(description)),
-                Err(error) => (false, error),
+            let (applied, message, plugin_run) = match outcome {
+                Ok(outcome) => (
+                    true,
+                    outcome.detail.unwrap_or(description),
+                    outcome.plugin_run,
+                ),
+                Err(error) => (false, error, None),
             };
             let _ = inputs.send(Input::OperationDone {
                 client,
                 request,
                 applied,
                 message,
+                plugin_run,
             });
+        });
+    }
+
+    /// Read one target's plugin registry off the daemon loop. The target and
+    /// generation ride back with the answer so a reconnect cannot make a late
+    /// registry look current.
+    fn list_plugin_actions(&mut self, client: ClientId, request: u64, key: TargetSession) {
+        let Some(target) = self.targets.get(&key).cloned() else {
+            self.refuse(client, request, format!("{key} is not a configured target"));
+            return;
+        };
+        let generation = self
+            .state
+            .targets
+            .get(&key)
+            .map_or(0, |runtime| runtime.connection_generation);
+        let Some(outbox) = self.outboxes.get(&client).cloned() else {
+            return;
+        };
+        let transport = self.transport.clone();
+        let request_timeout = self.command_timeout;
+        tokio::spawn(async move {
+            let message = match plugin::list(&key, &target, &transport, request_timeout).await {
+                Ok(actions) => ServerMessage::PluginActions {
+                    request,
+                    target: key,
+                    generation,
+                    actions,
+                },
+                Err(error) => ServerMessage::Error {
+                    request: Some(request),
+                    message: format!("plugin actions unavailable on {key}: {}", error.message),
+                },
+            };
+            let _ = outbox.send(message);
+        });
+    }
+
+    /// Poll lifecycle metadata for one plugin command. Herdr's log response
+    /// also contains command arguments and process output; `plugin::status`
+    /// discards those before the result can cross the daemon boundary.
+    fn get_plugin_run(&mut self, client: ClientId, request: u64, run: plugin::PluginRunId) {
+        let key = run.target.clone();
+        let Some(target) = self.targets.get(&key).cloned() else {
+            self.refuse(client, request, format!("{key} is not a configured target"));
+            return;
+        };
+        let Some(outbox) = self.outboxes.get(&client).cloned() else {
+            return;
+        };
+        let transport = self.transport.clone();
+        let request_timeout = self.command_timeout;
+        tokio::spawn(async move {
+            let message = match plugin::status(&run, &target, &transport, request_timeout).await {
+                Ok(run) => ServerMessage::PluginRun { request, run },
+                Err(error) => ServerMessage::Error {
+                    request: Some(request),
+                    message: format!("plugin run unavailable on {key}: {}", error.message),
+                },
+            };
+            let _ = outbox.send(message);
         });
     }
 
@@ -2744,7 +2829,7 @@ async fn execute(
     executable: Option<&str>,
     transport: &TransportConfig,
     timeout: Duration,
-) -> Result<Option<String>, String> {
+) -> Result<ExecutionOutcome, String> {
     match operation {
         Operation::MoveWorkspace {
             workspace,
@@ -2757,11 +2842,12 @@ async fn execute(
             timeout,
         )
         .await
-        .map(|summary| {
-            Some(format!(
+        .map(|summary| ExecutionOutcome {
+            detail: Some(format!(
                 "moved {} tab(s) and {} pane(s)",
                 summary.tabs, summary.panes
-            ))
+            )),
+            plugin_run: None,
         }),
         Operation::RecreateWorkspace {
             workspace, label, ..
@@ -2774,12 +2860,22 @@ async fn execute(
             timeout,
         )
         .await
-        .map(|summary| {
-            Some(format!(
+        .map(|summary| ExecutionOutcome {
+            detail: Some(format!(
                 "recreated {} tab(s) and {} pane(s) as {}",
                 summary.tabs, summary.panes, summary.workspace
-            ))
+            )),
+            plugin_run: None,
         }),
+        Operation::InvokePluginAction {
+            action, context, ..
+        } => plugin::invoke(action, context, source, transport, timeout)
+            .await
+            .map(|plugin_run| ExecutionOutcome {
+                detail: Some("plugin action started".to_owned()),
+                plugin_run: Some(plugin_run),
+            })
+            .map_err(|error| error.message),
         single => {
             let args = single
                 .herdr_args()
@@ -2788,10 +2884,18 @@ async fn execute(
                 executable.ok_or_else(|| "no compatible Herdr client is selected".to_owned())?;
             run_herdr_operation(source, transport, executable, &args, timeout)
                 .await
-                .map(|()| None)
+                .map(|()| ExecutionOutcome {
+                    detail: None,
+                    plugin_run: None,
+                })
                 .map_err(|error| error.message)
         }
     }
+}
+
+struct ExecutionOutcome {
+    detail: Option<String>,
+    plugin_run: Option<plugin::PluginRun>,
 }
 
 /// `Vec` has no queue-shaped pop, and effects must be applied in the order the

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -700,6 +700,11 @@ mod tests {
         assert!(APP.contains("crypto.subtle.digest('SHA-256'"));
         assert_eq!(APP.matches("data-reply=").count(), 4);
         assert!(APP.contains("class=\"keys control-strip\""));
+        assert!(APP.contains("id=\"plugin-tools\""));
+        assert!(APP.contains("type: 'plugin.actions.list'"));
+        assert!(APP.contains("operation: 'invoke_plugin_action'"));
+        assert!(APP.contains("type: 'plugin.run.get'"));
+        assert!(APP.contains("Open ${paneLabel(pane)}"));
         assert_eq!(APP.matches("id=\"attention\"").count(), 1);
         assert!(!APP.contains("id=\"waiting\""));
         assert!(!APP.contains("id=\"history\""));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod model;
 pub mod notifications;
 pub mod operation;
 pub mod pairing;
+pub mod plugin;
 pub mod probe;
 pub mod protocol;
 pub mod resource_action;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -14,6 +14,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::model::{PaneId, TabId, TargetSession, WorkspaceId};
+use crate::plugin::{PluginActionId, PluginInvocationTarget};
 use crate::resource_action::SplitDirection;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,6 +64,14 @@ pub enum Operation {
     ClosePane {
         pane: PaneId,
     },
+    /// Start an installed Herdr plugin action through the documented socket
+    /// API. Both the action and its context remain qualified until that final
+    /// hop, because plugin identifiers are server-local too.
+    InvokePluginAction {
+        action: PluginActionId,
+        context: PluginInvocationTarget,
+        title: String,
+    },
 }
 
 impl Operation {
@@ -80,6 +89,7 @@ impl Operation {
             Self::SplitPane { pane, .. }
             | Self::TogglePaneZoom { pane }
             | Self::ClosePane { pane } => pane.target_session(),
+            Self::InvokePluginAction { action, .. } => action.target.clone(),
         }
     }
 
@@ -124,6 +134,7 @@ impl Operation {
                 workspace.server_local_id().to_owned(),
             ],
             Self::MoveWorkspace { .. } | Self::RecreateWorkspace { .. } => return None,
+            Self::InvokePluginAction { .. } => return None,
             Self::CreateTab { workspace } => vec![
                 "tab".to_owned(),
                 "create".to_owned(),
@@ -196,6 +207,10 @@ impl Operation {
             }
             Self::TogglePaneZoom { pane } => format!("toggle zoom on pane {pane}"),
             Self::ClosePane { pane } => format!("close pane {pane}"),
+            Self::InvokePluginAction { action, title, .. } => format!(
+                "start plugin action {title:?} ({}/{}) on {}",
+                action.plugin_id, action.action_id, action.target
+            ),
         }
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,0 +1,771 @@
+//! Herdr plugin actions exposed through the documented socket API.
+//!
+//! Plugin and action identifiers are server-local just like pane identifiers,
+//! so they remain qualified with their target and session until the final API
+//! request. The command behind an action deliberately never enters this model:
+//! Herdr owns execution, while Super-Herdr needs only enough metadata to let a
+//! person choose an action and route it back to the same server.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use tokio::time::timeout;
+
+use crate::config::{Target, TransportConfig};
+use crate::model::{PaneId, TabId, TargetSession, WorkspaceId};
+use crate::transport::{ApiSession, SnapshotError};
+
+const MAX_PLUGIN_ACTIONS: usize = 512;
+const MAX_PLUGIN_RUNS: usize = 64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginActionContext {
+    Global,
+    Workspace,
+    Tab,
+    Pane,
+    Selection,
+    /// A context introduced by a newer Herdr. Kept non-global so an older
+    /// Super-Herdr hides the action instead of invoking it with the wrong
+    /// resource.
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginActionId {
+    pub target: TargetSession,
+    pub plugin_id: String,
+    pub action_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginAction {
+    pub id: PluginActionId,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub contexts: Vec<PluginActionContext>,
+}
+
+/// A Herdr plugin command qualified with the server that owns its log ID.
+/// Command arguments and process output deliberately never enter this model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginRunId {
+    pub target: TargetSession,
+    pub plugin_id: String,
+    pub log_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginRunStatus {
+    Running,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginRun {
+    pub id: PluginRunId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<String>,
+    pub status: PluginRunStatus,
+}
+
+impl PluginAction {
+    pub fn supports(&self, context: PluginActionContext) -> bool {
+        if self.contexts.is_empty() {
+            return context == PluginActionContext::Global;
+        }
+        self.contexts.contains(&context)
+    }
+}
+
+/// The resource a person invoked an action from. Each identifier stays
+/// qualified; conversion to server-local strings happens inside `invoke`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "context", rename_all = "snake_case")]
+pub enum PluginInvocationTarget {
+    Session { target: TargetSession },
+    Workspace { workspace: WorkspaceId },
+    Tab { tab: TabId },
+    Pane { pane: PaneId },
+}
+
+impl PluginInvocationTarget {
+    pub fn target_session(&self) -> TargetSession {
+        match self {
+            Self::Session { target } => target.clone(),
+            Self::Workspace { workspace } => workspace.target_session(),
+            Self::Tab { tab } => tab.target_session(),
+            Self::Pane { pane } => pane.target_session(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ListedAction {
+    plugin_id: String,
+    action_id: String,
+    title: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    contexts: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ActionList {
+    #[serde(rename = "type")]
+    kind: String,
+    actions: Vec<ListedAction>,
+}
+
+#[derive(Deserialize)]
+struct CommandLog {
+    log_id: String,
+    plugin_id: String,
+    #[serde(default)]
+    action_id: Option<String>,
+    status: PluginRunStatus,
+}
+
+#[derive(Deserialize)]
+struct CommandLogList {
+    #[serde(rename = "type")]
+    kind: String,
+    logs: Vec<CommandLog>,
+}
+
+/// List actions without carrying their command arrays across the daemon
+/// boundary. One malformed or oversized registry fails only this target.
+pub async fn list(
+    target_key: &TargetSession,
+    target: &Target,
+    transport: &TransportConfig,
+    request_timeout: Duration,
+) -> Result<Vec<PluginAction>, SnapshotError> {
+    timeout(request_timeout, async {
+        let mut session = ApiSession::open(target, transport, request_timeout).await?;
+        let value = session.request("plugin.action.list", json!({})).await?;
+        parse_list(target_key, value)
+    })
+    .await
+    .map_err(|_| SnapshotError::timed_out(request_timeout))?
+}
+
+fn parse_list(target: &TargetSession, value: Value) -> Result<Vec<PluginAction>, SnapshotError> {
+    let listed: ActionList = serde_json::from_value(value).map_err(|_| {
+        SnapshotError::unavailable("Herdr returned an invalid plugin action registry")
+    })?;
+    if listed.kind != "plugin_action_list" {
+        return Err(SnapshotError::unavailable(
+            "Herdr returned an unexpected plugin action response",
+        ));
+    }
+    if listed.actions.len() > MAX_PLUGIN_ACTIONS {
+        return Err(SnapshotError::unavailable(format!(
+            "Herdr returned more than {MAX_PLUGIN_ACTIONS} plugin actions"
+        )));
+    }
+    Ok(listed
+        .actions
+        .into_iter()
+        .map(|action| PluginAction {
+            id: PluginActionId {
+                target: target.clone(),
+                plugin_id: action.plugin_id,
+                action_id: action.action_id,
+            },
+            title: action.title,
+            description: action.description,
+            contexts: action
+                .contexts
+                .into_iter()
+                .map(|context| match context.as_str() {
+                    "global" => PluginActionContext::Global,
+                    "workspace" => PluginActionContext::Workspace,
+                    "tab" => PluginActionContext::Tab,
+                    "pane" => PluginActionContext::Pane,
+                    "selection" => PluginActionContext::Selection,
+                    _ => PluginActionContext::Unsupported,
+                })
+                .collect(),
+        })
+        .collect())
+}
+
+/// Invoke one action with a context hydrated from the same Herdr server.
+///
+/// Herdr fills missing context fields from its own current focus. Hydrating the
+/// complete workspace/tab/pane chain here prevents a click on one Super-Herdr
+/// pane from accidentally inheriting a different pane that Herdr happens to
+/// have focused locally. Selection text is explicitly empty: Super-Herdr does
+/// not expose selection-only plugin actions and never forwards terminal text as
+/// incidental plugin context.
+pub async fn invoke(
+    action: &PluginActionId,
+    context: &PluginInvocationTarget,
+    target: &Target,
+    transport: &TransportConfig,
+    request_timeout: Duration,
+) -> Result<PluginRun, SnapshotError> {
+    let context_target = context.target_session();
+    if action.target != context_target {
+        return Err(SnapshotError::unavailable(
+            "plugin action and invocation context belong to different Herdr sessions",
+        ));
+    }
+
+    timeout(request_timeout, async {
+        let mut session = ApiSession::open(target, transport, request_timeout).await?;
+        let context = hydrated_context(&mut session, context).await?;
+        let result = session
+            .request(
+                "plugin.action.invoke",
+                json!({
+                    "plugin_id": action.plugin_id,
+                    "action_id": action.action_id,
+                    "context": context,
+                }),
+            )
+            .await?;
+        if result.get("type").and_then(Value::as_str) != Some("plugin_action_invoked") {
+            return Err(SnapshotError::unavailable(
+                "Herdr returned an unexpected plugin action result",
+            ));
+        }
+        let log: CommandLog =
+            serde_json::from_value(result.get("log").cloned().ok_or_else(|| {
+                SnapshotError::unavailable("Herdr returned no plugin action run")
+            })?)
+            .map_err(|_| {
+                SnapshotError::unavailable("Herdr returned an invalid plugin action run")
+            })?;
+        let run = qualify_run(&action.target, log);
+        if run.id.plugin_id != action.plugin_id
+            || run.action_id.as_deref() != Some(&action.action_id)
+        {
+            return Err(SnapshotError::unavailable(
+                "Herdr returned a different plugin action run",
+            ));
+        }
+        Ok(run)
+    })
+    .await
+    .map_err(|_| SnapshotError::timed_out(request_timeout))?
+}
+
+/// Read one command's lifecycle without returning its command or output.
+pub async fn status(
+    run: &PluginRunId,
+    target: &Target,
+    transport: &TransportConfig,
+    request_timeout: Duration,
+) -> Result<PluginRun, SnapshotError> {
+    timeout(request_timeout, async {
+        let mut session = ApiSession::open(target, transport, request_timeout).await?;
+        let value = session
+            .request(
+                "plugin.log.list",
+                json!({
+                    "plugin_id": run.plugin_id,
+                    "limit": MAX_PLUGIN_RUNS,
+                }),
+            )
+            .await?;
+        let listed: CommandLogList = serde_json::from_value(value)
+            .map_err(|_| SnapshotError::unavailable("Herdr returned invalid plugin run state"))?;
+        if listed.kind != "plugin_log_list" {
+            return Err(SnapshotError::unavailable(
+                "Herdr returned an unexpected plugin run response",
+            ));
+        }
+        listed
+            .logs
+            .into_iter()
+            .find(|candidate| {
+                candidate.log_id == run.log_id && candidate.plugin_id == run.plugin_id
+            })
+            .map(|log| qualify_run(&run.target, log))
+            .ok_or_else(|| SnapshotError::unavailable("Herdr no longer has that plugin run"))
+    })
+    .await
+    .map_err(|_| SnapshotError::timed_out(request_timeout))?
+}
+
+fn qualify_run(target: &TargetSession, log: CommandLog) -> PluginRun {
+    PluginRun {
+        id: PluginRunId {
+            target: target.clone(),
+            plugin_id: log.plugin_id,
+            log_id: log.log_id,
+        },
+        action_id: log.action_id,
+        status: log.status,
+    }
+}
+
+async fn hydrated_context(
+    session: &mut ApiSession,
+    target: &PluginInvocationTarget,
+) -> Result<Value, SnapshotError> {
+    let requested_pane = match target {
+        PluginInvocationTarget::Pane { pane } => Some(pane.server_local_id().to_owned()),
+        _ => None,
+    };
+    let requested_tab = match target {
+        PluginInvocationTarget::Tab { tab } => Some(tab.server_local_id().to_owned()),
+        _ => None,
+    };
+    let requested_workspace = match target {
+        PluginInvocationTarget::Workspace { workspace } => {
+            Some(workspace.server_local_id().to_owned())
+        }
+        _ => None,
+    };
+
+    let mut pane = match (target, requested_pane.as_deref()) {
+        (_, Some(pane_id)) => Some(response_object(
+            session
+                .request("pane.get", json!({ "pane_id": pane_id }))
+                .await?,
+            "pane_info",
+            "pane",
+        )?),
+        (PluginInvocationTarget::Session { .. }, None) => Some(response_object(
+            session.request("pane.current", json!({})).await?,
+            "pane_current",
+            "pane",
+        )?),
+        (_, None) => None,
+    };
+    let mut tab_id = requested_tab.or_else(|| string_field(pane.as_ref(), "tab_id"));
+    let mut workspace_id =
+        requested_workspace.or_else(|| string_field(pane.as_ref(), "workspace_id"));
+
+    let mut tab = match tab_id.as_deref() {
+        Some(tab_id) => Some(response_object(
+            session
+                .request("tab.get", json!({ "tab_id": tab_id }))
+                .await?,
+            "tab_info",
+            "tab",
+        )?),
+        None => None,
+    };
+    workspace_id = workspace_id.or_else(|| string_field(tab.as_ref(), "workspace_id"));
+
+    let workspace = match workspace_id.as_deref() {
+        Some(workspace_id) => Some(response_object(
+            session
+                .request("workspace.get", json!({ "workspace_id": workspace_id }))
+                .await?,
+            "workspace_info",
+            "workspace",
+        )?),
+        None => None,
+    };
+
+    if tab_id.is_none() {
+        tab_id = string_field(workspace.as_ref(), "active_tab_id");
+        if let Some(active_tab_id) = tab_id.as_deref() {
+            tab = Some(response_object(
+                session
+                    .request("tab.get", json!({ "tab_id": active_tab_id }))
+                    .await?,
+                "tab_info",
+                "tab",
+            )?);
+        }
+    }
+
+    if pane.is_none()
+        && let Some(workspace_id) = workspace_id.as_deref()
+    {
+        let listed = session
+            .request("pane.list", json!({ "workspace_id": workspace_id }))
+            .await?;
+        if listed.get("type").and_then(Value::as_str) != Some("pane_list") {
+            return Err(SnapshotError::unavailable(
+                "Herdr returned an unexpected pane list while building plugin context",
+            ));
+        }
+        pane = listed
+            .get("panes")
+            .and_then(Value::as_array)
+            .and_then(|panes| {
+                panes
+                    .iter()
+                    .filter(|candidate| {
+                        tab_id.as_deref().is_none_or(|tab_id| {
+                            candidate.get("tab_id").and_then(Value::as_str) == Some(tab_id)
+                        })
+                    })
+                    .find(|candidate| {
+                        candidate
+                            .get("focused")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false)
+                    })
+                    .or_else(|| {
+                        panes.iter().find(|candidate| {
+                            tab_id.as_deref().is_none_or(|tab_id| {
+                                candidate.get("tab_id").and_then(Value::as_str) == Some(tab_id)
+                            })
+                        })
+                    })
+                    .and_then(Value::as_object)
+                    .cloned()
+            });
+    }
+
+    ensure_requested(
+        "pane",
+        requested_pane.as_deref(),
+        pane.as_ref()
+            .and_then(|value| value.get("pane_id"))
+            .and_then(Value::as_str),
+    )?;
+    ensure_requested("tab", tab_id.as_deref(), string_ref(tab.as_ref(), "tab_id"))?;
+    ensure_requested(
+        "workspace",
+        workspace_id.as_deref(),
+        string_ref(workspace.as_ref(), "workspace_id"),
+    )?;
+    if workspace_id.is_some() && pane.is_none() {
+        return Err(SnapshotError::unavailable(
+            "Herdr returned no pane in the selected plugin context",
+        ));
+    }
+
+    let pane_cwd = pane.as_ref().and_then(|pane| {
+        pane.get("foreground_cwd")
+            .and_then(Value::as_str)
+            .or_else(|| pane.get("cwd").and_then(Value::as_str))
+    });
+    let worktree = workspace
+        .as_ref()
+        .and_then(|workspace| workspace.get("worktree"))
+        .filter(|worktree| !worktree.is_null())
+        .cloned();
+    let workspace_cwd = worktree
+        .as_ref()
+        .and_then(|worktree| worktree.get("checkout_path"))
+        .and_then(Value::as_str)
+        .or(pane_cwd);
+
+    let mut context = Map::new();
+    insert_optional(&mut context, "workspace_id", workspace_id.as_deref());
+    insert_optional(
+        &mut context,
+        "workspace_label",
+        string_ref(workspace.as_ref(), "label"),
+    );
+    insert_optional(&mut context, "workspace_cwd", workspace_cwd);
+    if let Some(worktree) = worktree {
+        context.insert("worktree".to_owned(), worktree);
+    }
+    insert_optional(&mut context, "tab_id", tab_id.as_deref());
+    insert_optional(&mut context, "tab_label", string_ref(tab.as_ref(), "label"));
+    insert_optional(
+        &mut context,
+        "focused_pane_id",
+        string_ref(pane.as_ref(), "pane_id"),
+    );
+    insert_optional(&mut context, "focused_pane_cwd", pane_cwd);
+    insert_optional(
+        &mut context,
+        "focused_pane_agent",
+        string_ref(pane.as_ref(), "display_agent").or_else(|| string_ref(pane.as_ref(), "agent")),
+    );
+    if let Some(status) = pane
+        .as_ref()
+        .and_then(|pane| pane.get("agent_status"))
+        .filter(|status| !status.is_null())
+    {
+        context.insert("focused_pane_status".to_owned(), status.clone());
+    }
+    context.insert(
+        "invocation_source".to_owned(),
+        Value::String("super-herdr".to_owned()),
+    );
+    context.insert("selected_text".to_owned(), Value::String(String::new()));
+    context.insert("clicked_url".to_owned(), Value::String(String::new()));
+    context.insert("link_handler_id".to_owned(), Value::String(String::new()));
+    Ok(Value::Object(context))
+}
+
+fn response_object(
+    value: Value,
+    expected_type: &str,
+    field: &str,
+) -> Result<Map<String, Value>, SnapshotError> {
+    if value.get("type").and_then(Value::as_str) != Some(expected_type) {
+        return Err(SnapshotError::unavailable(format!(
+            "Herdr returned an unexpected {expected_type} response"
+        )));
+    }
+    value
+        .get(field)
+        .and_then(Value::as_object)
+        .cloned()
+        .ok_or_else(|| {
+            SnapshotError::unavailable(format!("Herdr returned invalid {expected_type} data"))
+        })
+}
+
+fn ensure_requested(
+    kind: &str,
+    requested: Option<&str>,
+    returned: Option<&str>,
+) -> Result<(), SnapshotError> {
+    if requested.is_some_and(|requested| returned != Some(requested)) {
+        return Err(SnapshotError::unavailable(format!(
+            "Herdr returned a different {kind} while building plugin context"
+        )));
+    }
+    Ok(())
+}
+
+fn string_field(value: Option<&Map<String, Value>>, field: &str) -> Option<String> {
+    string_ref(value, field).map(str::to_owned)
+}
+
+fn string_ref<'a>(value: Option<&'a Map<String, Value>>, field: &str) -> Option<&'a str> {
+    value?.get(field)?.as_str()
+}
+
+fn insert_optional(context: &mut Map<String, Value>, field: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        context.insert(field.to_owned(), Value::String(value.to_owned()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{
+        MAX_PLUGIN_RUNS, PluginActionContext, PluginActionId, PluginInvocationTarget,
+        PluginRunStatus, invoke, parse_list, status,
+    };
+    use crate::model::{PaneId, TargetSession};
+
+    #[test]
+    fn listed_actions_are_qualified_and_commands_do_not_cross_the_boundary() {
+        let target = TargetSession::new("build", "work");
+        let actions = parse_list(
+            &target,
+            json!({
+                "type": "plugin_action_list",
+                "actions": [{
+                    "plugin_id": "herdr-workflows",
+                    "action_id": "run",
+                    "title": "Run workflow",
+                    "description": "Choose a workflow",
+                    "contexts": ["workspace", "pane"],
+                    "platforms": null,
+                    "command": ["secret-command", "--never-forward-this"]
+                }]
+            }),
+        )
+        .expect("valid registry");
+
+        assert_eq!(actions[0].id.target, target);
+        assert!(actions[0].supports(PluginActionContext::Pane));
+        let encoded = serde_json::to_string(&actions).expect("actions encode");
+        assert!(!encoded.contains("secret-command"));
+        assert!(!encoded.contains("never-forward-this"));
+    }
+
+    #[test]
+    fn an_action_without_contexts_is_global() {
+        let actions = parse_list(
+            &TargetSession::new("local", "default"),
+            json!({
+                "type": "plugin_action_list",
+                "actions": [{
+                    "plugin_id": "one",
+                    "action_id": "two",
+                    "title": "Three",
+                    "command": ["true"]
+                }]
+            }),
+        )
+        .expect("valid registry");
+
+        assert!(actions[0].supports(PluginActionContext::Global));
+        assert!(!actions[0].supports(PluginActionContext::Selection));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn invocation_hydrates_the_exact_qualified_pane_without_selection_text() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        use tokio::net::UnixListener;
+
+        use crate::config::Config;
+
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let socket = directory.path().join("herdr.sock");
+        let listener = UnixListener::bind(&socket).expect("test socket");
+        let server = tokio::spawn(async move {
+            for method in [
+                "pane.get",
+                "tab.get",
+                "workspace.get",
+                "plugin.action.invoke",
+                "plugin.log.list",
+            ] {
+                let (stream, _) = listener.accept().await.expect("request connection");
+                let mut reader = BufReader::new(stream);
+                let mut line = String::new();
+                reader.read_line(&mut line).await.expect("request line");
+                let request: serde_json::Value = serde_json::from_str(&line).expect("JSON request");
+                assert_eq!(request["method"], method);
+                let id = request["id"].as_str().expect("request id");
+                let result = match method {
+                    "pane.get" => {
+                        assert_eq!(request["params"]["pane_id"], "w2:p3");
+                        json!({
+                            "type": "pane_info",
+                            "pane": {
+                                "pane_id": "w2:p3",
+                                "workspace_id": "w2",
+                                "tab_id": "w2:t1",
+                                "foreground_cwd": "/work/repo/subdir",
+                                "display_agent": "codex",
+                                "agent_status": "working"
+                            }
+                        })
+                    }
+                    "tab.get" => {
+                        assert_eq!(request["params"]["tab_id"], "w2:t1");
+                        json!({
+                            "type": "tab_info",
+                            "tab": {
+                                "tab_id": "w2:t1",
+                                "workspace_id": "w2",
+                                "label": "implementation"
+                            }
+                        })
+                    }
+                    "workspace.get" => {
+                        assert_eq!(request["params"]["workspace_id"], "w2");
+                        json!({
+                            "type": "workspace_info",
+                            "workspace": {
+                                "workspace_id": "w2",
+                                "label": "super-herdr",
+                                "active_tab_id": "w2:t1",
+                                "worktree": {
+                                    "checkout_path": "/work/repo",
+                                    "repo_key": "repo",
+                                    "repo_name": "repo",
+                                    "repo_root": "/work/repo",
+                                    "is_linked_worktree": false
+                                }
+                            }
+                        })
+                    }
+                    "plugin.action.invoke" => {
+                        let params = &request["params"];
+                        assert_eq!(params["plugin_id"], "herdr-workflows");
+                        assert_eq!(params["action_id"], "run");
+                        assert_eq!(params["context"]["workspace_id"], "w2");
+                        assert_eq!(params["context"]["tab_id"], "w2:t1");
+                        assert_eq!(params["context"]["focused_pane_id"], "w2:p3");
+                        assert_eq!(params["context"]["workspace_cwd"], "/work/repo");
+                        assert_eq!(params["context"]["focused_pane_cwd"], "/work/repo/subdir");
+                        assert_eq!(params["context"]["selected_text"], "");
+                        assert_eq!(params["context"]["invocation_source"], "super-herdr");
+                        json!({
+                            "type": "plugin_action_invoked",
+                            "log": {
+                                "log_id": "log-7",
+                                "plugin_id": "herdr-workflows",
+                                "action_id": "run",
+                                "status": "running",
+                                "started_unix_ms": 1,
+                                "command": ["secret-command"],
+                                "stdout": "terminal contents do not cross",
+                                "stderr": null,
+                                "error": null
+                            }
+                        })
+                    }
+                    "plugin.log.list" => {
+                        assert_eq!(request["params"]["plugin_id"], "herdr-workflows");
+                        assert_eq!(request["params"]["limit"], MAX_PLUGIN_RUNS);
+                        json!({
+                            "type": "plugin_log_list",
+                            "logs": [{
+                                "log_id": "log-7",
+                                "plugin_id": "herdr-workflows",
+                                "action_id": "run",
+                                "status": "succeeded",
+                                "started_unix_ms": 1,
+                                "finished_unix_ms": 2,
+                                "command": ["secret-command"],
+                                "stdout": "terminal contents do not cross",
+                                "stderr": "nor does stderr",
+                                "error": null
+                            }]
+                        })
+                    }
+                    _ => unreachable!(),
+                };
+                reader
+                    .get_mut()
+                    .write_all(format!("{{\"id\":{id:?},\"result\":{result}}}\n").as_bytes())
+                    .await
+                    .expect("response");
+            }
+        });
+        let config = Config::parse(&format!(
+            "[[targets]]\nname = \"local\"\nsession = \"work\"\nsocket = {:?}\n",
+            socket.display().to_string()
+        ))
+        .expect("test config");
+        let target = TargetSession::new("local", "work");
+
+        let run = invoke(
+            &PluginActionId {
+                target: target.clone(),
+                plugin_id: "herdr-workflows".to_owned(),
+                action_id: "run".to_owned(),
+            },
+            &PluginInvocationTarget::Pane {
+                pane: PaneId::new("local", "work", "w2:p3"),
+            },
+            &config.targets[0],
+            &config.transport,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect("action invocation");
+        assert_eq!(run.id.target, target);
+        assert_eq!(run.id.log_id, "log-7");
+        assert_eq!(run.status, PluginRunStatus::Running);
+        let encoded = serde_json::to_string(&run).expect("run encodes");
+        assert!(!encoded.contains("secret-command"));
+        assert!(!encoded.contains("terminal contents"));
+        let finished = status(
+            &run.id,
+            &config.targets[0],
+            &config.transport,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect("run status");
+        assert_eq!(finished.status, PluginRunStatus::Succeeded);
+        let encoded = serde_json::to_string(&finished).expect("status encodes");
+        assert!(!encoded.contains("secret-command"));
+        assert!(!encoded.contains("stderr"));
+        server.await.expect("fake Herdr server");
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 use crate::attention::AttentionEvent;
 use crate::model::{PaneId, TargetSession};
 use crate::operation::Operation;
+use crate::plugin::{PluginAction, PluginRun, PluginRunId};
 use crate::screen::{Diff as ScreenDiff, Snapshot};
 use crate::state::{FederationState, TargetRuntimeState};
 use crate::terminal::{TerminalAccess, TerminalScrollDirection};
@@ -47,7 +48,7 @@ use crate::terminal::{TerminalAccess, TerminalScrollDirection};
 /// Incremented only for a change a peer at the previous version cannot honor.
 /// A mismatch closes the connection during the handshake; it never degrades
 /// into a partially understood session.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// One message may not exceed this encoded size. The largest legitimate
 /// messages are a full-screen terminal frame and a bracketed paste, and the
@@ -151,6 +152,13 @@ pub enum ClientMessage {
     /// client, so what arrives here is already agreed to.
     #[serde(rename = "operation.run")]
     RunOperation { request: u64, operation: Operation },
+    /// Discover the enabled actions registered with one Herdr session. The
+    /// daemon strips command arrays before returning them.
+    #[serde(rename = "plugin.actions.list")]
+    ListPluginActions { request: u64, target: TargetSession },
+    /// Poll the sanitized lifecycle state of an action this client started.
+    #[serde(rename = "plugin.run.get")]
+    GetPluginRun { request: u64, run: PluginRunId },
     /// Deliver text to a pane as one atomic paste.
     ///
     /// This is not `PaneInput`: Herdr writes it in one piece through the
@@ -365,7 +373,22 @@ pub enum ServerMessage {
         request: u64,
         applied: bool,
         message: String,
+        /// Present only when this operation started a plugin command. Herdr's
+        /// command arguments and process output never cross this boundary.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        plugin_run: Option<PluginRun>,
     },
+    #[serde(rename = "plugin.actions")]
+    PluginActions {
+        request: u64,
+        target: TargetSession,
+        /// The connection generation the registry came from. A client can
+        /// discard a late answer after that target reconnects.
+        generation: u64,
+        actions: Vec<PluginAction>,
+    },
+    #[serde(rename = "plugin.run")]
+    PluginRun { request: u64, run: PluginRun },
     /// A pairing code and how long it lasts. Never persisted: a code that
     /// survived a restart would be a credential nobody knew was outstanding.
     #[serde(rename = "pairing.code")]
@@ -561,6 +584,9 @@ mod tests {
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{PaneId, TargetSession, WorkspaceId};
     use crate::operation::Operation;
+    use crate::plugin::{
+        PluginAction, PluginActionContext, PluginActionId, PluginRun, PluginRunId, PluginRunStatus,
+    };
     use crate::resource_action::SplitDirection;
     use crate::state::{
         FederationState, NormalizedSnapshot, PaneState, TargetConnectionState, TargetRuntimeState,
@@ -633,6 +659,18 @@ mod tests {
                 direction: SplitDirection::Down,
             },
         });
+        round_trip_client(ClientMessage::ListPluginActions {
+            request: 8,
+            target: TargetSession::new("development", "work"),
+        });
+        round_trip_client(ClientMessage::GetPluginRun {
+            request: 9,
+            run: PluginRunId {
+                target: TargetSession::new("development", "work"),
+                plugin_id: "herdr-workflows".to_owned(),
+                log_id: "log-1".to_owned(),
+            },
+        });
         round_trip_client(ClientMessage::PastePaneText {
             request: 3,
             pane: pane(),
@@ -703,7 +741,43 @@ mod tests {
         round_trip_server(ServerMessage::OperationResult {
             request: 7,
             applied: true,
-            message: "split pane".to_owned(),
+            message: "plugin action started".to_owned(),
+            plugin_run: Some(PluginRun {
+                id: PluginRunId {
+                    target: TargetSession::new("development", "work"),
+                    plugin_id: "herdr-workflows".to_owned(),
+                    log_id: "log-1".to_owned(),
+                },
+                action_id: Some("run".to_owned()),
+                status: PluginRunStatus::Running,
+            }),
+        });
+        round_trip_server(ServerMessage::PluginActions {
+            request: 8,
+            target: TargetSession::new("development", "work"),
+            generation: 2,
+            actions: vec![PluginAction {
+                id: PluginActionId {
+                    target: TargetSession::new("development", "work"),
+                    plugin_id: "herdr-workflows".to_owned(),
+                    action_id: "run".to_owned(),
+                },
+                title: "Run workflow".to_owned(),
+                description: None,
+                contexts: vec![PluginActionContext::Workspace],
+            }],
+        });
+        round_trip_server(ServerMessage::PluginRun {
+            request: 9,
+            run: PluginRun {
+                id: PluginRunId {
+                    target: TargetSession::new("development", "work"),
+                    plugin_id: "herdr-workflows".to_owned(),
+                    log_id: "log-1".to_owned(),
+                },
+                action_id: Some("run".to_owned()),
+                status: PluginRunStatus::Succeeded,
+            },
         });
         round_trip_server(ServerMessage::Attention {
             event: AttentionEvent {
@@ -789,8 +863,8 @@ mod tests {
         let workspace = WorkspaceId::new(&target.target, &target.session, "w1");
         let pane = PaneId::new(&target.target, &target.session, "w1:p1");
         let mut snapshot = NormalizedSnapshot {
-            server_version: Some("0.8.0".to_owned()),
-            protocol: Some(19),
+            server_version: Some("0.8.2".to_owned()),
+            protocol: Some(20),
             focused_pane: Some(pane.clone()),
             ..NormalizedSnapshot::default()
         };

--- a/src/resource_action.rs
+++ b/src/resource_action.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::model::{PaneId, TabId, TargetSession, WorkspaceId};
+use crate::plugin::{PluginAction, PluginInvocationTarget};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -93,6 +94,10 @@ pub enum ResourceAction {
         pane: PaneId,
         label: String,
     },
+    InvokePluginAction {
+        action: PluginAction,
+        context: PluginInvocationTarget,
+    },
 }
 
 impl ResourceAction {
@@ -126,6 +131,7 @@ impl ResourceAction {
             | Self::RecreateWorkspace { workspace, .. }
             | Self::CreateTab { workspace } => Some(workspace.target_session()),
             Self::RenameTab { tab, .. } | Self::CloseTab { tab, .. } => Some(tab.target_session()),
+            Self::InvokePluginAction { action, .. } => Some(action.id.target.clone()),
             Self::OpenTargetManager | Self::OpenAgentNavigator | Self::OpenAttentionCenter => None,
         }
     }
@@ -155,6 +161,9 @@ impl ResourceAction {
             Self::SplitPane { direction, .. } => format!("Split pane {}", direction.label()),
             Self::TogglePaneZoom { .. } => "Toggle pane zoom".to_owned(),
             Self::ClosePane { label, .. } => format!("Close pane {label:?}"),
+            Self::InvokePluginAction { action, .. } => {
+                format!("Plugin: {}", action.title)
+            }
         }
     }
 
@@ -165,7 +174,17 @@ impl ResourceAction {
     }
 
     pub fn search_text(&self) -> String {
-        format!("{} {}", self.palette_label(), self.palette_scope())
+        let description = match self {
+            Self::InvokePluginAction { action, .. } => {
+                action.description.as_deref().unwrap_or_default()
+            }
+            _ => "",
+        };
+        format!(
+            "{} {} {description}",
+            self.palette_label(),
+            self.palette_scope()
+        )
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -32,6 +32,7 @@ use crate::daemon::server::{DaemonOptions, spawn_in_process};
 use crate::model::{PaneId, TabId, TargetSession, WorkspaceId};
 use crate::notifications::{self, NotificationDelivery, NotificationQueue};
 use crate::operation::Operation;
+use crate::plugin::{PluginAction, PluginActionContext, PluginInvocationTarget};
 use crate::protocol::ServerMessage;
 use crate::resource_action::{ResourceAction, SplitDirection};
 use crate::state::{
@@ -59,6 +60,7 @@ const MIN_RENDER_INTERVAL: Duration = Duration::from_millis(16);
 const ROUTE_EVENT_DRAIN_LIMIT: usize = 64;
 const SELECTION_AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(30);
 const CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
+const PLUGIN_CATALOG_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InputMode {
@@ -636,6 +638,17 @@ enum ContextTarget {
     Pane(PaneId),
 }
 
+impl ContextTarget {
+    fn target_session(&self) -> TargetSession {
+        match self {
+            Self::Session(target) => target.clone(),
+            Self::Workspace(workspace) => workspace.target_session(),
+            Self::Tab(tab) => tab.target_session(),
+            Self::Pane(pane) => pane.target_session(),
+        }
+    }
+}
+
 /// A pane this frontend is watching.
 ///
 /// The terminal itself lives with the daemon; what is local is the screen model
@@ -755,9 +768,23 @@ struct CommandPalette {
 struct ContextMenu {
     title: String,
     actions: Vec<ResourceAction>,
+    target: ContextTarget,
     selected: usize,
     anchor: Position,
     pressed: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+struct PluginCatalog {
+    generation: u64,
+    actions: Vec<PluginAction>,
+    loaded_at: Instant,
+}
+
+#[derive(Debug, Clone)]
+struct PendingPluginCatalog {
+    target: TargetSession,
+    generation: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -810,6 +837,8 @@ struct App {
     /// carries its other senders.
     client: Option<ClientCommands>,
     pending_operations: BTreeMap<u64, PendingOperation>,
+    plugin_catalogs: BTreeMap<TargetSession, PluginCatalog>,
+    pending_plugin_catalogs: BTreeMap<u64, PendingPluginCatalog>,
     pending_uploads: BTreeMap<u64, PendingUpload>,
     last_frame_area: Option<Rect>,
     last_terminal_area: Option<Rect>,
@@ -867,6 +896,8 @@ impl Default for App {
             route_retry_after: BTreeMap::new(),
             client: None,
             pending_operations: BTreeMap::new(),
+            plugin_catalogs: BTreeMap::new(),
+            pending_plugin_catalogs: BTreeMap::new(),
             pending_uploads: BTreeMap::new(),
             last_frame_area: None,
             last_terminal_area: None,
@@ -977,6 +1008,7 @@ pub async fn run(config: Config, config_path: PathBuf) -> Result<()> {
         client: Some(client.commands()),
         ..App::default()
     };
+    ensure_plugin_catalogs(&updates.borrow(), &mut app);
     let mut should_draw = true;
 
     let result = loop {
@@ -1035,6 +1067,7 @@ pub async fn run(config: Config, config_path: PathBuf) -> Result<()> {
                 if changed.is_err() {
                     break Ok(());
                 }
+                ensure_plugin_catalogs(&updates.borrow(), &mut app);
                 should_draw = true;
             }
             refresh = config_refreshes.recv() => {
@@ -2286,7 +2319,10 @@ async fn handle_input(
                     None => app.message = Some("pairing is unavailable".to_owned()),
                 },
                 b'd' => request_workspace_close(state, app),
-                b' ' => app.command_palette = Some(CommandPalette::default()),
+                b' ' => {
+                    ensure_plugin_catalogs(state, app);
+                    app.command_palette = Some(CommandPalette::default());
+                }
                 b'1'..=b'9' => select_workspace(state, app, usize::from(key - b'1')),
                 PREFIX_KEY => {
                     if let Some(pane) = app.selected_pane.clone()
@@ -2556,6 +2592,7 @@ fn request_workspace_close(state: &FederationState, app: &mut App) {
 fn command_palette_actions(
     state: &FederationState,
     selected: Option<&PaneId>,
+    plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
 ) -> Vec<ResourceAction> {
     let mut actions = vec![
         ResourceAction::OpenTargetManager,
@@ -2695,7 +2732,126 @@ fn command_palette_actions(
             });
         }
     }
+    for (target, catalog) in plugin_catalogs {
+        if !plugin_target_available(state, target) {
+            continue;
+        }
+        let context = selected
+            .filter(|pane| pane.target_session() == *target)
+            .cloned()
+            .map_or_else(
+                || PluginInvocationTarget::Session {
+                    target: target.clone(),
+                },
+                |pane| PluginInvocationTarget::Pane { pane },
+            );
+        actions.extend(plugin_resource_actions(catalog, &context));
+    }
     actions
+}
+
+fn plugin_target_available(state: &FederationState, target: &TargetSession) -> bool {
+    state.targets.get(target).is_some_and(|runtime| {
+        runtime.connection == TargetConnectionState::Live
+            && runtime
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.protocol)
+                .is_some_and(|protocol| protocol >= 20)
+    })
+}
+
+fn plugin_resource_actions(
+    catalog: &PluginCatalog,
+    target: &PluginInvocationTarget,
+) -> Vec<ResourceAction> {
+    catalog
+        .actions
+        .iter()
+        .filter(|action| action.id.target == target.target_session())
+        .filter(|action| match target {
+            PluginInvocationTarget::Session { .. } => action.supports(PluginActionContext::Global),
+            PluginInvocationTarget::Workspace { .. } => {
+                action.supports(PluginActionContext::Global)
+                    || action.supports(PluginActionContext::Workspace)
+            }
+            PluginInvocationTarget::Tab { .. } => {
+                action.supports(PluginActionContext::Global)
+                    || action.supports(PluginActionContext::Workspace)
+                    || action.supports(PluginActionContext::Tab)
+            }
+            PluginInvocationTarget::Pane { .. } => {
+                action.supports(PluginActionContext::Global)
+                    || action.supports(PluginActionContext::Workspace)
+                    || action.supports(PluginActionContext::Tab)
+                    || action.supports(PluginActionContext::Pane)
+            }
+        })
+        .cloned()
+        .map(|action| ResourceAction::InvokePluginAction {
+            action,
+            context: target.clone(),
+        })
+        .collect()
+}
+
+fn insert_plugin_actions(
+    actions: &mut Vec<ResourceAction>,
+    catalog: &PluginCatalog,
+    target: &PluginInvocationTarget,
+) {
+    let plugins = plugin_resource_actions(catalog, target);
+    let before_destructive = actions
+        .iter()
+        .position(ResourceAction::is_destructive)
+        .unwrap_or(actions.len());
+    actions.splice(before_destructive..before_destructive, plugins);
+}
+
+fn ensure_plugin_catalogs(state: &FederationState, app: &mut App) {
+    app.plugin_catalogs
+        .retain(|target, _| state.targets.contains_key(target));
+    let targets = state.targets.keys().cloned().collect::<Vec<_>>();
+    for target in targets {
+        ensure_plugin_catalog(state, &target, app);
+    }
+}
+
+fn ensure_plugin_catalog(state: &FederationState, target: &TargetSession, app: &mut App) {
+    let Some(runtime) = state.targets.get(target) else {
+        return;
+    };
+    if runtime.connection != TargetConnectionState::Live
+        || runtime
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.protocol)
+            .is_none_or(|protocol| protocol < 20)
+    {
+        return;
+    }
+    let generation = runtime.connection_generation;
+    if app.plugin_catalogs.get(target).is_some_and(|catalog| {
+        catalog.generation == generation
+            && catalog.loaded_at.elapsed() < PLUGIN_CATALOG_REFRESH_INTERVAL
+    }) || app
+        .pending_plugin_catalogs
+        .values()
+        .any(|pending| pending.target == *target && pending.generation == generation)
+    {
+        return;
+    }
+    let Some(client) = app.client.as_ref() else {
+        return;
+    };
+    let request = client.list_plugin_actions(target.clone());
+    app.pending_plugin_catalogs.insert(
+        request,
+        PendingPluginCatalog {
+            target: target.clone(),
+            generation,
+        },
+    );
 }
 
 /// A context menu is not scrollable, so it lists at most this many move
@@ -2764,18 +2920,24 @@ fn context_menu_for_target(
     state: &FederationState,
     target: ContextTarget,
     anchor: Position,
+    plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
 ) -> Option<ContextMenu> {
-    let (title, actions) = match target {
+    let (title, mut actions, invocation_target) = match &target {
         ContextTarget::Session(target) => {
-            actionable_snapshot(state, &target)?;
+            actionable_snapshot(state, target)?;
             (
                 format!("session {target}"),
-                vec![ResourceAction::CreateWorkspace { target }],
+                vec![ResourceAction::CreateWorkspace {
+                    target: target.clone(),
+                }],
+                PluginInvocationTarget::Session {
+                    target: target.clone(),
+                },
             )
         }
         ContextTarget::Workspace(workspace) => {
             let snapshot = actionable_snapshot(state, &workspace.target_session())?;
-            let resource = snapshot.workspaces.get(&workspace)?;
+            let resource = snapshot.workspaces.get(workspace)?;
             let label = display_label(&resource.id.resource, resource.label.as_deref());
             let mut actions = vec![
                 ResourceAction::CreateTab {
@@ -2787,22 +2949,31 @@ fn context_menu_for_target(
                 },
             ];
             actions.extend(
-                workspace_move_actions(snapshot, &workspace)
+                workspace_move_actions(snapshot, workspace)
                     .into_iter()
                     .take(MAX_CONTEXT_MENU_MOVE_DESTINATIONS),
             );
             actions.extend(
-                workspace_recreate_actions(state, snapshot, &workspace)
+                workspace_recreate_actions(state, snapshot, workspace)
                     .into_iter()
                     .take(MAX_CONTEXT_MENU_MOVE_DESTINATIONS),
             );
             let title = format!("workspace {label} · {}", workspace.target_session());
-            actions.push(ResourceAction::CloseWorkspace { workspace, label });
-            (title, actions)
+            actions.push(ResourceAction::CloseWorkspace {
+                workspace: workspace.clone(),
+                label,
+            });
+            (
+                title,
+                actions,
+                PluginInvocationTarget::Workspace {
+                    workspace: workspace.clone(),
+                },
+            )
         }
         ContextTarget::Tab(tab) => {
             let snapshot = actionable_snapshot(state, &tab.target_session())?;
-            let resource = snapshot.tabs.get(&tab)?;
+            let resource = snapshot.tabs.get(tab)?;
             let label = display_label(&resource.id.resource, resource.label.as_deref());
             (
                 format!("tab {label} · {}", tab.target_session()),
@@ -2811,13 +2982,17 @@ fn context_menu_for_target(
                         tab: tab.clone(),
                         current_label: label.clone(),
                     },
-                    ResourceAction::CloseTab { tab, label },
+                    ResourceAction::CloseTab {
+                        tab: tab.clone(),
+                        label,
+                    },
                 ],
+                PluginInvocationTarget::Tab { tab: tab.clone() },
             )
         }
         ContextTarget::Pane(pane) => {
             let snapshot = actionable_snapshot(state, &pane.target_session())?;
-            let resource = snapshot.panes.get(&pane)?;
+            let resource = snapshot.panes.get(pane)?;
             let label = display_label(&resource.id.resource, resource.label.as_deref());
             (
                 format!("pane {label} · {}", pane.target_session()),
@@ -2831,14 +3006,22 @@ fn context_menu_for_target(
                         direction: SplitDirection::Down,
                     },
                     ResourceAction::TogglePaneZoom { pane: pane.clone() },
-                    ResourceAction::ClosePane { pane, label },
+                    ResourceAction::ClosePane {
+                        pane: pane.clone(),
+                        label,
+                    },
                 ],
+                PluginInvocationTarget::Pane { pane: pane.clone() },
             )
         }
     };
+    if let Some(catalog) = plugin_catalogs.get(&invocation_target.target_session()) {
+        insert_plugin_actions(&mut actions, catalog, &invocation_target);
+    }
     Some(ContextMenu {
         title,
         actions,
+        target,
         selected: 0,
         anchor,
         pressed: None,
@@ -2863,7 +3046,8 @@ fn open_context_menu(
 ) {
     app.selection = None;
     app.selection_autoscroll = None;
-    if let Some(menu) = context_menu_for_target(state, target, anchor) {
+    ensure_plugin_catalog(state, &target.target_session(), app);
+    if let Some(menu) = context_menu_for_target(state, target, anchor, &app.plugin_catalogs) {
         app.context_menu = Some(menu);
         app.message = None;
     } else {
@@ -2901,8 +3085,9 @@ fn filtered_palette_actions(
     state: &FederationState,
     selected: Option<&PaneId>,
     query: &str,
+    plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
 ) -> Vec<ResourceAction> {
-    let mut actions = command_palette_actions(state, selected)
+    let mut actions = command_palette_actions(state, selected, plugin_catalogs)
         .into_iter()
         .filter_map(|action| fuzzy_score(&action.search_text(), query).map(|score| (score, action)))
         .collect::<Vec<_>>();
@@ -2919,7 +3104,12 @@ fn handle_command_palette_input(key: u8, state: &FederationState, app: &mut App)
     let Some(mut palette) = app.command_palette.take() else {
         return Ok(false);
     };
-    let actions = filtered_palette_actions(state, app.selected_pane.as_ref(), &palette.query);
+    let actions = filtered_palette_actions(
+        state,
+        app.selected_pane.as_ref(),
+        &palette.query,
+        &app.plugin_catalogs,
+    );
     match key {
         0x1b => return Ok(false),
         b'\r' | b'\n' => {
@@ -2952,7 +3142,13 @@ fn handle_command_palette_input(key: u8, state: &FederationState, app: &mut App)
         }
         _ => {}
     }
-    let count = filtered_palette_actions(state, app.selected_pane.as_ref(), &palette.query).len();
+    let count = filtered_palette_actions(
+        state,
+        app.selected_pane.as_ref(),
+        &palette.query,
+        &app.plugin_catalogs,
+    )
+    .len();
     palette.selected = palette.selected.min(count.saturating_sub(1));
     app.command_palette = Some(palette);
     Ok(false)
@@ -3146,6 +3342,20 @@ fn execute_resource_action(action: ResourceAction, state: &FederationState, app:
                 app,
                 Operation::TogglePaneZoom { pane },
                 format!("toggled pane zoom on {target_session}"),
+                false,
+            );
+        }
+        ResourceAction::InvokePluginAction { action, context } => {
+            let title = action.title.clone();
+            let target = action.id.target.clone();
+            run_operation(
+                app,
+                Operation::InvokePluginAction {
+                    action: action.id,
+                    context,
+                    title: title.clone(),
+                },
+                format!("started plugin action {title:?} on {target}"),
                 false,
             );
         }
@@ -4819,6 +5029,7 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
             request,
             applied,
             message,
+            ..
         } => {
             app.herdr_action_inflight = false;
             let pending = app.pending_operations.remove(&request);
@@ -4850,6 +5061,59 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
             } else {
                 app.message = Some(format!("Herdr action failed: {message}"));
             }
+        }
+        ServerMessage::PluginActions {
+            request,
+            target,
+            generation,
+            mut actions,
+        } => {
+            let Some(pending) = app.pending_plugin_catalogs.remove(&request) else {
+                return;
+            };
+            if pending.target != target || pending.generation != generation {
+                return;
+            }
+            actions.retain(|action| action.id.target == target);
+            let catalog = PluginCatalog {
+                generation,
+                actions,
+                loaded_at: Instant::now(),
+            };
+            if app
+                .plugin_catalogs
+                .get(&target)
+                .is_some_and(|current| current.generation > generation)
+                || app
+                    .pending_plugin_catalogs
+                    .values()
+                    .any(|newer| newer.target == target && newer.generation > generation)
+            {
+                return;
+            }
+            if let Some(menu) = app
+                .context_menu
+                .as_mut()
+                .filter(|menu| menu.target.target_session() == target)
+            {
+                menu.actions
+                    .retain(|action| !matches!(action, ResourceAction::InvokePluginAction { .. }));
+                let invocation = match &menu.target {
+                    ContextTarget::Session(target) => PluginInvocationTarget::Session {
+                        target: target.clone(),
+                    },
+                    ContextTarget::Workspace(workspace) => PluginInvocationTarget::Workspace {
+                        workspace: workspace.clone(),
+                    },
+                    ContextTarget::Tab(tab) => PluginInvocationTarget::Tab { tab: tab.clone() },
+                    ContextTarget::Pane(pane) => {
+                        PluginInvocationTarget::Pane { pane: pane.clone() }
+                    }
+                };
+                insert_plugin_actions(&mut menu.actions, &catalog, &invocation);
+                menu.selected = menu.selected.min(menu.actions.len().saturating_sub(1));
+            }
+            app.plugin_catalogs.insert(target, catalog);
         }
         // The frontend uploads what a clipboard held, in one attempt, over a
         // socket it shares a machine with. It has nothing to resume from and
@@ -4943,6 +5207,35 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
             // A refusal ends whatever asked for it, so a failed transfer does
             // not leave the frontend waiting on a result that will not come.
             if let Some(request) = request {
+                if let Some(pending) = app.pending_plugin_catalogs.remove(&request) {
+                    let is_stale = app
+                        .plugin_catalogs
+                        .get(&pending.target)
+                        .is_some_and(|current| current.generation > pending.generation)
+                        || app.pending_plugin_catalogs.values().any(|newer| {
+                            newer.target == pending.target && newer.generation > pending.generation
+                        });
+                    if is_stale {
+                        return;
+                    }
+                    app.plugin_catalogs.insert(
+                        pending.target.clone(),
+                        PluginCatalog {
+                            generation: pending.generation,
+                            actions: Vec::new(),
+                            loaded_at: Instant::now(),
+                        },
+                    );
+                    if app.command_palette.is_some()
+                        || app
+                            .context_menu
+                            .as_ref()
+                            .is_some_and(|menu| menu.target.target_session() == pending.target)
+                    {
+                        app.message = Some(message);
+                    }
+                    return;
+                }
                 // A file that failed still has to settle its batch, or the
                 // files that did arrive wait forever for one that never will.
                 if let Some(pending) = app.pending_uploads.remove(&request)
@@ -4972,7 +5265,8 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
         }
         ServerMessage::Hello { .. }
         | ServerMessage::FederationState { .. }
-        | ServerMessage::TargetState { .. } => {}
+        | ServerMessage::TargetState { .. }
+        | ServerMessage::PluginRun { .. } => {}
     }
 }
 
@@ -5062,7 +5356,13 @@ fn render(frame: &mut Frame, state: &FederationState, app: &App) {
     } else if let Some(menu) = app.context_menu.as_ref() {
         render_context_menu(frame, menu);
     } else if let Some(palette) = app.command_palette.as_ref() {
-        render_command_palette(frame, state, app.selected_pane.as_ref(), palette);
+        render_command_palette(
+            frame,
+            state,
+            app.selected_pane.as_ref(),
+            palette,
+            &app.plugin_catalogs,
+        );
     } else if let Some(prompt) = app.text_prompt.as_ref() {
         render_text_prompt(frame, prompt);
     } else if let Some(confirmation) = app.close_confirmation.as_ref() {
@@ -5166,6 +5466,7 @@ fn render_command_palette(
     state: &FederationState,
     selected: Option<&PaneId>,
     palette: &CommandPalette,
+    plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
 ) {
     let area = centered_popup(frame.area(), 82, 22);
     frame.render_widget(Clear, area);
@@ -5176,7 +5477,7 @@ fn render_command_palette(
         .padding(Padding::horizontal(1));
     let inner = block.inner(area);
     frame.render_widget(block, area);
-    let actions = filtered_palette_actions(state, selected, &palette.query);
+    let actions = filtered_palette_actions(state, selected, &palette.query, plugin_catalogs);
     let mut lines = vec![
         Line::from(vec![
             Span::styled("> ", Style::default().fg(Color::Cyan)),
@@ -7431,7 +7732,7 @@ mod tests {
         AgentFilter, AgentNavigator, App, AttentionCenter, AttentionIndex, CellPosition,
         ClipboardFeedback, ContextTarget, DecodedInput, HERDR_PREFIX_KEY, InputDecoder, InputMode,
         MAX_CLIPBOARD_BYTES, MAX_CONTEXT_MENU_MOVE_DESTINATIONS, MOUSE_CAPTURE_ENABLE, MouseInput,
-        PREFIX_KEY, PaneDirection, SIDEBAR_WIDTH, SelectionAutoscroll,
+        PREFIX_KEY, PaneDirection, PluginCatalog, SIDEBAR_WIDTH, SelectionAutoscroll,
         SelectionAutoscrollDirection, SelectionFinish, TargetForm, TargetManager,
         TargetManagerControl, TargetManagerMode, TargetTestEvent, TargetTestState,
         TerminalSelection, agent_jump_entries, capture_screen_rows, capture_selection_viewport,
@@ -7450,6 +7751,7 @@ mod tests {
     };
     use crate::config::{Config, Target};
     use crate::model::{PaneId, TargetSession, WorkspaceId};
+    use crate::plugin::{PluginAction, PluginActionContext, PluginActionId};
     use crate::resource_action::ResourceAction;
     use crate::state::{
         FederationState, NormalizedSnapshot, TargetConnectionState, TargetRuntimeState,
@@ -7614,7 +7916,12 @@ mod tests {
         assert!(app.close_confirmation.is_none());
         assert!(!app.herdr_action_inflight);
 
-        let actions = filtered_palette_actions(&state, app.selected_pane.as_ref(), "jump second");
+        let actions = filtered_palette_actions(
+            &state,
+            app.selected_pane.as_ref(),
+            "jump second",
+            &app.plugin_catalogs,
+        );
         assert_eq!(actions.len(), 1);
         let ResourceAction::JumpToPane { pane, .. } = &actions[0] else {
             panic!("expected a jump action");
@@ -7626,6 +7933,59 @@ mod tests {
     fn command_palette_search_is_case_insensitive_and_fuzzy() {
         assert!(fuzzy_score("Close workspace Simulator", "CWSim").is_some());
         assert!(fuzzy_score("Open agent navigator", "target remove").is_none());
+    }
+
+    #[test]
+    fn plugin_actions_are_qualified_and_selection_only_actions_stay_hidden() {
+        let target = TargetSession::new("host-b", "work");
+        let pane = PaneId::new("host-b", "work", "w1:p1");
+        let action = |action_id: &str, context| PluginAction {
+            id: PluginActionId {
+                target: target.clone(),
+                plugin_id: "herdr-workflows".to_owned(),
+                action_id: action_id.to_owned(),
+            },
+            title: format!("Run {action_id}"),
+            description: None,
+            contexts: vec![context],
+        };
+        let catalogs = BTreeMap::from([(
+            target.clone(),
+            PluginCatalog {
+                generation: 3,
+                actions: vec![
+                    action("workflow", PluginActionContext::Pane),
+                    action("translate-selection", PluginActionContext::Selection),
+                ],
+                loaded_at: Instant::now(),
+            },
+        )]);
+
+        let mut state = FederationState::default();
+        let snapshot = NormalizedSnapshot {
+            protocol: Some(20),
+            ..NormalizedSnapshot::default()
+        };
+        state.targets.insert(
+            target.clone(),
+            runtime(target, TargetConnectionState::Live, Some(snapshot)),
+        );
+        let actions = command_palette_actions(&state, Some(&pane), &catalogs);
+        assert!(actions.iter().any(|action| {
+            matches!(
+                action,
+                ResourceAction::InvokePluginAction { action, .. }
+                    if action.id.action_id == "workflow"
+                        && action.id.target == pane.target_session()
+            )
+        }));
+        assert!(!actions.iter().any(|action| {
+            matches!(
+                action,
+                ResourceAction::InvokePluginAction { action, .. }
+                    if action.id.action_id == "translate-selection"
+            )
+        }));
     }
 
     #[test]
@@ -7650,6 +8010,7 @@ mod tests {
             &state,
             ContextTarget::Workspace(workspace.clone()),
             ratatui::layout::Position::new(4, 5),
+            &BTreeMap::new(),
         )
         .unwrap();
 
@@ -7701,6 +8062,7 @@ mod tests {
             &state,
             ContextTarget::Workspace(workspace.clone()),
             ratatui::layout::Position::new(4, 5),
+            &BTreeMap::new(),
         )
         .unwrap();
 
@@ -7815,6 +8177,7 @@ mod tests {
             &state,
             ContextTarget::Workspace(workspace.clone()),
             ratatui::layout::Position::new(4, 5),
+            &BTreeMap::new(),
         )
         .unwrap();
 
@@ -7861,6 +8224,7 @@ mod tests {
             &state,
             ContextTarget::Workspace(WorkspaceId::new("host-b", "work", "w1")),
             ratatui::layout::Position::new(0, 0),
+            &BTreeMap::new(),
         )
         .unwrap();
         let menu_moves = menu
@@ -7870,8 +8234,11 @@ mod tests {
             .count();
         assert_eq!(menu_moves, MAX_CONTEXT_MENU_MOVE_DESTINATIONS);
 
-        let palette =
-            command_palette_actions(&state, Some(&PaneId::new("host-b", "work", "w1:p1")));
+        let palette = command_palette_actions(
+            &state,
+            Some(&PaneId::new("host-b", "work", "w1:p1")),
+            &BTreeMap::new(),
+        );
         let palette_moves = palette
             .iter()
             .filter(|action| matches!(action, ResourceAction::MoveWorkspace { .. }))

--- a/src/workspace_move.rs
+++ b/src/workspace_move.rs
@@ -6,10 +6,10 @@
 //! restarting its process. A move turns an exported tree into the ordered
 //! `pane.move` requests that rebuild the same tree in the destination workspace.
 //!
-//! Panes belong to one server process and protocol 19 has no cross-session
-//! transfer, so nothing can be moved between sessions. Crossing that boundary is
-//! offered only as a recreation, which rebuilds the structure with fresh shells
-//! and says so; it is never presented as a move.
+//! Panes belong to one server process and the documented API has no
+//! cross-session transfer, so nothing can be moved between sessions. Crossing
+//! that boundary is offered only as a recreation, which rebuilds the structure
+//! with fresh shells and says so; it is never presented as a move.
 
 use std::collections::BTreeMap;
 use std::time::Duration;


### PR DESCRIPTION
Adds qualified Herdr 0.8.2 plugin actions to the TUI and browser, sanitized run status, and explicit non-focus-stealing pane handoff.

Validation: formatting, 308 tests, host clippy, and macOS x86_64 clippy all pass.