### PR TITLE
Agent inbox: daemon projection, browser view, and per-agent marks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -442,6 +442,35 @@ clears in the frame the person acted in, but that edit is optimistic — the
 republished history overrides it, so a request that never lands is corrected
 rather than silently believed.
 
+The same ownership argument produces the agent card projection. The federation
+hierarchy answers where a pane is; it does not answer which agent is waiting,
+and on a phone that is the only question with room on the screen. The daemon
+therefore builds one inbox — sections for needs-attention, working, and recent,
+in one order — rather than letting each client derive its own. Two clients
+deriving sections independently would disagree the moment their snapshots
+differed by a refresh, and a person moving between the TUI and a phone would be
+reading two different inboxes of the same federation.
+
+A card is keyed by a qualified agent identity, which is the pane it occupies
+carried with its target and Herdr session, because that is the only identity
+Herdr's documented snapshot gives an agent. Two hosts that both name a pane
+`w1:p1` produce two cards that never collapse. Ordering is by section entry
+rather than by first sighting, so the agent blocked longest is at the top, and
+an unrelated target connecting, disconnecting, or refreshing does not renumber
+anything: the projection republishes only when the cards actually differ.
+
+A card is not a route. It records what was true when it was built, and the live
+pane is derived again from the current federation before anything is sent —
+refusing when the target is not live, the agent is gone, its pane is missing, or
+a snapshot disagrees with itself. That is what lets a card one refresh out of
+date be rendered safely, and it is why a disconnect never changes which pane
+receives the next byte. A disappeared agent stays visible as bounded history
+with no pane at all, so it can be read and never typed into. Cards carry labels,
+a status word, a phase, and timestamps; terminal contents are not summarized,
+indexed, or persisted, and the projection itself is derived rather than stored,
+because the federation state and attention index it reads already survive a
+restart on their own terms.
+
 Delivering a notification is a separate question from owning the index, and it
 divides the way the clipboard does. Native desktop delivery is a desktop-session
 capability: it belongs to the client, because a daemon on another machine

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -471,6 +471,31 @@ indexed, or persisted, and the projection itself is derived rather than stored,
 because the federation state and attention index it reads already survive a
 restart on their own terms.
 
+Pins, mutes and snoozes are Super-Herdr's own opinions about that inbox, and
+deliberately not Herdr's. Pinning an agent does not rename, move, or focus the
+pane it runs in; muting one does not stop it working or change what its target
+reports. Nothing in a mark crosses back to a host, so a mark can never be the
+reason a session behaves differently — which is why the TUI files them among
+the Herdr actions a person reaches for while excluding them from the actions
+that mutate Herdr.
+
+They are keyed by the same qualified agent identity the cards use, so pinning
+an agent on one host cannot silence a same-named agent on another. A pin is the
+one reorder a person actually asked for and so is allowed to win over section
+entry; a mute or a snooze moves a card out of the way without denying what it
+is, because an agent that is still blocked is still blocked and a card claiming
+otherwise is one a person could act on wrongly. Coming back from either is
+re-entering the queue rather than reclaiming a former place in it.
+
+A snooze is stored as a deadline the daemon computed from a duration the client
+asked for. A client never names a moment: a phone with a wrong clock would
+otherwise be able to silence an agent until next year, and the daemon has no
+way to tell that from a deliberate request. Expiry is checked on the projection
+path rather than by a timer, so it surfaces within one federation refresh
+without another clock in the process to keep correct. The file is bounded in
+every direction — how many agents may be marked, how large it may be, how far a
+snooze may reach — because it is written by a request from a paired device.
+
 Delivering a notification is a separate question from owning the index, and it
 divides the way the clipboard does. Native desktop delivery is a desktop-session
 capability: it belongs to the client, because a daemon on another machine

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -451,10 +451,26 @@ deriving sections independently would disagree the moment their snapshots
 differed by a refresh, and a person moving between the TUI and a phone would be
 reading two different inboxes of the same federation.
 
-A card is keyed by a qualified agent identity, which is the pane it occupies
-carried with its target and Herdr session, because that is the only identity
-Herdr's documented snapshot gives an agent. Two hosts that both name a pane
-`w1:p1` produce two cards that never collapse. Ordering is by section entry
+A card is keyed by a qualified agent identity: the agent session Herdr reports
+where it reports one, and otherwise the pane the agent occupies, in both cases
+carried with its target and Herdr session. Two hosts that both name a pane
+`w1:p1` produce two cards that never collapse. The session is preferred because
+it survives the agent moving to another pane, which a pane id cannot express —
+a move would otherwise read as one agent dying and another being born, taking
+the card's place in the queue and any pin on it along with it. It is optional
+in Herdr's schema and absent in practice at protocol 19, so nothing depends on
+having one, and the two forms are tagged rather than merged so that a session
+value which happened to equal a pane id cannot name the same card as a
+different agent. A reference missing any of its four fields, or carrying the
+separator the key is built from, is treated as no reference at all: a partial
+key is one two different sessions could share.
+
+Because the identity is not the route, resolution asks the current snapshot
+which agent answers to a key rather than taking the key apart. Two agents
+answering to one identity is therefore a case that can happen and is refused —
+both cards stay visible, because a person should be able to see that it
+happened, and neither is offered, because the daemon cannot say which pane an
+action would mean. Ordering is by section entry
 rather than by first sighting, so the agent blocked longest is at the top, and
 an unrelated target connecting, disconnecting, or refreshing does not renumber
 anything: the projection republishes only when the cards actually differ.

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -105,7 +105,7 @@ the exact selected route while targets connect or disconnect.
 - [ ] Resolve the live pane again before every card action and fail closed on a
       missing or ambiguous route. The resolver and its refusals exist; this
       closes when a card action calls it.
-- [ ] Add persistence for pins, mutes, and snoozes using qualified identities.
+- [x] Add persistence for pins, mutes, and snoozes using qualified identities.
 - [x] Keep historical cards non-actionable after their agent disappears.
 - [x] Add protocol and daemon tests for duplicate server-local IDs, target
       churn, agent moves, and stale cards.
@@ -114,9 +114,8 @@ the exact selected route while targets connect or disconnect.
 
 - [x] Make the inbox the default paired-device screen.
 - [x] Give each card one primary action: open the live pane.
-- [ ] Add compact filters for needs-attention, active, pinned, target, and
-      provider. State, target, and provider chips ship; pinned waits on the
-      pin store.
+- [x] Add compact filters for needs-attention, active, pinned, target, and
+      provider.
 - [x] Add a clear path back to the full infrastructure hierarchy.
 - [ ] Add an optional pinned-agent grid for monitoring several panes.
 - [x] Keep cards readable and controls reachable at narrow phone widths.
@@ -127,10 +126,12 @@ the exact selected route while targets connect or disconnect.
 
 #### TUI
 
-- [ ] Reuse the daemon projection in the existing agent navigator.
-- [ ] Show pin, mute, and snooze actions in qualified context menus and the
+- [ ] Reuse the daemon projection in the existing agent navigator. The TUI
+      subscribes and mirrors each agent's marks; the navigator still derives
+      its own list from federation state.
+- [x] Show pin, mute, and snooze actions in qualified context menus and the
       searchable action palette.
-- [ ] Keep the full hierarchy available; do not replace expert navigation with
+- [x] Keep the full hierarchy available; do not replace expert navigation with
       the inbox.
 
 Exit condition: a person with agents across several machines can identify and

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -1,0 +1,354 @@
+# Super-Herdr product backlog
+
+This backlog turns the recurring needs seen in the Herdr community and the
+useful interaction patterns in CCGram into work that fits Super-Herdr's trust
+model. It supplements `ROADMAP.md`; the operational and real-device
+qualification gates there still come first.
+
+## Product decision
+
+Super-Herdr should be the cross-machine inbox and control plane for Herdr, not
+another generic mobile terminal and not another agent runtime.
+
+The default browser experience should answer three questions immediately:
+
+1. Which agent needs me?
+2. What safe, explicit response can I send?
+3. Which machine and Herdr session will receive it?
+
+The existing target/session/workspace/tab/pane hierarchy remains the source of
+navigation truth. The agent inbox is a task-oriented projection of that truth,
+optimized for a small screen.
+
+## What "topic per agent" means
+
+CCGram uses a Telegram topic as the durable place where a person returns to one
+agent. Super-Herdr should adopt the mental model without adopting Telegram,
+transcript storage, or CCGram's lifecycle behavior.
+
+In Super-Herdr, a topic is a stable card in the browser and TUI:
+
+```text
+Federation hierarchy                         Agent inbox
+
+target                                      Needs you
+└── session                                 ├── agent card
+    └── workspace                           └── agent card
+        └── tab
+            └── pane ── agent session  ->  Working
+                                             ├── agent card
+                                             └── agent card
+
+                                            Recent
+                                             └── non-actionable history card
+```
+
+Each live card resolves to one qualified route:
+
+```text
+target + Herdr session + agent session + current pane
+```
+
+The target and Herdr session are part of the identity. Workspace, tab, pane,
+provider, and user-facing labels are display and routing metadata; names are
+never used as identity. The daemon must resolve the current pane again before
+every action and fail closed if the agent disappeared, became ambiguous, or
+moved outside the expected qualified session.
+
+The model has these UX rules:
+
+- Opening the browser lands on the agent inbox, with **Needs you** first.
+- A card stays in the same section and relative position during unrelated
+  target churn whenever possible.
+- A connected or disconnected server never changes the pane receiving the
+  user's next byte.
+- Opening a card observes the pane. Sending input still requires an explicit
+  control lease.
+- A card can be pinned, muted, or snoozed without changing the Herdr object.
+- A disappeared agent can remain in recent history, but its historical card is
+  never an input target.
+- Cards show bounded metadata only. Terminal contents and transcripts are not
+  persisted, indexed, summarized, or logged.
+- This remains a single-operator model. A paired personal device is not a team
+  member or delegated user.
+
+This makes the product easier to understand: the hierarchy answers "where is
+it?" while the inbox answers "what needs me now?"
+
+## Delivery order
+
+### 0. Make the current baseline installable and qualified
+
+- [ ] Complete the deployed-bridge and real-phone qualification in
+      `ROADMAP.md` before treating the hosted path as dependable.
+- [ ] Run the required release checks on the merged plugin-action build.
+- [ ] Publish the next tagged release so Homebrew, Debian, and archive users
+      receive the plugin actions already merged after `v0.7.20`.
+- [ ] Verify the Homebrew formula and every published binary from the release.
+- [ ] Record the exact released commit and phone/browser matrix in
+      `TESTING.md`.
+
+Exit condition: a new user can install the latest release, pair a real phone on
+an unrelated network, open an existing pane, invoke a plugin action, and retain
+the exact selected route while targets connect or disconnect.
+
+### 1. Agent inbox
+
+#### Daemon and protocol
+
+- [ ] Define a versioned `AgentCard` projection owned by the daemon.
+- [ ] Key each live card by target, Herdr session, and agent-session identity.
+- [ ] Include bounded display metadata: target label, workspace, tab, pane,
+      provider, agent state, attention state, and last state-change time.
+- [ ] Publish deterministic sections: needs attention, active, and recent.
+- [ ] Preserve card ordering across unrelated federation refreshes.
+- [ ] Resolve the live pane again before every card action and fail closed on a
+      missing or ambiguous route.
+- [ ] Add persistence for pins, mutes, and snoozes using qualified identities.
+- [ ] Keep historical cards non-actionable after their agent disappears.
+- [ ] Add protocol and daemon tests for duplicate server-local IDs, target
+      churn, agent moves, and stale cards.
+
+#### Browser
+
+- [ ] Make the inbox the default paired-device screen.
+- [ ] Give each card one primary action: open the live pane.
+- [ ] Add compact filters for needs-attention, active, pinned, target, and
+      provider.
+- [ ] Add a clear path back to the full infrastructure hierarchy.
+- [ ] Add an optional pinned-agent grid for monitoring several panes.
+- [ ] Keep cards readable and controls reachable at narrow phone widths.
+- [ ] Preserve the open card and its exact qualified pane during background
+      target churn.
+- [ ] Extend `tools/page-harness.mjs` for ordering, filtering, reconnection,
+      accessibility, and non-focus-stealing behavior.
+
+#### TUI
+
+- [ ] Reuse the daemon projection in the existing agent navigator.
+- [ ] Show pin, mute, and snooze actions in qualified context menus and the
+      searchable action palette.
+- [ ] Keep the full hierarchy available; do not replace expert navigation with
+      the inbox.
+
+Exit condition: a person with agents across several machines can identify and
+open the next agent needing attention without browsing a long hierarchy, and
+no connection event can redirect input.
+
+### 2. Structured response actions
+
+- [ ] Define a protocol representation for bounded response choices with a
+      stable action ID, label, qualified agent route, expiry, and action kind.
+- [ ] Accept structured choices only from documented Herdr or plugin metadata.
+- [ ] Do not infer buttons by scraping or parsing terminal output.
+- [ ] Render common choices as compact buttons: yes, no, approve, deny, and
+      numbered selections.
+- [ ] Keep Enter, Escape, Tab, Ctrl-C, history arrows, and customizable quick
+      replies as explicit terminal controls.
+- [ ] Require the pane control lease for any response that becomes terminal
+      input.
+- [ ] Expire buttons when the prompt, agent, session, or control lease changes.
+- [ ] Confirm actions whose structured metadata declares a destructive or
+      irreversible effect.
+- [ ] Test stale choices, duplicate IDs across targets, lease loss, retries,
+      and partial target failure.
+
+Dependency: if the documented Herdr/plugin interfaces cannot supply structured
+prompt choices, ship only user-configured quick replies and keep semantic
+choices blocked rather than guessing from terminal contents.
+
+Exit condition: a phone can answer a supported prompt with one tap, while a
+stale or ambiguous action reaches no pane.
+
+### 3. Paired-device notifications
+
+- [ ] Add opt-in push delivery as another sink under the existing attention
+      filters, coalescing, and rate limits.
+- [ ] Add per-agent modes: default, needs-attention only, muted, and temporary
+      snooze.
+- [ ] Put only bounded metadata in notification payloads.
+- [ ] Make a notification open the exact qualified live card or report that it
+      is no longer available.
+- [ ] Never embed terminal output, clipboard data, filenames, pairing material,
+      or secrets in a notification.
+- [ ] Document browser/platform requirements and a deterministic test path.
+- [ ] Test delayed delivery, duplicate delivery, revoked devices, expired
+      routes, target disconnects, and notification-click races.
+
+Exit condition: the user can leave the browser closed, receive one useful
+attention alert, and return to the correct agent without exposing payloads.
+
+### 4. Remote files and artifacts
+
+- [ ] Finish browser upload and target-to-device download surfaces on the
+      existing transfer protocol.
+- [ ] Finish TUI target-to-client save and target-to-target transfer surfaces.
+- [ ] Add an explicit, bounded remote-path picker scoped to one qualified
+      target and session.
+- [ ] Support bounded filename, substring, and opt-in glob search without
+      traversing beyond configured roots.
+- [ ] Show metadata before transfer: name, type, size, source target, and
+      digest when available.
+- [ ] Add safe client-side previews for text, images, and PDF files after the
+      normal bounded transfer and digest verification.
+- [ ] Route Git diff, source browsing, Office rendering, and richer review
+      experiences through plugin actions rather than duplicating an IDE.
+- [ ] Add cancellation and cleanup tests for every transfer direction.
+- [ ] Never discover "files the agent read" by parsing transcripts or terminal
+      contents; require an explicit path or structured plugin result.
+
+Exit condition: a phone user can find a permitted remote file, verify its
+source and size, download or preview it, and send an uploaded file to exactly
+one controlled pane.
+
+### 5. Unified diagnostics
+
+- [ ] Add a read-only `super-herdr doctor` command.
+- [ ] Check configuration permissions, Herdr executable/protocol compatibility,
+      SSH aliases, each target independently, the daemon socket, bridge route,
+      pairing prerequisites, clipboard tools, notification capability, and
+      transfer dependencies.
+- [ ] Bound and time out every network check.
+- [ ] Redact host details, credentials, authorization headers, private routes,
+      terminal contents, and pairing material from output.
+- [ ] Report corrective commands instead of changing the system automatically.
+- [ ] If a later `--fix` mode is added, require a separate confirmation for
+      every mutation and never stop or restart a Herdr session.
+- [ ] Add machine-readable output for support bundles containing metadata only.
+
+Exit condition: a user can identify which layer is broken without exposing
+private material or affecting a healthy target.
+
+### 6. Cross-host plugin inventory and explicit sync
+
+- [ ] Read installed plugin inventory through documented Herdr CLI/socket
+      interfaces for each qualified target and session.
+- [ ] Show missing plugins and version drift without treating same-named
+      server-local plugin IDs as globally identical.
+- [ ] Add marketplace search and plugin-detail links.
+- [ ] Export a desired plugin set with pinned references and a lockfile.
+- [ ] Produce an installation/update plan before making changes.
+- [ ] Apply only to explicitly selected targets after confirmation.
+- [ ] Isolate errors per target and never roll back by stopping or restarting a
+      Herdr session.
+- [ ] Do not import Herdr internals or duplicate its plugin installer.
+
+Exit condition: the operator can see and deliberately reconcile plugin drift
+across machines while one failing target leaves every other target usable.
+
+### 7. Aliases, favourites, and saved views
+
+- [ ] Add Super-Herdr-local display aliases for qualified agents, workspaces,
+      panes, sessions, and targets.
+- [ ] Never use an alias as routing identity.
+- [ ] Add pinned workspaces and favourite qualified destinations.
+- [ ] Add optional numbered jump slots without renaming Herdr resources.
+- [ ] Save inbox filters and the preferred landing view per client.
+- [ ] Surface an explicit Herdr rename action separately when the documented
+      interface supports it; never rename automatically.
+- [ ] Handle deleted, moved, and duplicate-looking resources without silently
+      retargeting an alias.
+
+Exit condition: frequently used projects and agents are one action away while
+all operations remain bound to qualified live identities.
+
+### 8. Multi-host onboarding and network choices
+
+- [ ] Offer an OpenSSH-config alias importer with a preview and explicit target
+      selection.
+- [ ] Support adding and probing several targets in one wizard with independent
+      results and timeouts.
+- [ ] Add local tags and groups such as work, home, lab, and pods.
+- [ ] Explain hosted bridge, direct LAN, Tailscale, NetBird/WireGuard-style
+      private routes, and an operator-managed proxy as peer choices.
+- [ ] Make the default hosted route clear: it needs no Tailscale but remains a
+      trusted relay because TLS terminates there.
+- [ ] Investigate a native Windows control-plane build that can supervise SSH
+      targets without claiming native Herdr support or depending on Herdr
+      internals.
+- [ ] Keep WSL2 as the documented Windows fallback until the native matrix is
+      complete.
+
+Exit condition: a new user with several existing SSH hosts can add them without
+hand-writing TOML and can understand which network trust boundary they chose.
+
+### 9. Remote development preview, after the core path is qualified
+
+- [ ] Write a threat model before implementation, covering SSRF, private-network
+      traversal, redirects, cookies, authentication headers, response size,
+      content type, and malicious target services.
+- [ ] Require an explicit, expiring grant for one target-local origin.
+- [ ] Restrict the first version to configured loopback origins on the selected
+      target.
+- [ ] Bound connections, redirects, headers, bodies, frame rates, and lifetime.
+- [ ] Keep preview traffic isolated from terminal control and other targets.
+- [ ] Do not log URLs containing secrets, headers, cookies, or response bodies.
+- [ ] Revoke the preview immediately when the device, route, or grant is
+      revoked.
+
+Exit condition: a paired device can deliberately open one approved development
+origin without becoming a general-purpose proxy into the target network.
+
+## Explicit non-goals
+
+The following ideas are useful, but do not belong in Super-Herdr's core:
+
+- Telegram or another hosted chat service as the control transport.
+- Persisted transcript delivery, transcript search, or terminal-content
+  summaries.
+- Automatic session start, recovery, restart, replacement, or cleanup.
+- Provider-specific agent runtimes or orchestration.
+- Native DAG, cost-tracking, IDE explorer, code-review, command-policy, theme,
+  or automatic-title implementations. These should remain Herdr plugins whose
+  documented actions and panes Super-Herdr exposes consistently.
+- Heuristic interpretation of terminal output as approvals, choices, file
+  paths, commands, or security policy.
+- Team sharing, delegated authority, or audit products before the
+  single-operator desktop and paired-device paths are fully qualified.
+- Server-side voice recording or transcription by default. Device dictation is
+  sufficient for the first iteration; any later transcription service must be
+  explicit and disclose its data boundary.
+
+## Suggested branch sequence
+
+Keep each branch small enough to review and qualify independently:
+
+1. `feat/agent-card-protocol`
+2. `feat/browser-agent-inbox`
+3. `feat/agent-pins-and-filters`
+4. `feat/structured-response-actions`
+5. `feat/paired-device-push`
+6. `feat/browser-file-downloads`
+7. `feat/remote-file-picker`
+8. `feat/super-herdr-doctor`
+9. `feat/plugin-fleet-inventory`
+10. `feat/local-aliases-and-favourites`
+11. `feat/ssh-target-import`
+
+Remote development preview and native Windows support require separate design
+reviews before an implementation branch is opened.
+
+## Research signals
+
+- Herdr users repeatedly describe mobile SSH/TUI use as painful and want a
+  simple way to check and steer existing agents.
+- Agent-first mobile clients prioritize blocked agents, direct prompt choices,
+  quick actions, notifications, files, and stable per-agent destinations.
+- Herdr's growing plugin ecosystem creates demand for discovery, consistent
+  installation across machines, and access to plugin surfaces remotely.
+- Requests for remote file inspection, automatic labels, favourite projects,
+  command palettes, and cross-machine setup all point to reducing navigation
+  and recall rather than adding another orchestration engine.
+
+Primary examples:
+
+- <https://github.com/alexei-led/ccgram>
+- <https://www.reddit.com/r/herdr/comments/1vxsh7w/>
+- <https://www.reddit.com/r/herdr/comments/1w29y7v/>
+- <https://www.reddit.com/r/herdr/comments/1w2pq9d/>
+- <https://www.reddit.com/r/herdr/comments/1v5m3jb/>
+- <https://www.reddit.com/r/herdr/comments/1v28abf/>
+- <https://www.reddit.com/r/herdr/comments/1v9wweu/>
+- <https://www.reddit.com/r/herdr/comments/1vkkzqp/>
+- <https://www.reddit.com/r/herdr/comments/1w1mj6e/>
+- <https://coles.codes/posts/herdr-vs-cmux/>

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -96,17 +96,18 @@ the exact selected route while targets connect or disconnect.
 
 #### Daemon and protocol
 
-- [ ] Define a versioned `AgentCard` projection owned by the daemon.
-- [ ] Key each live card by target, Herdr session, and agent-session identity.
-- [ ] Include bounded display metadata: target label, workspace, tab, pane,
+- [x] Define a versioned `AgentCard` projection owned by the daemon.
+- [x] Key each live card by target, Herdr session, and agent-session identity.
+- [x] Include bounded display metadata: target label, workspace, tab, pane,
       provider, agent state, attention state, and last state-change time.
-- [ ] Publish deterministic sections: needs attention, active, and recent.
-- [ ] Preserve card ordering across unrelated federation refreshes.
+- [x] Publish deterministic sections: needs attention, active, and recent.
+- [x] Preserve card ordering across unrelated federation refreshes.
 - [ ] Resolve the live pane again before every card action and fail closed on a
-      missing or ambiguous route.
+      missing or ambiguous route. The resolver and its refusals exist; this
+      closes when a card action calls it.
 - [ ] Add persistence for pins, mutes, and snoozes using qualified identities.
-- [ ] Keep historical cards non-actionable after their agent disappears.
-- [ ] Add protocol and daemon tests for duplicate server-local IDs, target
+- [x] Keep historical cards non-actionable after their agent disappears.
+- [x] Add protocol and daemon tests for duplicate server-local IDs, target
       churn, agent moves, and stale cards.
 
 #### Browser

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -112,16 +112,17 @@ the exact selected route while targets connect or disconnect.
 
 #### Browser
 
-- [ ] Make the inbox the default paired-device screen.
-- [ ] Give each card one primary action: open the live pane.
+- [x] Make the inbox the default paired-device screen.
+- [x] Give each card one primary action: open the live pane.
 - [ ] Add compact filters for needs-attention, active, pinned, target, and
-      provider.
-- [ ] Add a clear path back to the full infrastructure hierarchy.
+      provider. State, target, and provider chips ship; pinned waits on the
+      pin store.
+- [x] Add a clear path back to the full infrastructure hierarchy.
 - [ ] Add an optional pinned-agent grid for monitoring several panes.
-- [ ] Keep cards readable and controls reachable at narrow phone widths.
-- [ ] Preserve the open card and its exact qualified pane during background
+- [x] Keep cards readable and controls reachable at narrow phone widths.
+- [x] Preserve the open card and its exact qualified pane during background
       target churn.
-- [ ] Extend `tools/page-harness.mjs` for ordering, filtering, reconnection,
+- [x] Extend `tools/page-harness.mjs` for ordering, filtering, reconnection,
       accessibility, and non-focus-stealing behavior.
 
 #### TUI

--- a/README.md
+++ b/README.md
@@ -134,9 +134,20 @@ shows whether the plugin command is running, finished, or failed. If the action
 opens a picker, overlay, board, or another pane, an **Open** button appears;
 your current terminal never changes until you tap it.
 
+The browser opens on an agent inbox rather than the full hierarchy: your
+agents grouped into **Needs you**, **Working**, and **Recent**, each card
+naming the host and Herdr session it belongs to. Tap one to open that exact
+pane. Chips filter by state, host, and agent kind, and **All targets and
+panes** is always one tap away when you want the hierarchy instead. A card
+whose host has disconnected, or whose agent has ended, is shown and not
+offered — Super-Herdr resolves the live pane again before it routes anything,
+so a reconnect can never redirect your next keystroke.
+
 ## What is included
 
 - Concurrent discovery and supervision across local and SSH targets
+- A browser agent inbox: qualified per-agent cards, compact filters, and one
+  tap to the exact pane that needs you
 - A live, clickable TUI with tabs, split panes, search, and agent attention
 - Qualified plugin actions in the TUI and browser, with sanitized run status
   and explicit routing to any newly opened pane

--- a/README.md
+++ b/README.md
@@ -138,8 +138,14 @@ The browser opens on an agent inbox rather than the full hierarchy: your
 agents grouped into **Needs you**, **Working**, and **Recent**, each card
 naming the host and Herdr session it belongs to. Tap one to open that exact
 pane. Chips filter by state, host, and agent kind, and **All targets and
-panes** is always one tap away when you want the hierarchy instead. A card
-whose host has disconnected, or whose agent has ended, is shown and not
+panes** is always one tap away when you want the hierarchy instead.
+
+Pin an agent to keep it at the top, or mute or snooze one to move it out of the
+way for a while — in the browser on the card itself, in the TUI from the same
+right-click menus and action palette. These are Super-Herdr's own view of your
+inbox: nothing about a mark reaches the host or changes a Herdr session.
+
+A card whose host has disconnected, or whose agent has ended, is shown and not
 offered — Super-Herdr resolves the live pane again before it routes anything,
 so a reconnect can never redirect your next keystroke.
 
@@ -148,6 +154,8 @@ so a reconnect can never redirect your next keystroke.
 - Concurrent discovery and supervision across local and SSH targets
 - A browser agent inbox: qualified per-agent cards, compact filters, and one
   tap to the exact pane that needs you
+- Per-agent pins, mutes, and snoozes that order your own inbox and never touch
+  a Herdr session
 - A live, clickable TUI with tabs, split panes, search, and agent attention
 - Qualified plugin actions in the TUI and browser, with sanitized run status
   and explicit routing to any newly opened pane

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Please report vulnerabilities privately as described in [SECURITY.md](SECURITY.m
 - [Architecture and protocol boundaries](ARCHITECTURE.md)
 - [Security policy](SECURITY.md)
 - [Roadmap and current limitations](ROADMAP.md)
+- [Community-informed product backlog](PRODUCT_BACKLOG.md)
 - [Release test matrix](TESTING.md)
 - [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,9 @@
 
 Work is ordered by dependency and product risk.
 
+The community-informed product epics that follow these qualification gates are
+specified as checkable work in [PRODUCT_BACKLOG.md](PRODUCT_BACKLOG.md).
+
 ## Completed foundation
 
 - Persistent multi-host federation with qualified target/session IDs.

--- a/examples/qualify-upload.rs
+++ b/examples/qualify-upload.rs
@@ -218,6 +218,7 @@ async fn relay(
         None,
         DaemonOptions {
             socket: directory.path().join("unused.sock"),
+            agent_marks: None,
             attention_state: Some(directory.path().join("attention.json")),
             refresh_interval: std::time::Duration::from_secs(3600),
             web_port: None,

--- a/src/agent_card.rs
+++ b/src/agent_card.rs
@@ -1,0 +1,1059 @@
+//! Agent cards: the daemon's task-oriented projection of the federation.
+//!
+//! The federation hierarchy answers "where is it?" — a target holds Herdr
+//! sessions, a session holds workspaces, tabs and panes. It is the routing
+//! truth and it does not change here. What it does not answer is "what needs
+//! me now?", and on a phone that is the only question worth a screen. A card
+//! is that second view of the same facts: one agent, one line of bounded
+//! metadata, one route.
+//!
+//! Three properties make the projection safe to act on, and each one is a type
+//! or an invariant here rather than a convention a frontend is trusted to keep:
+//!
+//! * **The daemon owns it.** Two clients deriving sections and ordering
+//!   independently would disagree about which agent is first the moment their
+//!   snapshots differed by one refresh, and a person moving between the TUI
+//!   and a phone would be reading two different inboxes. The projection is
+//!   computed once, next to the state it summarises, and rendered everywhere.
+//! * **Identity is qualified.** A card is keyed by [`AgentId`], which carries
+//!   target and Herdr session alongside the server-local resource. Two hosts
+//!   that both call a pane `w1:p1` produce two cards that never collapse into
+//!   one, and a card never resolves onto a host it did not come from.
+//! * **A card is not a route.** The card records what was true when the
+//!   projection was built; [`AgentCardIndex::resolve`] re-derives the live pane
+//!   against the current federation before anything is sent, and fails closed
+//!   when the agent moved, vanished, or belongs to a target that is no longer
+//!   live. A snapshot that is one refresh stale can therefore be rendered
+//!   safely, because rendering it is all it is ever used for.
+//!
+//! Cards carry bounded display metadata only: labels, a status word, a phase,
+//! and timestamps. Terminal contents, scrollback, command lines and plugin
+//! output are not summarised, indexed or persisted here — the inbox tells a
+//! person which agent to open, and opening it is what shows them a terminal.
+
+use std::collections::{BTreeMap, VecDeque};
+
+use serde::{Deserialize, Serialize};
+
+use crate::attention::{AgentPhase, AttentionIndex, agent_phase, bounded_metadata};
+use crate::model::{AgentId, PaneId};
+use crate::state::{AgentState, FederationState, NormalizedSnapshot, TargetConnectionState};
+
+/// Incremented when a card's meaning changes in a way an older renderer would
+/// get wrong. Added fields do not bump it: unknown fields are ignored on this
+/// wire, so a newer daemon can describe more without breaking an older client.
+pub const AGENT_CARD_PROJECTION_VERSION: u32 = 1;
+
+/// How many vanished agents stay visible in `recent`.
+///
+/// History exists so a person can see what an agent did just before it went
+/// away, not so the daemon accumulates a log of every agent it has ever seen.
+const MAX_HISTORY_CARDS: usize = 64;
+
+const MAX_LABEL_CHARACTERS: usize = 128;
+const MAX_STATUS_CHARACTERS: usize = 64;
+
+/// Where a card sits in the inbox.
+///
+/// The sections are a priority order, not a taxonomy: the first one is what a
+/// person opened the app to deal with, and the last one is what they are only
+/// checking on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentCardSection {
+    /// The agent is blocked on a person.
+    NeedsYou,
+    /// The agent is running and does not need anything.
+    Working,
+    /// Everything else: idle or unrecognised live agents, and agents that have
+    /// gone away. Live cards here remain openable; vanished ones do not.
+    Recent,
+}
+
+/// What the agent is doing, as far as its target reported.
+///
+/// `Unknown` is deliberately distinct from `Idle`. A status word Super-Herdr
+/// does not recognise means the projection has no opinion, and saying so is
+/// more useful than filing it under a phase it might not be in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentActivity {
+    NeedsInput,
+    Working,
+    Idle,
+    Unknown,
+    /// The agent was observed before and is not in its target's snapshot any
+    /// more. A card in this state is history and never a route.
+    Gone,
+}
+
+impl From<AgentPhase> for AgentActivity {
+    fn from(phase: AgentPhase) -> Self {
+        match phase {
+            AgentPhase::Attention => Self::NeedsInput,
+            AgentPhase::Working => Self::Working,
+            AgentPhase::Idle => Self::Idle,
+            AgentPhase::Unknown => Self::Unknown,
+        }
+    }
+}
+
+/// One agent, as the inbox shows it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentCard {
+    /// Identity. Carries the target label and Herdr session, so nothing else
+    /// on this card is needed to tell two same-named agents apart.
+    pub agent: AgentId,
+    /// The pane the agent occupied when the projection was built, or absent
+    /// for a card that is history. This is a display convenience and a hint;
+    /// it is never the route an action uses. See [`AgentCardIndex::resolve`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane: Option<PaneId>,
+    /// The agent's own name when it has one, else the pane's label, else the
+    /// server-local resource. Bounded, never a terminal line.
+    pub title: String,
+    pub workspace: String,
+    pub tab: String,
+    pub pane_label: String,
+    /// Which agent program this is, when the target said so.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    pub activity: AgentActivity,
+    /// The target's own status word, bounded. Shown, never interpreted as
+    /// policy: `activity` is the only classification anything acts on.
+    pub status: String,
+    pub section: AgentCardSection,
+    /// Whether this agent has attention history a person has not seen.
+    pub unread: bool,
+    /// The target stopped being live and this is its last known snapshot. A
+    /// stale card still renders, because disappearing from the inbox the
+    /// moment a link flaps would be worse than showing it greyed.
+    pub stale: bool,
+    /// Whether opening this card could resolve to a live pane at projection
+    /// time. A client uses it to decide what to offer; the daemon still
+    /// re-resolves before acting, so this is never the only check.
+    pub actionable: bool,
+    /// When this agent last changed state, from attention history. Absent when
+    /// the agent has not changed since the daemon started watching it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_change_ms: Option<u64>,
+}
+
+/// The whole inbox, in the order it should be rendered.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentCardProjection {
+    pub version: u32,
+    /// Bumped only when the cards actually differ, so a client can skip a
+    /// repaint that would change nothing and a test can assert that an
+    /// unrelated federation refresh was in fact unrelated.
+    pub revision: u64,
+    pub needs_you: Vec<AgentCard>,
+    pub working: Vec<AgentCard>,
+    pub recent: Vec<AgentCard>,
+}
+
+impl AgentCardProjection {
+    pub fn cards(&self) -> impl Iterator<Item = &AgentCard> {
+        self.needs_you
+            .iter()
+            .chain(self.working.iter())
+            .chain(self.recent.iter())
+    }
+
+    pub fn card(&self, agent: &AgentId) -> Option<&AgentCard> {
+        self.cards().find(|card| &card.agent == agent)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.needs_you.is_empty() && self.working.is_empty() && self.recent.is_empty()
+    }
+}
+
+/// A resolved, current route to an agent's pane.
+///
+/// The generation is the target connection it was resolved against. An action
+/// carrying it can be refused if the target reconnected in between, which is
+/// the same rule the plugin registry already uses: a route derived before a
+/// reconnect describes a server process that may no longer exist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CardRoute {
+    pub pane: PaneId,
+    pub generation: u64,
+}
+
+/// Why a card could not be turned into a route.
+///
+/// Every variant is a refusal. There is deliberately no "best effort" outcome:
+/// the failure mode this type exists to prevent is delivering a person's
+/// keystroke to whatever pane happened to be nearby.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardRouteError {
+    /// The card's target and Herdr session are not in the federation.
+    UnknownTarget,
+    /// The target is not live, so there is nothing to route to right now.
+    TargetUnavailable,
+    /// The target is live and the agent is not in its snapshot.
+    AgentGone,
+    /// The agent exists but its pane does not, so the route is incomplete.
+    PaneMissing,
+    /// The snapshot disagrees with itself about where the agent is. This
+    /// should not happen; if it does, refusing is the only safe answer.
+    Ambiguous,
+}
+
+impl CardRouteError {
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::UnknownTarget => "that agent's target is no longer in the federation",
+            Self::TargetUnavailable => "that agent's target is not connected",
+            Self::AgentGone => "that agent is no longer running",
+            Self::PaneMissing => "that agent's pane is no longer open",
+            Self::Ambiguous => "that agent's location is ambiguous",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Tracked {
+    /// When this card entered the section it is in now. Ordering within a
+    /// section is by this number, so a card holds its place while unrelated
+    /// targets appear, disappear and refresh around it.
+    ///
+    /// Ordering by section entry rather than by first sighting also gives the
+    /// queue the behaviour a person expects from an inbox: the agent that has
+    /// been blocked longest is at the top, and answering it does not reshuffle
+    /// the ones below.
+    rank: u64,
+    section: AgentCardSection,
+    card: AgentCard,
+}
+
+/// The daemon's live projection state.
+///
+/// It is a state machine, not a cache: ordering and history only make sense
+/// across successive federations, so the index remembers what it published
+/// last and each call describes the change from it.
+#[derive(Debug, Clone, Default)]
+pub struct AgentCardIndex {
+    tracked: BTreeMap<AgentId, Tracked>,
+    history: VecDeque<AgentCard>,
+    next_rank: u64,
+    revision: u64,
+    published: Option<Published>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Published {
+    needs_you: Vec<AgentCard>,
+    working: Vec<AgentCard>,
+    recent: Vec<AgentCard>,
+}
+
+impl AgentCardIndex {
+    /// Rebuild the inbox from the current federation and attention history.
+    ///
+    /// Called on every federation update. It is deliberately pure with respect
+    /// to the clock: every timestamp on a card comes from attention history,
+    /// which the daemon already stamps when it observes the transition, so two
+    /// projections of the same inputs are equal and a test can say so.
+    pub fn project(
+        &mut self,
+        state: &FederationState,
+        attention: &AttentionIndex,
+    ) -> AgentCardProjection {
+        let mut seen = BTreeMap::new();
+        for target in state.targets.values() {
+            let Some(snapshot) = target.snapshot.as_deref() else {
+                continue;
+            };
+            let live = target.connection == TargetConnectionState::Live;
+            for agent in snapshot.agents.values() {
+                let id = agent_id(&agent.pane);
+                let card = self.build_card(agent, snapshot, attention, live);
+                seen.insert(id, card);
+            }
+        }
+
+        // An agent is only *gone* when the target that owned it is live and
+        // says so. A target that dropped its connection is not evidence about
+        // anything running on the far side of it, and retiring cards on a
+        // flapping link would empty a person's inbox for reasons that have
+        // nothing to do with their agents.
+        let mut vanished = Vec::new();
+        for (id, tracked) in &self.tracked {
+            if seen.contains_key(id) {
+                continue;
+            }
+            match state.targets.get(&id.target_session()) {
+                Some(target) if target.connection == TargetConnectionState::Live => {
+                    vanished.push(tracked.card.clone());
+                }
+                Some(_) => {}
+                // The target left the federation entirely, which is a
+                // configuration change rather than an agent ending. Its cards
+                // go with it instead of becoming history nobody can act on.
+                None => {}
+            }
+        }
+        // Keeping a card requires either seeing the agent again or a target
+        // that cannot currently be asked. A live target that no longer lists
+        // the agent is the one authority that can end it.
+        self.tracked.retain(|id, _| {
+            seen.contains_key(id)
+                || state
+                    .targets
+                    .get(&id.target_session())
+                    .is_some_and(|target| target.connection != TargetConnectionState::Live)
+        });
+        // What is left unseen belongs to a target that is not live and has no
+        // snapshot to rebuild from — a target that dropped its connection
+        // before this refresh. Its cards stay, because the agents behind them
+        // probably still exist, but they stop claiming to be current and stop
+        // offering themselves as a destination.
+        for (id, tracked) in &mut self.tracked {
+            if seen.contains_key(id) {
+                continue;
+            }
+            tracked.card.stale = true;
+            tracked.card.actionable = false;
+        }
+        for card in vanished {
+            self.retire(card);
+        }
+
+        for (id, card) in seen {
+            let section = card.section;
+            match self.tracked.get_mut(&id) {
+                Some(tracked) if tracked.section == section => {
+                    tracked.card = card;
+                }
+                _ => {
+                    let rank = self.next_rank;
+                    self.next_rank = self.next_rank.saturating_add(1);
+                    self.tracked.insert(
+                        id,
+                        Tracked {
+                            rank,
+                            section,
+                            card,
+                        },
+                    );
+                }
+            }
+        }
+
+        let needs_you = self.section(AgentCardSection::NeedsYou);
+        let working = self.section(AgentCardSection::Working);
+        let mut recent = self.section(AgentCardSection::Recent);
+        recent.extend(self.history.iter().cloned());
+
+        let published = Published {
+            needs_you,
+            working,
+            recent,
+        };
+        if self.published.as_ref() != Some(&published) {
+            self.revision = self.revision.saturating_add(1);
+        }
+        self.published = Some(published.clone());
+        AgentCardProjection {
+            version: AGENT_CARD_PROJECTION_VERSION,
+            revision: self.revision,
+            needs_you: published.needs_you,
+            working: published.working,
+            recent: published.recent,
+        }
+    }
+
+    /// Derive the live pane for a card against the current federation.
+    ///
+    /// This is the only way a card becomes something that can be sent to, and
+    /// it deliberately ignores everything the projection recorded: the card
+    /// says where the agent *was*, and by the time a person taps it the answer
+    /// may have changed. Anything short of an agent that is present, in a pane
+    /// that is present, on a target that is live, is a refusal.
+    pub fn resolve(agent: &AgentId, state: &FederationState) -> Result<CardRoute, CardRouteError> {
+        let target = state
+            .targets
+            .get(&agent.target_session())
+            .ok_or(CardRouteError::UnknownTarget)?;
+        if target.connection != TargetConnectionState::Live {
+            return Err(CardRouteError::TargetUnavailable);
+        }
+        let snapshot = target
+            .snapshot
+            .as_deref()
+            .ok_or(CardRouteError::TargetUnavailable)?;
+        let pane = pane_id(agent);
+        let observed = snapshot
+            .agents
+            .get(&pane)
+            .ok_or(CardRouteError::AgentGone)?;
+        // The snapshot keys agents by pane, so this can only fail if a target
+        // sent a record that disagrees with its own index. Refuse rather than
+        // pick one of the two answers.
+        if observed.pane != pane {
+            return Err(CardRouteError::Ambiguous);
+        }
+        if !snapshot.panes.contains_key(&pane) {
+            return Err(CardRouteError::PaneMissing);
+        }
+        Ok(CardRoute {
+            pane,
+            generation: target.connection_generation,
+        })
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    fn section(&self, section: AgentCardSection) -> Vec<AgentCard> {
+        let mut cards = self
+            .tracked
+            .values()
+            .filter(|tracked| tracked.section == section)
+            .collect::<Vec<_>>();
+        // The rank orders the section; the identity only breaks a tie, which
+        // two cards can reach when they entered in the same projection. Both
+        // keys are total, so the result is one order rather than whichever one
+        // the map happened to yield.
+        cards.sort_by(|left, right| {
+            left.rank
+                .cmp(&right.rank)
+                .then_with(|| left.card.agent.cmp(&right.card.agent))
+        });
+        cards
+            .into_iter()
+            .map(|tracked| tracked.card.clone())
+            .collect()
+    }
+
+    fn retire(&mut self, card: AgentCard) {
+        self.history.push_front(AgentCard {
+            pane: None,
+            activity: AgentActivity::Gone,
+            section: AgentCardSection::Recent,
+            actionable: false,
+            stale: false,
+            ..card
+        });
+        while self.history.len() > MAX_HISTORY_CARDS {
+            self.history.pop_back();
+        }
+    }
+
+    fn build_card(
+        &self,
+        agent: &AgentState,
+        snapshot: &NormalizedSnapshot,
+        attention: &AttentionIndex,
+        live: bool,
+    ) -> AgentCard {
+        let pane = snapshot.panes.get(&agent.pane);
+        let status = bounded_metadata(
+            agent
+                .status
+                .as_deref()
+                .or_else(|| pane.and_then(|pane| pane.agent_status.as_deref()))
+                .unwrap_or("unknown"),
+            MAX_STATUS_CHARACTERS,
+        );
+        let activity = AgentActivity::from(agent_phase(
+            &status,
+            agent.interactive_ready.unwrap_or(false),
+        ));
+        let section = match activity {
+            AgentActivity::NeedsInput => AgentCardSection::NeedsYou,
+            AgentActivity::Working => AgentCardSection::Working,
+            AgentActivity::Idle | AgentActivity::Unknown | AgentActivity::Gone => {
+                AgentCardSection::Recent
+            }
+        };
+        let workspace = pane
+            .and_then(|pane| pane.workspace.as_ref())
+            .map(|workspace| {
+                snapshot
+                    .workspaces
+                    .get(workspace)
+                    .and_then(|held| held.label.as_deref())
+                    .unwrap_or(workspace.resource.as_str())
+            })
+            .unwrap_or("unassigned");
+        let tab = pane
+            .and_then(|pane| pane.tab.as_ref())
+            .map(|tab| {
+                snapshot
+                    .tabs
+                    .get(tab)
+                    .and_then(|held| held.label.as_deref())
+                    .unwrap_or(tab.resource.as_str())
+            })
+            .unwrap_or("unassigned");
+        AgentCard {
+            agent: agent_id(&agent.pane),
+            pane: Some(agent.pane.clone()),
+            title: bounded_metadata(
+                agent
+                    .name
+                    .as_deref()
+                    .or_else(|| pane.and_then(|pane| pane.agent.as_deref()))
+                    .or_else(|| pane.and_then(|pane| pane.label.as_deref()))
+                    .unwrap_or(&agent.pane.resource),
+                MAX_LABEL_CHARACTERS,
+            ),
+            workspace: bounded_metadata(workspace, MAX_LABEL_CHARACTERS),
+            tab: bounded_metadata(tab, MAX_LABEL_CHARACTERS),
+            pane_label: bounded_metadata(
+                pane.and_then(|pane| pane.label.as_deref())
+                    .unwrap_or(&agent.pane.resource),
+                MAX_LABEL_CHARACTERS,
+            ),
+            provider: agent
+                .agent
+                .as_deref()
+                .map(|provider| bounded_metadata(provider, MAX_LABEL_CHARACTERS)),
+            activity,
+            status,
+            section,
+            unread: attention.has_unread_for_pane(&agent.pane),
+            stale: !live,
+            // A pane the snapshot does not list cannot be resolved, so the
+            // card is shown and not offered as a destination.
+            actionable: live && pane.is_some(),
+            last_change_ms: attention
+                .events()
+                .rev()
+                .find(|event| event.pane == agent.pane)
+                .map(|event| event.occurred_at_ms),
+        }
+    }
+}
+
+/// An agent is identified by the pane it occupies, because that is the only
+/// identity Herdr's documented snapshot gives one. Both halves of the
+/// conversion keep the target and session, so the qualification survives.
+fn agent_id(pane: &PaneId) -> AgentId {
+    AgentId::new(&pane.target, &pane.session, &pane.resource)
+}
+
+fn pane_id(agent: &AgentId) -> PaneId {
+    PaneId::new(&agent.target, &agent.session, &agent.resource)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::{Value, json};
+
+    use super::{
+        AgentActivity, AgentCardIndex, AgentCardSection, CardRouteError, MAX_HISTORY_CARDS,
+    };
+    use crate::attention::AttentionIndex;
+    use crate::model::{AgentId, TargetSession};
+    use crate::state::{
+        FederationState, NormalizedSnapshot, TargetConnectionState, TargetRuntimeState,
+        TargetUpdateMode,
+    };
+
+    #[test]
+    fn separates_the_agent_that_is_blocked_from_the_one_that_is_busy() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(json!({
+                "workspaces": [{"workspace_id": "w1", "label": "compiler"}],
+                "tabs": [{"tab_id": "t1", "workspace_id": "w1", "label": "build"}],
+                "panes": [
+                    {"pane_id": "p1", "workspace_id": "w1", "tab_id": "t1", "label": "left"},
+                    {"pane_id": "p2", "workspace_id": "w1", "tab_id": "t1", "label": "right"}
+                ],
+                "agents": [
+                    {"pane_id": "p1", "name": "reviewer", "agent": "claude", "agent_status": "blocked"},
+                    {"pane_id": "p2", "name": "builder", "agent": "codex", "agent_status": "working"}
+                ]
+            })),
+        )]);
+
+        let projection = index.project(&state, &AttentionIndex::default());
+
+        assert_eq!(titles(&projection.needs_you), ["reviewer"]);
+        assert_eq!(titles(&projection.working), ["builder"]);
+        assert!(projection.recent.is_empty());
+        let blocked = &projection.needs_you[0];
+        assert_eq!(blocked.activity, AgentActivity::NeedsInput);
+        assert_eq!(blocked.section, AgentCardSection::NeedsYou);
+        assert_eq!(blocked.workspace, "compiler");
+        assert_eq!(blocked.tab, "build");
+        assert_eq!(blocked.pane_label, "left");
+        assert_eq!(blocked.provider.as_deref(), Some("claude"));
+        assert!(blocked.actionable);
+        assert!(!blocked.stale);
+    }
+
+    #[test]
+    fn files_an_idle_or_unrecognised_agent_under_recent_while_it_stays_openable() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "idle"), ("p2", "meditating")])),
+        )]);
+
+        let projection = index.project(&state, &AttentionIndex::default());
+
+        assert!(projection.needs_you.is_empty());
+        assert!(projection.working.is_empty());
+        assert_eq!(
+            projection
+                .recent
+                .iter()
+                .map(|card| card.activity)
+                .collect::<Vec<_>>(),
+            [AgentActivity::Idle, AgentActivity::Unknown]
+        );
+        assert!(projection.recent.iter().all(|card| card.actionable));
+    }
+
+    #[test]
+    fn keeps_two_hosts_that_name_a_pane_identically_apart() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![
+            (
+                "host-a",
+                TargetConnectionState::Live,
+                Some(agents_snapshot(&[("w1:p1", "blocked")])),
+            ),
+            (
+                "host-b",
+                TargetConnectionState::Live,
+                Some(agents_snapshot(&[("w1:p1", "blocked")])),
+            ),
+        ]);
+
+        let projection = index.project(&state, &AttentionIndex::default());
+
+        assert_eq!(projection.needs_you.len(), 2);
+        let targets = projection
+            .needs_you
+            .iter()
+            .map(|card| card.agent.target.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(targets, ["host-a", "host-b"]);
+        // The route each card resolves to carries its own host, so the two
+        // never collapse into one destination.
+        for card in &projection.needs_you {
+            let route = AgentCardIndex::resolve(&card.agent, &state).unwrap();
+            assert_eq!(route.pane.target, card.agent.target);
+            assert_eq!(route.pane.resource, "w1:p1");
+        }
+    }
+
+    #[test]
+    fn holds_a_cards_place_while_an_unrelated_target_churns() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let first = federation(vec![
+            (
+                "host-a",
+                TargetConnectionState::Live,
+                Some(agents_snapshot(&[("p1", "blocked")])),
+            ),
+            (
+                "host-b",
+                TargetConnectionState::Live,
+                Some(agents_snapshot(&[("p9", "blocked")])),
+            ),
+        ]);
+        let before = index.project(&first, &attention);
+        assert_eq!(
+            order(&before.needs_you),
+            ["host-a/work/p1", "host-b/work/p9"]
+        );
+
+        // host-c arrives, and host-b's snapshot is refreshed without changing
+        // anything a card shows. Neither is a reason to renumber the inbox.
+        let mut second = first.clone();
+        second.targets.insert(
+            TargetSession::new("host-c", "work"),
+            target(
+                "host-c",
+                TargetConnectionState::Live,
+                Some(agents_snapshot(&[("p1", "blocked")])),
+            ),
+        );
+        let after = index.project(&second, &attention);
+
+        assert_eq!(
+            order(&after.needs_you),
+            ["host-a/work/p1", "host-b/work/p9", "host-c/work/p1"],
+            "an arriving target appends and never reorders what was there"
+        );
+        assert_eq!(
+            after.revision,
+            before.revision + 1,
+            "the inbox did change: it gained a card"
+        );
+
+        // A refresh that changes nothing at all publishes nothing at all.
+        let unchanged = index.project(&second, &attention);
+        assert_eq!(unchanged.revision, after.revision);
+        assert_eq!(unchanged.needs_you, after.needs_you);
+    }
+
+    #[test]
+    fn sends_an_agent_to_the_back_of_the_section_it_enters() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let blocked_pair = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked"), ("p2", "blocked")])),
+        )]);
+        index.project(&blocked_pair, &attention);
+
+        // p1 is answered and starts working, then blocks again. It is now the
+        // most recently blocked agent, so it queues behind p2 rather than
+        // reclaiming the top of a list p2 has been waiting at.
+        let answered = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "working"), ("p2", "blocked")])),
+        )]);
+        index.project(&answered, &attention);
+        let projection = index.project(&blocked_pair, &attention);
+
+        assert_eq!(
+            order(&projection.needs_you),
+            ["host-a/work/p2", "host-a/work/p1"]
+        );
+    }
+
+    #[test]
+    fn retires_a_vanished_agent_into_history_that_cannot_be_opened() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let running = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked")])),
+        )]);
+        index.project(&running, &attention);
+
+        let ended = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[])),
+        )]);
+        let projection = index.project(&ended, &attention);
+
+        assert!(projection.needs_you.is_empty());
+        assert_eq!(projection.recent.len(), 1);
+        let card = &projection.recent[0];
+        assert_eq!(card.activity, AgentActivity::Gone);
+        assert!(!card.actionable);
+        assert!(card.pane.is_none(), "history is not a route");
+        assert_eq!(
+            AgentCardIndex::resolve(&card.agent, &ended),
+            Err(CardRouteError::AgentGone)
+        );
+    }
+
+    #[test]
+    fn treats_an_agent_that_moved_pane_as_a_new_card_and_refuses_the_old_route() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let before = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked")])),
+        )]);
+        index.project(&before, &attention);
+
+        let after_move = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p2", "blocked")])),
+        )]);
+        let projection = index.project(&after_move, &attention);
+
+        assert_eq!(order(&projection.needs_you), ["host-a/work/p2"]);
+        assert_eq!(projection.recent.len(), 1);
+        let stale_card = AgentId::new("host-a", "work", "p1");
+        assert_eq!(
+            AgentCardIndex::resolve(&stale_card, &after_move),
+            Err(CardRouteError::AgentGone),
+            "a card built before the move must not reach the pane it used to name"
+        );
+        let moved = AgentCardIndex::resolve(&projection.needs_you[0].agent, &after_move).unwrap();
+        assert_eq!(moved.pane.resource, "p2");
+    }
+
+    #[test]
+    fn keeps_cards_when_a_target_drops_but_stops_offering_them() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let live = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked")])),
+        )]);
+        index.project(&live, &attention);
+
+        // Disconnected, but the last snapshot is retained: the agent is
+        // probably still there, and emptying the inbox on a flapping link
+        // would say otherwise.
+        let dropped = federation(vec![(
+            "host-a",
+            TargetConnectionState::Backoff { attempt: 1 },
+            Some(agents_snapshot(&[("p1", "blocked")])),
+        )]);
+        let projection = index.project(&dropped, &attention);
+
+        assert_eq!(projection.needs_you.len(), 1);
+        let card = &projection.needs_you[0];
+        assert!(card.stale);
+        assert!(!card.actionable);
+        assert_eq!(
+            AgentCardIndex::resolve(&card.agent, &dropped),
+            Err(CardRouteError::TargetUnavailable)
+        );
+        assert!(
+            projection.recent.is_empty(),
+            "a disconnect is not evidence that an agent ended"
+        );
+    }
+
+    #[test]
+    fn marks_cards_stale_when_a_target_drops_its_snapshot_entirely() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        index.project(
+            &federation(vec![(
+                "host-a",
+                TargetConnectionState::Live,
+                Some(agents_snapshot(&[("p1", "blocked")])),
+            )]),
+            &attention,
+        );
+
+        let projection = index.project(
+            &federation(vec![("host-a", TargetConnectionState::Connecting, None)]),
+            &attention,
+        );
+
+        assert_eq!(projection.needs_you.len(), 1);
+        assert!(projection.needs_you[0].stale);
+        assert!(!projection.needs_you[0].actionable);
+    }
+
+    #[test]
+    fn forgets_the_cards_of_a_target_that_left_the_federation() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        index.project(
+            &federation(vec![(
+                "host-a",
+                TargetConnectionState::Live,
+                Some(agents_snapshot(&[("p1", "blocked")])),
+            )]),
+            &attention,
+        );
+
+        let projection = index.project(&FederationState::default(), &attention);
+
+        assert!(
+            projection.is_empty(),
+            "removing a target is a configuration change, not agent history"
+        );
+    }
+
+    #[test]
+    fn refuses_a_card_whose_pane_the_snapshot_does_not_list() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(json!({
+                "workspaces": [],
+                "panes": [],
+                "agents": [{"pane_id": "p1", "name": "orphan", "agent_status": "blocked"}]
+            })),
+        )]);
+
+        let projection = index.project(&state, &AttentionIndex::default());
+
+        assert_eq!(projection.needs_you.len(), 1);
+        assert!(!projection.needs_you[0].actionable);
+        assert_eq!(
+            AgentCardIndex::resolve(&projection.needs_you[0].agent, &state),
+            Err(CardRouteError::PaneMissing)
+        );
+    }
+
+    #[test]
+    fn refuses_a_card_for_a_target_that_is_not_in_the_federation() {
+        assert_eq!(
+            AgentCardIndex::resolve(
+                &AgentId::new("host-gone", "work", "p1"),
+                &FederationState::default()
+            ),
+            Err(CardRouteError::UnknownTarget)
+        );
+    }
+
+    #[test]
+    fn resolves_against_the_live_connection_generation() {
+        let mut state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked")])),
+        )]);
+        let key = TargetSession::new("host-a", "work");
+        state.targets.get_mut(&key).unwrap().connection_generation = 7;
+
+        let route = AgentCardIndex::resolve(&AgentId::new("host-a", "work", "p1"), &state).unwrap();
+
+        assert_eq!(route.generation, 7);
+        assert_eq!(route.pane.to_string(), "host-a/work/p1");
+    }
+
+    #[test]
+    fn bounds_the_metadata_a_card_carries() {
+        let mut index = AgentCardIndex::default();
+        let noisy = format!("alpha\u{1b}[2Jbeta{}", "x".repeat(400));
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(json!({
+                "workspaces": [],
+                "panes": [{"pane_id": "p1"}],
+                "agents": [{
+                    "pane_id": "p1",
+                    "name": noisy,
+                    "agent_status": noisy
+                }]
+            })),
+        )]);
+
+        let projection = index.project(&state, &AttentionIndex::default());
+        let card = projection.cards().next().unwrap();
+
+        assert_eq!(card.title.chars().count(), 128);
+        assert_eq!(card.status.chars().count(), 64);
+        assert!(!card.title.contains('\u{1b}'));
+        assert!(!card.status.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn bounds_how_much_history_recent_accumulates() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        for pane in 0..MAX_HISTORY_CARDS + 10 {
+            let name = format!("p{pane}");
+            index.project(
+                &federation(vec![(
+                    "host-a",
+                    TargetConnectionState::Live,
+                    Some(agents_snapshot(&[(name.as_str(), "blocked")])),
+                )]),
+                &attention,
+            );
+        }
+        let projection = index.project(
+            &federation(vec![(
+                "host-a",
+                TargetConnectionState::Live,
+                Some(agents_snapshot(&[])),
+            )]),
+            &attention,
+        );
+
+        assert_eq!(projection.recent.len(), MAX_HISTORY_CARDS);
+        assert_eq!(
+            projection.recent[0].agent.resource,
+            format!("p{}", MAX_HISTORY_CARDS + 9),
+            "the newest departure is the first one a person sees"
+        );
+    }
+
+    #[test]
+    fn reports_attention_state_on_the_card_it_belongs_to() {
+        let mut attention = AttentionIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "working"), ("p2", "idle")])),
+        )]);
+        attention.observe(&state);
+        let blocked = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked"), ("p2", "idle")])),
+        )]);
+        attention.observe(&blocked);
+
+        let projection = AgentCardIndex::default().project(&blocked, &attention);
+
+        assert!(projection.needs_you[0].unread);
+        assert!(projection.needs_you[0].last_change_ms.is_some());
+        assert!(!projection.recent[0].unread);
+        assert!(projection.recent[0].last_change_ms.is_none());
+    }
+
+    fn titles(cards: &[super::AgentCard]) -> Vec<&str> {
+        cards.iter().map(|card| card.title.as_str()).collect()
+    }
+
+    fn order(cards: &[super::AgentCard]) -> Vec<String> {
+        cards.iter().map(|card| card.agent.to_string()).collect()
+    }
+
+    fn agents_snapshot(agents: &[(&str, &str)]) -> Value {
+        json!({
+            "workspaces": [],
+            "panes": agents
+                .iter()
+                .map(|(pane, _)| json!({"pane_id": pane}))
+                .collect::<Vec<_>>(),
+            "agents": agents
+                .iter()
+                .map(|(pane, status)| json!({"pane_id": pane, "agent_status": status}))
+                .collect::<Vec<_>>(),
+        })
+    }
+
+    fn federation(targets: Vec<(&str, TargetConnectionState, Option<Value>)>) -> FederationState {
+        let mut state = FederationState::default();
+        for (name, connection, snapshot) in targets {
+            state.targets.insert(
+                TargetSession::new(name, "work"),
+                target(name, connection, snapshot),
+            );
+        }
+        state
+    }
+
+    fn target(
+        name: &str,
+        connection: TargetConnectionState,
+        snapshot: Option<Value>,
+    ) -> TargetRuntimeState {
+        let key = TargetSession::new(name, "work");
+        TargetRuntimeState {
+            key: key.clone(),
+            endpoint: "test".to_owned(),
+            connection,
+            update_mode: TargetUpdateMode::Events,
+            event_error: None,
+            connection_generation: 1,
+            selected_herdr_bin: Some("herdr".to_owned()),
+            snapshot: snapshot.map(|value| Arc::new(NormalizedSnapshot::from_value(&key, &value))),
+            last_error: None,
+            last_success: None,
+            retry_at: None,
+        }
+    }
+}

--- a/src/agent_card.rs
+++ b/src/agent_card.rs
@@ -31,19 +31,21 @@
 //! output are not summarised, indexed or persisted here — the inbox tells a
 //! person which agent to open, and opening it is what shows them a terminal.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
 use crate::agent_marks::{AgentMarkState, AgentMarks};
 use crate::attention::{AgentPhase, AttentionIndex, agent_phase, bounded_metadata};
 use crate::model::{AgentId, PaneId};
-use crate::state::{AgentState, FederationState, NormalizedSnapshot, TargetConnectionState};
+use crate::state::{
+    AGENT_KEY_SEPARATOR, AgentState, FederationState, NormalizedSnapshot, TargetConnectionState,
+};
 
 /// Incremented when a card's meaning changes in a way an older renderer would
 /// get wrong. Added fields do not bump it: unknown fields are ignored on this
 /// wire, so a newer daemon can describe more without breaking an older client.
-pub const AGENT_CARD_PROJECTION_VERSION: u32 = 1;
+pub const AGENT_CARD_PROJECTION_VERSION: u32 = 2;
 
 /// How many vanished agents stay visible in `recent`.
 ///
@@ -269,15 +271,28 @@ impl AgentCardIndex {
         now_ms: u64,
     ) -> AgentCardProjection {
         let mut seen = BTreeMap::new();
+        let mut ambiguous = BTreeSet::new();
         for target in state.targets.values() {
             let Some(snapshot) = target.snapshot.as_deref() else {
                 continue;
             };
             let live = target.connection == TargetConnectionState::Live;
             for agent in snapshot.agents.values() {
-                let id = agent_id(&agent.pane);
+                let id = agent_key(agent);
                 let card = self.build_card(agent, snapshot, attention, live, marks, now_ms);
-                seen.insert(id, card);
+                if seen.insert(id.clone(), card).is_some() {
+                    // Two agents on one target answering to one identity. Both
+                    // cards stay visible — a person should be able to see that
+                    // it happened — but neither is offered, because the daemon
+                    // could not say which pane an action meant.
+                    ambiguous.insert(id);
+                }
+            }
+        }
+
+        for id in &ambiguous {
+            if let Some(card) = seen.get_mut(id) {
+                card.actionable = false;
             }
         }
 
@@ -391,22 +406,26 @@ impl AgentCardIndex {
             .snapshot
             .as_deref()
             .ok_or(CardRouteError::TargetUnavailable)?;
-        let pane = pane_id(agent);
-        let observed = snapshot
+        // Derived by asking the current snapshot which agent answers to this
+        // key, rather than by taking the key apart. An agent identified by its
+        // session may be in a different pane than it was when the card was
+        // built, and that is the whole reason to prefer that identity.
+        let mut matches = snapshot
             .agents
-            .get(&pane)
-            .ok_or(CardRouteError::AgentGone)?;
-        // The snapshot keys agents by pane, so this can only fail if a target
-        // sent a record that disagrees with its own index. Refuse rather than
-        // pick one of the two answers.
-        if observed.pane != pane {
+            .values()
+            .filter(|held| &agent_key(held) == agent);
+        let found = matches.next().ok_or(CardRouteError::AgentGone)?;
+        if matches.next().is_some() {
+            // Two agents answering to one identity. Refusing is the only safe
+            // answer: picking either would deliver a person's keystroke to a
+            // pane chosen by iteration order.
             return Err(CardRouteError::Ambiguous);
         }
-        if !snapshot.panes.contains_key(&pane) {
+        if !snapshot.panes.contains_key(&found.pane) {
             return Err(CardRouteError::PaneMissing);
         }
         Ok(CardRoute {
-            pane,
+            pane: found.pane.clone(),
             generation: target.connection_generation,
         })
     }
@@ -478,7 +497,8 @@ impl AgentCardIndex {
             &status,
             agent.interactive_ready.unwrap_or(false),
         ));
-        let marked = marks.state(&agent_id(&agent.pane));
+        let key = agent_key(agent);
+        let marked = marks.state(&key);
         // A muted or snoozed agent keeps its activity — it is still blocked,
         // and saying otherwise would be a lie a person could act on — but it
         // stops competing for the top of the inbox. Coming back is re-entering
@@ -516,7 +536,7 @@ impl AgentCardIndex {
             })
             .unwrap_or("unassigned");
         AgentCard {
-            agent: agent_id(&agent.pane),
+            agent: key,
             pane: Some(agent.pane.clone()),
             title: bounded_metadata(
                 agent
@@ -556,15 +576,29 @@ impl AgentCardIndex {
     }
 }
 
-/// An agent is identified by the pane it occupies, because that is the only
-/// identity Herdr's documented snapshot gives one. Both halves of the
-/// conversion keep the target and session, so the qualification survives.
-fn agent_id(pane: &PaneId) -> AgentId {
-    AgentId::new(&pane.target, &pane.session, &pane.resource)
-}
-
-fn pane_id(agent: &AgentId) -> PaneId {
-    PaneId::new(&agent.target, &agent.session, &agent.resource)
+/// The identity of one agent, qualified by target and Herdr session.
+///
+/// Herdr reports an optional `agent_session` for a pane, and where it is
+/// present it is the better identity: it survives the agent moving to another
+/// pane, which a pane id cannot express — a move would otherwise read as one
+/// agent dying and another being born, taking the card's place in the queue
+/// and any pin on it with it.
+///
+/// It is optional in the schema and, at protocol 19, absent in practice, so
+/// the pane remains the identity whenever there is no session to use. The two
+/// forms are tagged rather than merged, because an agent-session value that
+/// happened to equal a pane id would otherwise name the same card as a
+/// different agent.
+pub fn agent_key(agent: &AgentState) -> AgentId {
+    let separator = AGENT_KEY_SEPARATOR;
+    let resource = match agent.session.as_ref() {
+        Some(session) => format!(
+            "session{separator}{}{separator}{}{separator}{}{separator}{}",
+            session.kind, session.value, session.source, session.agent
+        ),
+        None => format!("pane{separator}{}", agent.pane.resource),
+    };
+    AgentId::new(&agent.pane.target, &agent.pane.session, &resource)
 }
 
 #[cfg(test)]
@@ -580,8 +614,8 @@ mod tests {
     use crate::attention::AttentionIndex;
     use crate::model::{AgentId, TargetSession};
     use crate::state::{
-        FederationState, NormalizedSnapshot, TargetConnectionState, TargetRuntimeState,
-        TargetUpdateMode,
+        AGENT_KEY_SEPARATOR, FederationState, NormalizedSnapshot, TargetConnectionState,
+        TargetRuntimeState, TargetUpdateMode,
     };
 
     /// A fixed clock. The projection reads one only to decide whether a
@@ -717,7 +751,7 @@ mod tests {
         let before = index.project(&first, &attention, &AgentMarks::default(), NOW);
         assert_eq!(
             order(&before.needs_you),
-            ["host-a/work/p1", "host-b/work/p9"]
+            [pane_key("host-a", "p1"), pane_key("host-b", "p9")]
         );
 
         // host-c arrives, and host-b's snapshot is refreshed without changing
@@ -735,7 +769,11 @@ mod tests {
 
         assert_eq!(
             order(&after.needs_you),
-            ["host-a/work/p1", "host-b/work/p9", "host-c/work/p1"],
+            [
+                pane_key("host-a", "p1"),
+                pane_key("host-b", "p9"),
+                pane_key("host-c", "p1")
+            ],
             "an arriving target appends and never reorders what was there"
         );
         assert_eq!(
@@ -774,7 +812,7 @@ mod tests {
 
         assert_eq!(
             order(&projection.needs_you),
-            ["host-a/work/p2", "host-a/work/p1"]
+            [pane_key("host-a", "p2"), pane_key("host-a", "p1")]
         );
     }
 
@@ -826,9 +864,9 @@ mod tests {
         )]);
         let projection = index.project(&after_move, &attention, &AgentMarks::default(), NOW);
 
-        assert_eq!(order(&projection.needs_you), ["host-a/work/p2"]);
+        assert_eq!(order(&projection.needs_you), [pane_key("host-a", "p2")]);
         assert_eq!(projection.recent.len(), 1);
-        let stale_card = AgentId::new("host-a", "work", "p1");
+        let stale_card = pane_agent("host-a", "p1");
         assert_eq!(
             AgentCardIndex::resolve(&stale_card, &after_move),
             Err(CardRouteError::AgentGone),
@@ -959,10 +997,7 @@ mod tests {
     #[test]
     fn refuses_a_card_for_a_target_that_is_not_in_the_federation() {
         assert_eq!(
-            AgentCardIndex::resolve(
-                &AgentId::new("host-gone", "work", "p1"),
-                &FederationState::default()
-            ),
+            AgentCardIndex::resolve(&pane_agent("host-gone", "p1"), &FederationState::default()),
             Err(CardRouteError::UnknownTarget)
         );
     }
@@ -977,9 +1012,11 @@ mod tests {
         let key = TargetSession::new("host-a", "work");
         state.targets.get_mut(&key).unwrap().connection_generation = 7;
 
-        let route = AgentCardIndex::resolve(&AgentId::new("host-a", "work", "p1"), &state).unwrap();
+        let route = AgentCardIndex::resolve(&pane_agent("host-a", "p1"), &state).unwrap();
 
         assert_eq!(route.generation, 7);
+        // The route is a pane, not an agent key: the identity is what the card
+        // carries, and the pane is what the daemon resolved it to now.
         assert_eq!(route.pane.to_string(), "host-a/work/p1");
     }
 
@@ -1046,7 +1083,7 @@ mod tests {
         assert_eq!(projection.recent.len(), MAX_HISTORY_CARDS);
         assert_eq!(
             projection.recent[0].agent.resource,
-            format!("p{}", MAX_HISTORY_CARDS + 9),
+            format!("pane{AGENT_KEY_SEPARATOR}p{}", MAX_HISTORY_CARDS + 9),
             "the newest departure is the first one a person sees"
         );
     }
@@ -1089,7 +1126,7 @@ mod tests {
 
         let mut marks = AgentMarks::default();
         marks.apply(
-            &AgentId::new("host-a", "work", "p2"),
+            &pane_agent("host-a", "p2"),
             AgentMarkRequest::Pin { pinned: true },
             NOW,
         );
@@ -1097,7 +1134,7 @@ mod tests {
 
         assert_eq!(
             order(&projection.needs_you),
-            ["host-a/work/p2", "host-a/work/p1"],
+            [pane_key("host-a", "p2"), pane_key("host-a", "p1")],
             "a pin is the one reorder a person actually asked for"
         );
         assert!(projection.needs_you[0].marks.pinned);
@@ -1113,7 +1150,7 @@ mod tests {
         )]);
         let mut marks = AgentMarks::default();
         marks.apply(
-            &AgentId::new("host-a", "work", "p1"),
+            &pane_agent("host-a", "p1"),
             AgentMarkRequest::Mute { muted: true },
             NOW,
         );
@@ -1147,21 +1184,223 @@ mod tests {
 
         let mut marks = AgentMarks::default();
         marks.apply(
-            &AgentId::new("host-a", "work", "p1"),
+            &pane_agent("host-a", "p1"),
             AgentMarkRequest::Snooze { minutes: Some(10) },
             NOW,
         );
         let quiet = index.project(&state, &attention, &marks, NOW);
-        assert_eq!(order(&quiet.needs_you), ["host-a/work/p2"]);
+        assert_eq!(order(&quiet.needs_you), [pane_key("host-a", "p2")]);
 
         marks.expire(NOW + 10 * 60_000);
         let awake = index.project(&state, &attention, &marks, NOW + 10 * 60_000);
 
         assert_eq!(
             order(&awake.needs_you),
-            ["host-a/work/p2", "host-a/work/p1"],
+            [pane_key("host-a", "p2"), pane_key("host-a", "p1")],
             "coming back is re-entering the queue, not reclaiming a place in it"
         );
+    }
+
+    #[test]
+    fn an_agent_that_reports_a_session_keeps_its_card_across_a_pane_move() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let before = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(session_snapshot("p1", "abc123")),
+        )]);
+        let first = index.project(&before, &attention, &AgentMarks::default(), NOW);
+        let identity = first.needs_you[0].agent.clone();
+
+        let after = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(session_snapshot("p2", "abc123")),
+        )]);
+        let moved = index.project(&after, &attention, &AgentMarks::default(), NOW);
+
+        assert_eq!(
+            moved
+                .needs_you
+                .iter()
+                .map(|card| &card.agent)
+                .collect::<Vec<_>>(),
+            vec![&identity],
+            "a move is the same agent somewhere else, not a death and a birth"
+        );
+        assert!(moved.recent.is_empty(), "nothing was retired");
+        let route = AgentCardIndex::resolve(&identity, &after).unwrap();
+        assert_eq!(
+            route.pane.resource, "p2",
+            "the identity resolves to where the agent is now"
+        );
+    }
+
+    #[test]
+    fn a_pin_follows_an_agent_that_moves_pane() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let before = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(session_snapshot("p1", "abc123")),
+        )]);
+        let identity = index
+            .project(&before, &attention, &AgentMarks::default(), NOW)
+            .needs_you[0]
+            .agent
+            .clone();
+        let mut marks = AgentMarks::default();
+        marks.apply(&identity, AgentMarkRequest::Pin { pinned: true }, NOW);
+
+        let after = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(session_snapshot("p2", "abc123")),
+        )]);
+        let moved = index.project(&after, &attention, &marks, NOW);
+
+        assert!(
+            moved.needs_you[0].marks.pinned,
+            "a pin belongs to the agent, not to the pane it happened to be in"
+        );
+    }
+
+    #[test]
+    fn two_agents_answering_to_one_identity_are_shown_and_not_offered() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(json!({
+                "workspaces": [],
+                "panes": [{"pane_id": "p1"}, {"pane_id": "p2"}],
+                "agents": [
+                    {"pane_id": "p1", "agent_status": "blocked", "agent_session": session("abc123")},
+                    {"pane_id": "p2", "agent_status": "blocked", "agent_session": session("abc123")}
+                ]
+            })),
+        )]);
+
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            &AgentMarks::default(),
+            NOW,
+        );
+
+        assert_eq!(projection.needs_you.len(), 1, "one identity is one card");
+        assert!(
+            !projection.needs_you[0].actionable,
+            "the daemon cannot say which pane an action would mean"
+        );
+        assert_eq!(
+            AgentCardIndex::resolve(&projection.needs_you[0].agent, &state),
+            Err(CardRouteError::Ambiguous)
+        );
+    }
+
+    #[test]
+    fn a_session_identity_never_collides_with_a_pane_of_the_same_name() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(json!({
+                "workspaces": [],
+                "panes": [{"pane_id": "p1"}, {"pane_id": "p2"}],
+                "agents": [
+                    {"pane_id": "p1", "agent_status": "blocked"},
+                    {"pane_id": "p2", "agent_status": "blocked", "agent_session": session("p1")}
+                ]
+            })),
+        )]);
+
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            &AgentMarks::default(),
+            NOW,
+        );
+
+        assert_eq!(projection.needs_you.len(), 2);
+        assert!(
+            projection.needs_you.iter().all(|card| card.actionable),
+            "a session value that reads like a pane id is still a different agent"
+        );
+    }
+
+    #[test]
+    fn an_incomplete_or_unsafe_session_reference_falls_back_to_the_pane() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(json!({
+                "workspaces": [],
+                "panes": [{"pane_id": "p1"}, {"pane_id": "p2"}],
+                "agents": [
+                    {
+                        "pane_id": "p1",
+                        "agent_status": "blocked",
+                        "agent_session": {"kind": "id", "value": "abc123"}
+                    },
+                    {
+                        "pane_id": "p2",
+                        "agent_status": "blocked",
+                        "agent_session": {
+                            "source": "herdr", "agent": "claude", "kind": "id",
+                            "value": "a\u{1f}b"
+                        }
+                    }
+                ]
+            })),
+        )]);
+
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            &AgentMarks::default(),
+            NOW,
+        );
+
+        assert_eq!(
+            order(&projection.needs_you),
+            vec![pane_key("host-a", "p1"), pane_key("host-a", "p2")],
+            "a partial record, or one carrying the key separator, is no record"
+        );
+    }
+
+    fn session(value: &str) -> Value {
+        json!({"source": "herdr", "agent": "claude", "kind": "id", "value": value})
+    }
+
+    fn session_snapshot(pane: &str, value: &str) -> Value {
+        json!({
+            "workspaces": [],
+            "panes": [{"pane_id": pane}],
+            "agents": [{
+                "pane_id": pane,
+                "agent_status": "blocked",
+                "agent_session": session(value)
+            }]
+        })
+    }
+
+    /// The identity a pane-keyed agent gets. Written out here rather than
+    /// hidden behind the production helper, so a test that asserts on identity
+    /// would notice the format changing under it.
+    fn pane_agent(target: &str, resource: &str) -> AgentId {
+        AgentId::new(
+            target,
+            "work",
+            &format!("pane{AGENT_KEY_SEPARATOR}{resource}"),
+        )
+    }
+
+    fn pane_key(target: &str, resource: &str) -> String {
+        pane_agent(target, resource).to_string()
     }
 
     fn titles(cards: &[super::AgentCard]) -> Vec<&str> {

--- a/src/agent_card.rs
+++ b/src/agent_card.rs
@@ -35,6 +35,7 @@ use std::collections::{BTreeMap, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
+use crate::agent_marks::{AgentMarkState, AgentMarks};
 use crate::attention::{AgentPhase, AttentionIndex, agent_phase, bounded_metadata};
 use crate::model::{AgentId, PaneId};
 use crate::state::{AgentState, FederationState, NormalizedSnapshot, TargetConnectionState};
@@ -137,6 +138,10 @@ pub struct AgentCard {
     /// the agent has not changed since the daemon started watching it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_change_ms: Option<u64>,
+    /// What a person marked on this card. Super-Herdr's own opinion, never
+    /// something that reached the host: see [`crate::agent_marks`].
+    #[serde(default)]
+    pub marks: AgentMarkState,
 }
 
 /// The whole inbox, in the order it should be rendered.
@@ -260,6 +265,8 @@ impl AgentCardIndex {
         &mut self,
         state: &FederationState,
         attention: &AttentionIndex,
+        marks: &AgentMarks,
+        now_ms: u64,
     ) -> AgentCardProjection {
         let mut seen = BTreeMap::new();
         for target in state.targets.values() {
@@ -269,7 +276,7 @@ impl AgentCardIndex {
             let live = target.connection == TargetConnectionState::Live;
             for agent in snapshot.agents.values() {
                 let id = agent_id(&agent.pane);
-                let card = self.build_card(agent, snapshot, attention, live);
+                let card = self.build_card(agent, snapshot, attention, live, marks, now_ms);
                 seen.insert(id, card);
             }
         }
@@ -414,13 +421,19 @@ impl AgentCardIndex {
             .values()
             .filter(|tracked| tracked.section == section)
             .collect::<Vec<_>>();
-        // The rank orders the section; the identity only breaks a tie, which
-        // two cards can reach when they entered in the same projection. Both
-        // keys are total, so the result is one order rather than whichever one
-        // the map happened to yield.
+        // Pinned first, then the rank, then the identity. Ordering by rank is
+        // what holds a card in place while unrelated targets churn; a pin is
+        // the one reorder a person actually asked for, so it is allowed to
+        // win. The identity only breaks a tie, which two cards reach when they
+        // entered in the same projection. All three keys are total, so the
+        // result is one order rather than whichever the map happened to yield.
         cards.sort_by(|left, right| {
-            left.rank
-                .cmp(&right.rank)
+            right
+                .card
+                .marks
+                .pinned
+                .cmp(&left.card.marks.pinned)
+                .then_with(|| left.rank.cmp(&right.rank))
                 .then_with(|| left.card.agent.cmp(&right.card.agent))
         });
         cards
@@ -449,6 +462,8 @@ impl AgentCardIndex {
         snapshot: &NormalizedSnapshot,
         attention: &AttentionIndex,
         live: bool,
+        marks: &AgentMarks,
+        now_ms: u64,
     ) -> AgentCard {
         let pane = snapshot.panes.get(&agent.pane);
         let status = bounded_metadata(
@@ -463,11 +478,21 @@ impl AgentCardIndex {
             &status,
             agent.interactive_ready.unwrap_or(false),
         ));
-        let section = match activity {
-            AgentActivity::NeedsInput => AgentCardSection::NeedsYou,
-            AgentActivity::Working => AgentCardSection::Working,
-            AgentActivity::Idle | AgentActivity::Unknown | AgentActivity::Gone => {
-                AgentCardSection::Recent
+        let marked = marks.state(&agent_id(&agent.pane));
+        // A muted or snoozed agent keeps its activity — it is still blocked,
+        // and saying otherwise would be a lie a person could act on — but it
+        // stops competing for the top of the inbox. Coming back is re-entering
+        // the queue: it takes a fresh place in the section rather than
+        // reclaiming the one it held before it was quieted.
+        let section = if marked.quiet_at(now_ms) {
+            AgentCardSection::Recent
+        } else {
+            match activity {
+                AgentActivity::NeedsInput => AgentCardSection::NeedsYou,
+                AgentActivity::Working => AgentCardSection::Working,
+                AgentActivity::Idle | AgentActivity::Unknown | AgentActivity::Gone => {
+                    AgentCardSection::Recent
+                }
             }
         };
         let workspace = pane
@@ -526,6 +551,7 @@ impl AgentCardIndex {
                 .rev()
                 .find(|event| event.pane == agent.pane)
                 .map(|event| event.occurred_at_ms),
+            marks: marked,
         }
     }
 }
@@ -550,12 +576,18 @@ mod tests {
     use super::{
         AgentActivity, AgentCardIndex, AgentCardSection, CardRouteError, MAX_HISTORY_CARDS,
     };
+    use crate::agent_marks::{AgentMarkRequest, AgentMarks};
     use crate::attention::AttentionIndex;
     use crate::model::{AgentId, TargetSession};
     use crate::state::{
         FederationState, NormalizedSnapshot, TargetConnectionState, TargetRuntimeState,
         TargetUpdateMode,
     };
+
+    /// A fixed clock. The projection reads one only to decide whether a
+    /// snooze has run out, so a test that is not about snoozing can hold it
+    /// still and stay a statement about the cards.
+    const NOW: u64 = 1_700_000_000_000;
 
     #[test]
     fn separates_the_agent_that_is_blocked_from_the_one_that_is_busy() {
@@ -577,7 +609,12 @@ mod tests {
             })),
         )]);
 
-        let projection = index.project(&state, &AttentionIndex::default());
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            &AgentMarks::default(),
+            NOW,
+        );
 
         assert_eq!(titles(&projection.needs_you), ["reviewer"]);
         assert_eq!(titles(&projection.working), ["builder"]);
@@ -602,7 +639,12 @@ mod tests {
             Some(agents_snapshot(&[("p1", "idle"), ("p2", "meditating")])),
         )]);
 
-        let projection = index.project(&state, &AttentionIndex::default());
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            &AgentMarks::default(),
+            NOW,
+        );
 
         assert!(projection.needs_you.is_empty());
         assert!(projection.working.is_empty());
@@ -633,7 +675,12 @@ mod tests {
             ),
         ]);
 
-        let projection = index.project(&state, &AttentionIndex::default());
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            &AgentMarks::default(),
+            NOW,
+        );
 
         assert_eq!(projection.needs_you.len(), 2);
         let targets = projection
@@ -667,7 +714,7 @@ mod tests {
                 Some(agents_snapshot(&[("p9", "blocked")])),
             ),
         ]);
-        let before = index.project(&first, &attention);
+        let before = index.project(&first, &attention, &AgentMarks::default(), NOW);
         assert_eq!(
             order(&before.needs_you),
             ["host-a/work/p1", "host-b/work/p9"]
@@ -684,7 +731,7 @@ mod tests {
                 Some(agents_snapshot(&[("p1", "blocked")])),
             ),
         );
-        let after = index.project(&second, &attention);
+        let after = index.project(&second, &attention, &AgentMarks::default(), NOW);
 
         assert_eq!(
             order(&after.needs_you),
@@ -698,7 +745,7 @@ mod tests {
         );
 
         // A refresh that changes nothing at all publishes nothing at all.
-        let unchanged = index.project(&second, &attention);
+        let unchanged = index.project(&second, &attention, &AgentMarks::default(), NOW);
         assert_eq!(unchanged.revision, after.revision);
         assert_eq!(unchanged.needs_you, after.needs_you);
     }
@@ -712,7 +759,7 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked"), ("p2", "blocked")])),
         )]);
-        index.project(&blocked_pair, &attention);
+        index.project(&blocked_pair, &attention, &AgentMarks::default(), NOW);
 
         // p1 is answered and starts working, then blocks again. It is now the
         // most recently blocked agent, so it queues behind p2 rather than
@@ -722,8 +769,8 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "working"), ("p2", "blocked")])),
         )]);
-        index.project(&answered, &attention);
-        let projection = index.project(&blocked_pair, &attention);
+        index.project(&answered, &attention, &AgentMarks::default(), NOW);
+        let projection = index.project(&blocked_pair, &attention, &AgentMarks::default(), NOW);
 
         assert_eq!(
             order(&projection.needs_you),
@@ -740,14 +787,14 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked")])),
         )]);
-        index.project(&running, &attention);
+        index.project(&running, &attention, &AgentMarks::default(), NOW);
 
         let ended = federation(vec![(
             "host-a",
             TargetConnectionState::Live,
             Some(agents_snapshot(&[])),
         )]);
-        let projection = index.project(&ended, &attention);
+        let projection = index.project(&ended, &attention, &AgentMarks::default(), NOW);
 
         assert!(projection.needs_you.is_empty());
         assert_eq!(projection.recent.len(), 1);
@@ -770,14 +817,14 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked")])),
         )]);
-        index.project(&before, &attention);
+        index.project(&before, &attention, &AgentMarks::default(), NOW);
 
         let after_move = federation(vec![(
             "host-a",
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p2", "blocked")])),
         )]);
-        let projection = index.project(&after_move, &attention);
+        let projection = index.project(&after_move, &attention, &AgentMarks::default(), NOW);
 
         assert_eq!(order(&projection.needs_you), ["host-a/work/p2"]);
         assert_eq!(projection.recent.len(), 1);
@@ -800,7 +847,7 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked")])),
         )]);
-        index.project(&live, &attention);
+        index.project(&live, &attention, &AgentMarks::default(), NOW);
 
         // Disconnected, but the last snapshot is retained: the agent is
         // probably still there, and emptying the inbox on a flapping link
@@ -810,7 +857,7 @@ mod tests {
             TargetConnectionState::Backoff { attempt: 1 },
             Some(agents_snapshot(&[("p1", "blocked")])),
         )]);
-        let projection = index.project(&dropped, &attention);
+        let projection = index.project(&dropped, &attention, &AgentMarks::default(), NOW);
 
         assert_eq!(projection.needs_you.len(), 1);
         let card = &projection.needs_you[0];
@@ -837,11 +884,15 @@ mod tests {
                 Some(agents_snapshot(&[("p1", "blocked")])),
             )]),
             &attention,
+            &AgentMarks::default(),
+            NOW,
         );
 
         let projection = index.project(
             &federation(vec![("host-a", TargetConnectionState::Connecting, None)]),
             &attention,
+            &AgentMarks::default(),
+            NOW,
         );
 
         assert_eq!(projection.needs_you.len(), 1);
@@ -860,9 +911,16 @@ mod tests {
                 Some(agents_snapshot(&[("p1", "blocked")])),
             )]),
             &attention,
+            &AgentMarks::default(),
+            NOW,
         );
 
-        let projection = index.project(&FederationState::default(), &attention);
+        let projection = index.project(
+            &FederationState::default(),
+            &attention,
+            &AgentMarks::default(),
+            NOW,
+        );
 
         assert!(
             projection.is_empty(),
@@ -883,7 +941,12 @@ mod tests {
             })),
         )]);
 
-        let projection = index.project(&state, &AttentionIndex::default());
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            &AgentMarks::default(),
+            NOW,
+        );
 
         assert_eq!(projection.needs_you.len(), 1);
         assert!(!projection.needs_you[0].actionable);
@@ -938,7 +1001,12 @@ mod tests {
             })),
         )]);
 
-        let projection = index.project(&state, &AttentionIndex::default());
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            &AgentMarks::default(),
+            NOW,
+        );
         let card = projection.cards().next().unwrap();
 
         assert_eq!(card.title.chars().count(), 128);
@@ -960,6 +1028,8 @@ mod tests {
                     Some(agents_snapshot(&[(name.as_str(), "blocked")])),
                 )]),
                 &attention,
+                &AgentMarks::default(),
+                NOW,
             );
         }
         let projection = index.project(
@@ -969,6 +1039,8 @@ mod tests {
                 Some(agents_snapshot(&[])),
             )]),
             &attention,
+            &AgentMarks::default(),
+            NOW,
         );
 
         assert_eq!(projection.recent.len(), MAX_HISTORY_CARDS);
@@ -995,12 +1067,101 @@ mod tests {
         )]);
         attention.observe(&blocked);
 
-        let projection = AgentCardIndex::default().project(&blocked, &attention);
+        let projection =
+            AgentCardIndex::default().project(&blocked, &attention, &AgentMarks::default(), NOW);
 
         assert!(projection.needs_you[0].unread);
         assert!(projection.needs_you[0].last_change_ms.is_some());
         assert!(!projection.recent[0].unread);
         assert!(projection.recent[0].last_change_ms.is_none());
+    }
+
+    #[test]
+    fn a_pin_lifts_a_card_to_the_top_of_its_section() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked"), ("p2", "blocked")])),
+        )]);
+        index.project(&state, &attention, &AgentMarks::default(), NOW);
+
+        let mut marks = AgentMarks::default();
+        marks.apply(
+            &AgentId::new("host-a", "work", "p2"),
+            AgentMarkRequest::Pin { pinned: true },
+            NOW,
+        );
+        let projection = index.project(&state, &attention, &marks, NOW);
+
+        assert_eq!(
+            order(&projection.needs_you),
+            ["host-a/work/p2", "host-a/work/p1"],
+            "a pin is the one reorder a person actually asked for"
+        );
+        assert!(projection.needs_you[0].marks.pinned);
+    }
+
+    #[test]
+    fn a_mute_stops_an_agent_competing_for_the_top_without_denying_it_is_blocked() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked")])),
+        )]);
+        let mut marks = AgentMarks::default();
+        marks.apply(
+            &AgentId::new("host-a", "work", "p1"),
+            AgentMarkRequest::Mute { muted: true },
+            NOW,
+        );
+
+        let projection = index.project(&state, &AttentionIndex::default(), &marks, NOW);
+
+        assert!(projection.needs_you.is_empty());
+        assert_eq!(projection.recent.len(), 1);
+        assert_eq!(
+            projection.recent[0].activity,
+            AgentActivity::NeedsInput,
+            "the agent is still blocked, and saying otherwise would be a lie"
+        );
+        assert!(projection.recent[0].marks.muted);
+        assert!(
+            projection.recent[0].actionable,
+            "a muted agent is quiet, not unreachable"
+        );
+    }
+
+    #[test]
+    fn a_snooze_quiets_an_agent_until_it_runs_out() {
+        let mut index = AgentCardIndex::default();
+        let attention = AttentionIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(agents_snapshot(&[("p1", "blocked"), ("p2", "blocked")])),
+        )]);
+        index.project(&state, &attention, &AgentMarks::default(), NOW);
+
+        let mut marks = AgentMarks::default();
+        marks.apply(
+            &AgentId::new("host-a", "work", "p1"),
+            AgentMarkRequest::Snooze { minutes: Some(10) },
+            NOW,
+        );
+        let quiet = index.project(&state, &attention, &marks, NOW);
+        assert_eq!(order(&quiet.needs_you), ["host-a/work/p2"]);
+
+        marks.expire(NOW + 10 * 60_000);
+        let awake = index.project(&state, &attention, &marks, NOW + 10 * 60_000);
+
+        assert_eq!(
+            order(&awake.needs_you),
+            ["host-a/work/p2", "host-a/work/p1"],
+            "coming back is re-entering the queue, not reclaiming a place in it"
+        );
     }
 
     fn titles(cards: &[super::AgentCard]) -> Vec<&str> {

--- a/src/agent_marks.rs
+++ b/src/agent_marks.rs
@@ -1,0 +1,512 @@
+//! What a person marked on an agent card: pins, mutes, and snoozes.
+//!
+//! These are Super-Herdr's own opinions about someone's inbox, and they are
+//! deliberately not Herdr's. Pinning an agent does not rename, move, focus, or
+//! otherwise touch the pane it runs in; muting one does not stop it working or
+//! change what its target reports. Nothing here crosses back to a host, so a
+//! mark can never be the reason a session behaves differently.
+//!
+//! They are keyed by [`AgentId`], the same qualified identity the cards use, so
+//! pinning an agent on one host cannot silence a same-named agent on another.
+//! The file is bounded in every direction — how many agents may be marked, how
+//! large it may be on disk, how far ahead a snooze may reach — because it is
+//! written by a request from a paired device and a device should not be able to
+//! grow a file on somebody's desktop without limit.
+//!
+//! A snooze is stored as a deadline the daemon computed from its own clock. A
+//! client asks for a duration, never a moment: a phone with a wrong clock would
+//! otherwise be able to snooze an agent until next year, and the daemon has no
+//! way to tell that from a deliberate request.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::attention::{set_directory_permissions, set_file_permissions};
+use crate::model::AgentId;
+
+const AGENT_MARKS_VERSION: u32 = 1;
+const MAX_AGENT_MARKS_BYTES: u64 = 256 * 1024;
+
+/// How many agents may carry a mark at once.
+///
+/// Marks are per-agent and a person only has so many agents; the cap is here
+/// so a paired device cannot make the file grow forever, and it is enforced by
+/// forgetting the least recently touched mark rather than by refusing the
+/// request, which would strand a person who genuinely reached the limit.
+const MAX_MARKED_AGENTS: usize = 512;
+
+/// The longest a snooze may run. Long enough to cover a working day, short
+/// enough that a forgotten snooze surfaces again by itself.
+pub const MAX_SNOOZE_MINUTES: u32 = 24 * 60;
+
+/// One agent's marks. All-default means "not marked", which is why an unmarked
+/// agent costs nothing to describe and nothing to store.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentMarkState {
+    pub pinned: bool,
+    pub muted: bool,
+    /// When a snooze ends, as daemon-computed wall-clock milliseconds. Absent
+    /// means not snoozed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snoozed_until_ms: Option<u64>,
+}
+
+impl AgentMarkState {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    pub fn snoozed_at(&self, now_ms: u64) -> bool {
+        self.snoozed_until_ms
+            .is_some_and(|deadline| deadline > now_ms)
+    }
+
+    /// Whether this agent should stop competing for the top of the inbox.
+    pub fn quiet_at(&self, now_ms: u64) -> bool {
+        self.muted || self.snoozed_at(now_ms)
+    }
+}
+
+/// What a client asks for. A duration rather than a deadline, and a boolean
+/// rather than a toggle, so the same request twice reaches the same state
+/// instead of undoing itself when one of them is retried.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentMarkRequest {
+    Pin {
+        pinned: bool,
+    },
+    Mute {
+        muted: bool,
+    },
+    /// `None` clears a snooze. A duration beyond [`MAX_SNOOZE_MINUTES`] is
+    /// clamped rather than refused: the person meant "for a long time", and
+    /// the bound is the daemon's business rather than an error to explain.
+    Snooze {
+        minutes: Option<u32>,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AgentMarks {
+    marks: BTreeMap<AgentId, Marked>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Marked {
+    state: AgentMarkState,
+    /// When this mark was last set, used only to decide what to forget first
+    /// when the cap is reached.
+    touched_ms: u64,
+}
+
+impl AgentMarks {
+    /// Apply one request. Returns whether anything changed, so the daemon can
+    /// skip a persist and a republish for a request that asked for the state
+    /// the agent was already in.
+    pub fn apply(&mut self, agent: &AgentId, request: AgentMarkRequest, now_ms: u64) -> bool {
+        let mut state = self.state(agent);
+        match request {
+            AgentMarkRequest::Pin { pinned } => state.pinned = pinned,
+            AgentMarkRequest::Mute { muted } => state.muted = muted,
+            AgentMarkRequest::Snooze { minutes } => {
+                state.snoozed_until_ms = minutes.map(|minutes| {
+                    let bounded = u64::from(minutes.min(MAX_SNOOZE_MINUTES));
+                    now_ms.saturating_add(bounded.saturating_mul(60_000))
+                });
+            }
+        }
+        if state == self.state(agent) {
+            return false;
+        }
+        if state.is_default() {
+            self.marks.remove(agent);
+        } else {
+            self.marks.insert(
+                agent.clone(),
+                Marked {
+                    state,
+                    touched_ms: now_ms,
+                },
+            );
+            self.enforce_cap();
+        }
+        true
+    }
+
+    pub fn state(&self, agent: &AgentId) -> AgentMarkState {
+        self.marks
+            .get(agent)
+            .map(|marked| marked.state)
+            .unwrap_or_default()
+    }
+
+    /// Drop snoozes that have run out, so an expired one stops being carried
+    /// in the file and in every projection built from it. Returns whether
+    /// anything changed.
+    pub fn expire(&mut self, now_ms: u64) -> bool {
+        let expired = self
+            .marks
+            .iter()
+            .filter(|(_, marked)| {
+                marked
+                    .state
+                    .snoozed_until_ms
+                    .is_some_and(|deadline| deadline <= now_ms)
+            })
+            .map(|(agent, _)| agent.clone())
+            .collect::<Vec<_>>();
+        if expired.is_empty() {
+            return false;
+        }
+        for agent in expired {
+            let Some(marked) = self.marks.get_mut(&agent) else {
+                continue;
+            };
+            marked.state.snoozed_until_ms = None;
+            if marked.state.is_default() {
+                self.marks.remove(&agent);
+            }
+        }
+        true
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.marks.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.marks.len()
+    }
+
+    fn enforce_cap(&mut self) {
+        while self.marks.len() > MAX_MARKED_AGENTS {
+            let Some(oldest) = self
+                .marks
+                .iter()
+                .min_by_key(|(agent, marked)| (marked.touched_ms, (*agent).clone()))
+                .map(|(agent, _)| agent.clone())
+            else {
+                break;
+            };
+            self.marks.remove(&oldest);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedMark {
+    agent: AgentId,
+    #[serde(flatten)]
+    state: AgentMarkState,
+    touched_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedMarks {
+    version: u32,
+    marks: Vec<PersistedMark>,
+}
+
+impl From<&AgentMarks> for PersistedMarks {
+    fn from(marks: &AgentMarks) -> Self {
+        Self {
+            version: AGENT_MARKS_VERSION,
+            marks: marks
+                .marks
+                .iter()
+                .map(|(agent, marked)| PersistedMark {
+                    agent: agent.clone(),
+                    state: marked.state,
+                    touched_ms: marked.touched_ms,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<PersistedMarks> for AgentMarks {
+    type Error = anyhow::Error;
+
+    fn try_from(persisted: PersistedMarks) -> Result<Self> {
+        if persisted.version != AGENT_MARKS_VERSION {
+            bail!("persisted agent marks have an unsupported version");
+        }
+        if persisted.marks.len() > MAX_MARKED_AGENTS {
+            bail!("persisted agent marks name too many agents");
+        }
+        let mut marks = BTreeMap::new();
+        for held in persisted.marks {
+            if marks
+                .insert(
+                    held.agent,
+                    Marked {
+                        state: held.state,
+                        touched_ms: held.touched_ms,
+                    },
+                )
+                .is_some()
+            {
+                bail!("persisted agent marks name one agent twice");
+            }
+        }
+        Ok(Self { marks })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentMarkStore {
+    path: PathBuf,
+}
+
+impl AgentMarkStore {
+    pub fn discover() -> Result<Self> {
+        let root = if let Some(root) = env::var_os("XDG_STATE_HOME") {
+            PathBuf::from(root)
+        } else {
+            let home: OsString = env::var_os("HOME")
+                .context("XDG_STATE_HOME or HOME is required to persist Super-Herdr agent marks")?;
+            PathBuf::from(home).join(".local/state")
+        };
+        Ok(Self {
+            path: root.join("super-herdr/agent-marks.json"),
+        })
+    }
+
+    pub fn at(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn load(&self) -> Result<AgentMarks> {
+        let metadata = match fs::metadata(&self.path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(AgentMarks::default());
+            }
+            Err(error) => return Err(error).context("failed to inspect agent marks"),
+        };
+        if metadata.len() > MAX_AGENT_MARKS_BYTES {
+            bail!("persisted agent marks exceed the size limit");
+        }
+        let bytes = fs::read(&self.path).context("failed to read agent marks")?;
+        let persisted: PersistedMarks =
+            serde_json::from_slice(&bytes).context("persisted agent marks are invalid")?;
+        persisted.try_into()
+    }
+
+    pub fn save(&self, marks: &AgentMarks) -> Result<()> {
+        let directory = self
+            .path
+            .parent()
+            .context("agent marks path has no parent directory")?;
+        fs::create_dir_all(directory).context("failed to create the agent marks directory")?;
+        set_directory_permissions(directory)?;
+        let mut temporary = tempfile::Builder::new()
+            .prefix(".agent-marks-")
+            .tempfile_in(directory)
+            .context("failed to create a temporary agent marks file")?;
+        set_file_permissions(temporary.path())?;
+        serde_json::to_writer(&mut temporary, &PersistedMarks::from(marks))
+            .context("failed to encode agent marks")?;
+        temporary
+            .write_all(b"\n")
+            .context("failed to finish agent marks")?;
+        if temporary
+            .as_file()
+            .metadata()
+            .context("failed to inspect encoded agent marks")?
+            .len()
+            > MAX_AGENT_MARKS_BYTES
+        {
+            bail!("encoded agent marks exceed the size limit");
+        }
+        temporary
+            .as_file()
+            .sync_all()
+            .context("failed to synchronize agent marks")?;
+        temporary
+            .persist(&self.path)
+            .context("failed to atomically replace agent marks")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AgentMarkRequest, AgentMarkStore, AgentMarks, MAX_MARKED_AGENTS, MAX_SNOOZE_MINUTES,
+    };
+    use crate::model::AgentId;
+
+    const NOW: u64 = 1_700_000_000_000;
+
+    #[test]
+    fn marks_one_agent_without_touching_its_namesake_on_another_host() {
+        let mut marks = AgentMarks::default();
+        let here = AgentId::new("host-a", "work", "p1");
+        let there = AgentId::new("host-b", "work", "p1");
+
+        assert!(marks.apply(&here, AgentMarkRequest::Pin { pinned: true }, NOW));
+
+        assert!(marks.state(&here).pinned);
+        assert!(!marks.state(&there).pinned);
+    }
+
+    #[test]
+    fn reports_a_request_that_changes_nothing() {
+        let mut marks = AgentMarks::default();
+        let agent = AgentId::new("host-a", "work", "p1");
+
+        assert!(marks.apply(&agent, AgentMarkRequest::Mute { muted: true }, NOW));
+        assert!(!marks.apply(&agent, AgentMarkRequest::Mute { muted: true }, NOW));
+    }
+
+    #[test]
+    fn forgets_an_agent_whose_marks_are_all_cleared() {
+        let mut marks = AgentMarks::default();
+        let agent = AgentId::new("host-a", "work", "p1");
+        marks.apply(&agent, AgentMarkRequest::Pin { pinned: true }, NOW);
+
+        marks.apply(&agent, AgentMarkRequest::Pin { pinned: false }, NOW);
+
+        assert!(
+            marks.is_empty(),
+            "an unmarked agent should cost nothing to store"
+        );
+    }
+
+    #[test]
+    fn turns_a_requested_duration_into_a_deadline_the_daemon_owns() {
+        let mut marks = AgentMarks::default();
+        let agent = AgentId::new("host-a", "work", "p1");
+
+        marks.apply(&agent, AgentMarkRequest::Snooze { minutes: Some(30) }, NOW);
+
+        assert_eq!(
+            marks.state(&agent).snoozed_until_ms,
+            Some(NOW + 30 * 60_000)
+        );
+        assert!(marks.state(&agent).snoozed_at(NOW));
+        assert!(!marks.state(&agent).snoozed_at(NOW + 31 * 60_000));
+    }
+
+    #[test]
+    fn clamps_a_snooze_that_reaches_further_than_a_day() {
+        let mut marks = AgentMarks::default();
+        let agent = AgentId::new("host-a", "work", "p1");
+
+        marks.apply(
+            &agent,
+            AgentMarkRequest::Snooze {
+                minutes: Some(u32::MAX),
+            },
+            NOW,
+        );
+
+        assert_eq!(
+            marks.state(&agent).snoozed_until_ms,
+            Some(NOW + u64::from(MAX_SNOOZE_MINUTES) * 60_000),
+            "a wrong clock on a phone must not silence an agent for a year"
+        );
+    }
+
+    #[test]
+    fn expires_a_snooze_that_has_run_out_and_keeps_the_rest() {
+        let mut marks = AgentMarks::default();
+        let expiring = AgentId::new("host-a", "work", "p1");
+        let pinned = AgentId::new("host-a", "work", "p2");
+        marks.apply(
+            &expiring,
+            AgentMarkRequest::Snooze { minutes: Some(5) },
+            NOW,
+        );
+        marks.apply(&pinned, AgentMarkRequest::Pin { pinned: true }, NOW);
+
+        assert!(!marks.expire(NOW));
+        assert!(marks.expire(NOW + 5 * 60_000));
+
+        assert!(marks.state(&expiring).snoozed_until_ms.is_none());
+        assert!(
+            marks.is_empty() || marks.state(&pinned).pinned,
+            "expiring one mark must not clear another"
+        );
+        assert_eq!(marks.len(), 1);
+    }
+
+    #[test]
+    fn keeps_a_snooze_alongside_a_pin_on_the_same_agent() {
+        let mut marks = AgentMarks::default();
+        let agent = AgentId::new("host-a", "work", "p1");
+        marks.apply(&agent, AgentMarkRequest::Pin { pinned: true }, NOW);
+
+        marks.apply(&agent, AgentMarkRequest::Snooze { minutes: Some(5) }, NOW);
+        marks.expire(NOW + 5 * 60_000);
+
+        assert!(marks.state(&agent).pinned);
+        assert!(!marks.state(&agent).snoozed_at(NOW + 5 * 60_000));
+    }
+
+    #[test]
+    fn forgets_the_least_recently_marked_agent_rather_than_refusing_a_request() {
+        let mut marks = AgentMarks::default();
+        for index in 0..=MAX_MARKED_AGENTS {
+            let agent = AgentId::new("host-a", "work", &format!("p{index}"));
+            marks.apply(
+                &agent,
+                AgentMarkRequest::Pin { pinned: true },
+                NOW + index as u64,
+            );
+        }
+
+        assert_eq!(marks.len(), MAX_MARKED_AGENTS);
+        assert!(!marks.state(&AgentId::new("host-a", "work", "p0")).pinned);
+        assert!(
+            marks
+                .state(&AgentId::new(
+                    "host-a",
+                    "work",
+                    &format!("p{MAX_MARKED_AGENTS}")
+                ))
+                .pinned,
+            "the newest request is the one that survives"
+        );
+    }
+
+    #[test]
+    fn round_trips_marks_through_a_bounded_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = AgentMarkStore::at(directory.path().join("agent-marks.json"));
+        let mut marks = AgentMarks::default();
+        let agent = AgentId::new("host-a", "work", "p1");
+        marks.apply(&agent, AgentMarkRequest::Pin { pinned: true }, NOW);
+        marks.apply(&agent, AgentMarkRequest::Snooze { minutes: Some(10) }, NOW);
+
+        store.save(&marks).unwrap();
+        let restored = store.load().unwrap();
+
+        assert_eq!(restored, marks);
+        assert!(restored.state(&agent).pinned);
+        assert_eq!(
+            restored.state(&agent).snoozed_until_ms,
+            Some(NOW + 10 * 60_000)
+        );
+    }
+
+    #[test]
+    fn treats_a_missing_file_as_nothing_marked() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = AgentMarkStore::at(directory.path().join("absent.json"));
+
+        assert!(store.load().unwrap().is_empty());
+    }
+}

--- a/src/agent_marks.rs
+++ b/src/agent_marks.rs
@@ -31,7 +31,12 @@ use serde::{Deserialize, Serialize};
 use crate::attention::{set_directory_permissions, set_file_permissions};
 use crate::model::AgentId;
 
-const AGENT_MARKS_VERSION: u32 = 1;
+/// Bumped with the agent key format. A mark is stored against an identity, so
+/// a file written before the keys changed names agents that no longer exist —
+/// silently keeping it would leave pins attached to nothing and no way to see
+/// why. Refusing it starts from nothing marked instead, which is recoverable
+/// in one tap.
+const AGENT_MARKS_VERSION: u32 = 2;
 const MAX_AGENT_MARKS_BYTES: u64 = 256 * 1024;
 
 /// How many agents may carry a mark at once.

--- a/src/attention.rs
+++ b/src/attention.rs
@@ -321,7 +321,7 @@ pub(crate) fn agent_phase(status: &str, interactive_ready: bool) -> AgentPhase {
     }
 }
 
-fn unix_time_ms() -> u64 {
+pub(crate) fn unix_time_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
@@ -483,26 +483,26 @@ impl AttentionStore {
 }
 
 #[cfg(unix)]
-fn set_directory_permissions(path: &Path) -> Result<()> {
+pub(crate) fn set_directory_permissions(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     fs::set_permissions(path, fs::Permissions::from_mode(0o700))
         .context("failed to secure the attention state directory")
 }
 
 #[cfg(not(unix))]
-fn set_directory_permissions(_path: &Path) -> Result<()> {
+pub(crate) fn set_directory_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
 #[cfg(unix)]
-fn set_file_permissions(path: &Path) -> Result<()> {
+pub(crate) fn set_file_permissions(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     fs::set_permissions(path, fs::Permissions::from_mode(0o600))
         .context("failed to secure the attention state file")
 }
 
 #[cfg(not(unix))]
-fn set_file_permissions(_path: &Path) -> Result<()> {
+pub(crate) fn set_file_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 

--- a/src/attention.rs
+++ b/src/attention.rs
@@ -63,7 +63,7 @@ struct AgentObservation {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AgentPhase {
+pub(crate) enum AgentPhase {
     Attention,
     Working,
     Idle,
@@ -298,7 +298,7 @@ fn transition_kind(
     })
 }
 
-fn agent_phase(status: &str, interactive_ready: bool) -> AgentPhase {
+pub(crate) fn agent_phase(status: &str, interactive_ready: bool) -> AgentPhase {
     if interactive_ready
         || matches!(
             status.to_ascii_lowercase().as_str(),
@@ -330,7 +330,7 @@ fn unix_time_ms() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
-fn bounded_metadata(value: &str, maximum_characters: usize) -> String {
+pub(crate) fn bounded_metadata(value: &str, maximum_characters: usize) -> String {
     value
         .chars()
         .map(|character| {

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,8 +21,9 @@ use tokio::net::UnixStream;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
+use crate::agent_marks::AgentMarkRequest;
 use crate::daemon::server::DaemonHandle;
-use crate::model::{PaneId, TargetSession};
+use crate::model::{AgentId, PaneId, TargetSession};
 use crate::operation::Operation;
 use crate::plugin::PluginRunId;
 use crate::protocol::{
@@ -203,6 +204,10 @@ impl Client {
 
     pub fn subscribe_state(&self) {
         self.commands.subscribe_state();
+    }
+
+    pub fn subscribe_agent_cards(&self) {
+        self.commands.subscribe_agent_cards();
     }
 }
 
@@ -454,6 +459,22 @@ impl ClientCommands {
         self.send(ClientMessage::DecidePairing { attempt, approve });
     }
 
+    /// Pin, mute, or snooze one agent. Super-Herdr's own inbox state; nothing
+    /// here reaches the host.
+    pub fn mark_agent(&self, agent: AgentId, mark: AgentMarkRequest) -> u64 {
+        let request = self.next_request();
+        self.send(ClientMessage::MarkAgent {
+            request,
+            agent,
+            mark,
+        });
+        request
+    }
+
+    pub fn subscribe_agent_cards(&self) {
+        self.send(ClientMessage::SubscribeAgentCards);
+    }
+
     pub fn mark_attention_seen(&self, pane: PaneId) {
         self.send(ClientMessage::MarkAttentionSeen { pane });
     }
@@ -515,6 +536,7 @@ mod tests {
         let options = DaemonOptions {
             // No socket is bound in this mode; the path is never used.
             socket: directory.path().join("unused.sock"),
+            agent_marks: None,
             attention_state: Some(directory.path().join("attention.json")),
             refresh_interval: Duration::from_secs(3600),
             web_port: None,

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -91,6 +91,25 @@
     padding: .35rem .7rem; cursor: pointer;
   }
   button:disabled { color: var(--dim); cursor: default; opacity: .6; }
+  .inbox-head { display: flex; align-items: baseline; gap: .6rem; }
+  .inbox-head h2 { margin: 0; }
+  .chips { display: flex; flex-wrap: wrap; gap: .35rem; margin: .6rem 0 .2rem; }
+  .chip {
+    background: var(--panel); color: var(--ink); border: 1px solid var(--line);
+    border-radius: 999px; padding: .35rem .7rem; font-size: .82rem;
+    min-height: 2.1rem; cursor: pointer;
+  }
+  .chip[aria-pressed="true"] { border-color: var(--work); color: var(--work); }
+  .inbox-section { margin-top: .9rem; }
+  .inbox-title { display: flex; gap: .5rem; align-items: baseline; color: var(--dim); font-size: .78rem; margin: .35rem 0; }
+  .card {
+    display: block; width: 100%; text-align: left; background: var(--panel);
+    color: var(--ink); border: 1px solid var(--line); border-radius: .6rem;
+    padding: .6rem .7rem; margin-top: .35rem; min-height: 3rem;
+  }
+  .card + .card { margin-top: .35rem; }
+  .card[aria-disabled="true"] { color: var(--dim); }
+  .card-meta { display: flex; gap: .4rem; color: var(--dim); font-size: .78rem; margin-top: .25rem; }
   .actions { display: flex; gap: .5rem; margin-top: .7rem; }
   #line {
     flex: 1; min-width: 0; padding: .5rem .6rem; font: inherit;
@@ -239,8 +258,20 @@
   <p class="note" id="pair-error"></p>
 </section>
 <main hidden>
-  <h2>Terminals</h2>
-  <ul id="panes"><li class="empty">no panes</li></ul>
+  <section id="inbox" aria-label="Agent inbox">
+    <div class="inbox-head">
+      <h2>Agents</h2>
+      <span id="inbox-count" class="note"></span>
+    </div>
+    <div id="inbox-filters" class="chips" role="group" aria-label="Filter agents"></div>
+    <div id="inbox-sections"></div>
+    <p id="inbox-empty" class="empty">waiting for the daemon…</p>
+  </section>
+
+  <details id="hierarchy">
+    <summary>All targets and panes</summary>
+    <ul id="panes"><li class="empty">no panes</li></ul>
+  </details>
 
   <details id="attention-panel">
     <summary>Attention <span id="attention-count" class="badge gone">none</span></summary>
@@ -1125,6 +1156,167 @@ function resync() {
   subscribeScreen(pane);
 }
 
+// The inbox exactly as the daemon built it. This page renders that answer and
+// never derives a second one: sections and ordering are the daemon's, so a
+// person moving between the TUI and this phone reads one inbox rather than two
+// views that disagree the moment a snapshot is a refresh apart.
+let inbox = null;
+// What is being shown of it. A filter is a view, never a different request:
+// hiding a card here does not change what the daemon sends or what it holds,
+// so a filtered-out agent that starts waiting is still one chip away.
+const filters = { state: 'all', target: 'all', provider: 'all' };
+
+const INBOX_SECTIONS = [
+  { key: 'needs_you', title: 'Needs you' },
+  { key: 'working', title: 'Working' },
+  { key: 'recent', title: 'Recent' },
+];
+
+function inboxCards() {
+  if (!inbox) return [];
+  return INBOX_SECTIONS.flatMap(section => inbox[section.key] || []);
+}
+
+function matchesFilters(card, section) {
+  if (filters.state === 'needs_you' && section !== 'needs_you') return false;
+  if (filters.state === 'working' && section !== 'working') return false;
+  if (filters.target !== 'all' && text(card.agent && card.agent.target) !== filters.target) {
+    return false;
+  }
+  return !(filters.provider !== 'all' && text(card.provider) !== filters.provider);
+}
+
+function chip(label, group, value, container) {
+  const button = document.createElement('button');
+  button.className = 'chip';
+  button.type = 'button';
+  button.textContent = label;
+  button.dataset.group = group;
+  button.dataset.value = value;
+  button.setAttribute('aria-pressed', filters[group] === value ? 'true' : 'false');
+  button.onclick = () => {
+    filters[group] = value;
+    renderInbox();
+  };
+  container.append(button);
+}
+
+function renderFilters() {
+  const strip = el('inbox-filters');
+  strip.innerHTML = '';
+  const cards = inboxCards();
+  chip('All', 'state', 'all', strip);
+  chip('Needs you', 'state', 'needs_you', strip);
+  chip('Working', 'state', 'working', strip);
+
+  // A chip for a dimension with one value would be a control that cannot
+  // change anything, so the row appears only once there is a choice to make.
+  const targetNames = [...new Set(cards.map(card => text(card.agent && card.agent.target)))]
+    .filter(Boolean).sort();
+  if (targetNames.length > 1) {
+    chip('All hosts', 'target', 'all', strip);
+    for (const name of targetNames) chip(name, 'target', name, strip);
+  } else if (filters.target !== 'all') {
+    filters.target = 'all';
+  }
+
+  const providers = [...new Set(cards.map(card => text(card.provider)))].filter(Boolean).sort();
+  if (providers.length > 1) {
+    chip('Any agent', 'provider', 'all', strip);
+    for (const name of providers) chip(name, 'provider', name, strip);
+  } else if (filters.provider !== 'all') {
+    filters.provider = 'all';
+  }
+}
+
+function renderCard(card, section) {
+  const item = document.createElement('button');
+  item.className = 'card';
+  item.type = 'button';
+  item.dataset.agent = paneKey(card.agent);
+  item.dataset.section = section;
+  if (card.unread) item.classList.add('unread');
+  const row = document.createElement('div');
+  row.className = 'row';
+  const name = document.createElement('span');
+  name.className = 'name';
+  name.textContent = text(card.title) || 'agent';
+  const badge = document.createElement('span');
+  badge.className = 'badge';
+  badge.textContent = text(card.status) || 'unknown';
+  badge.classList.add(card.stale ? 'gone' : phase(text(card.status)));
+  row.append(name, badge);
+  const meta = document.createElement('div');
+  meta.className = 'card-meta';
+  const where = document.createElement('span');
+  // The host and Herdr session are named on every card, because the whole
+  // reason to qualify an identity is undone if a person cannot see which
+  // machine they are about to type into.
+  where.textContent = [
+    text(card.agent && card.agent.target),
+    text(card.agent && card.agent.session),
+    text(card.workspace),
+    text(card.pane_label),
+  ].filter(Boolean).join(' · ');
+  meta.append(where);
+  item.append(row, meta);
+
+  if (card.actionable && card.pane) {
+    item.onclick = () => {
+      if (card.unread) send({ type: 'attention.mark_seen', pane: card.pane });
+      observe(card.pane, `${qualify(card.pane)}/${text(card.title)}`);
+    };
+    return item;
+  }
+
+  // A card that cannot resolve is shown and not offered. The daemon refuses a
+  // stale route anyway; this is so a person is told why rather than tapping
+  // something that silently does nothing.
+  item.setAttribute('aria-disabled', 'true');
+  item.disabled = true;
+  const why = document.createElement('span');
+  why.className = 'note';
+  why.textContent = card.stale ? 'host not connected' : 'no longer running';
+  meta.append(why);
+  return item;
+}
+
+function renderInbox() {
+  const container = el('inbox-sections');
+  container.innerHTML = '';
+  if (!inbox) {
+    el('inbox-empty').hidden = false;
+    el('inbox-empty').textContent = 'waiting for the daemon…';
+    el('inbox-count').textContent = '';
+    el('inbox-filters').innerHTML = '';
+    return;
+  }
+  renderFilters();
+
+  let shown = 0;
+  for (const section of INBOX_SECTIONS) {
+    const cards = (inbox[section.key] || []).filter(card => matchesFilters(card, section.key));
+    if (!cards.length) continue;
+    shown += cards.length;
+    const block = document.createElement('section');
+    block.className = 'inbox-section';
+    block.dataset.section = section.key;
+    const title = document.createElement('div');
+    title.className = 'inbox-title';
+    title.textContent = `${section.title} (${cards.length})`;
+    block.append(title);
+    for (const card of cards) block.append(renderCard(card, section.key));
+    container.append(block);
+  }
+
+  const waiting = (inbox.needs_you || []).length;
+  el('inbox-count').textContent = waiting ? `${waiting} waiting` : 'nothing waiting';
+  el('inbox-empty').hidden = shown > 0;
+  el('inbox-empty').textContent = inboxCards().length
+    ? 'no agents match these filters'
+    : 'no agents yet';
+}
+
 function renderPanes() {
   const list = el('panes');
   list.innerHTML = '';
@@ -1288,6 +1480,21 @@ function apply(message) {
       }
       pendingPluginOperations.clear();
       send({ type: 'state.subscribe' });
+      // The inbox is a separate subscription because it answers a separate
+      // question. A reconnect asks again: the daemon holds no memory of what
+      // this page had, and the projection is sent whole, so the first message
+      // after this replaces whatever was on screen.
+      //
+      // A daemon that does not offer it is an older one this page can still
+      // drive. Say so and open the hierarchy, rather than leaving a person
+      // watching a panel that will never fill.
+      if ((message.features || []).includes('agent_cards')) {
+        send({ type: 'agents.subscribe' });
+      } else {
+        inbox = null;
+        el('inbox').hidden = true;
+        el('hierarchy').open = true;
+      }
       // A reconnect is a new client to the daemon, which knows nothing about
       // what this page was watching — so what was being watched is asked for
       // again here. Without this the last screen stays painted and the link
@@ -1299,6 +1506,10 @@ function apply(message) {
         subscribeScreen(watching);
       }
       schedulePluginPoll();
+      break;
+    case 'agents.cards':
+      inbox = message.projection;
+      renderInbox();
       break;
     case 'state.full':
       targets.clear();

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -108,6 +108,12 @@
     padding: .6rem .7rem; margin-top: .35rem; min-height: 3rem;
   }
   .card + .card { margin-top: .35rem; }
+  .card-open {
+    display: block; width: 100%; text-align: left; background: none;
+    border: 0; color: inherit; padding: 0; min-height: 2.4rem;
+  }
+  .card-marks { display: flex; flex-wrap: wrap; gap: .3rem; margin-top: .45rem; }
+  .card-marks .chip { padding: .25rem .6rem; font-size: .76rem; min-height: 1.9rem; }
   .card[aria-disabled="true"] { color: var(--dim); }
   .card-meta { display: flex; gap: .4rem; color: var(--dim); font-size: .78rem; margin-top: .25rem; }
   .actions { display: flex; gap: .5rem; margin-top: .7rem; }
@@ -1166,6 +1172,11 @@ let inbox = null;
 // so a filtered-out agent that starts waiting is still one chip away.
 const filters = { state: 'all', target: 'all', provider: 'all' };
 
+// One duration, chosen here rather than asked for: a phone offering a menu of
+// snooze lengths is three taps where one will do, and the daemon clamps
+// anything longer anyway.
+const SNOOZE_MINUTES = 60;
+
 const INBOX_SECTIONS = [
   { key: 'needs_you', title: 'Needs you' },
   { key: 'working', title: 'Working' },
@@ -1180,6 +1191,7 @@ function inboxCards() {
 function matchesFilters(card, section) {
   if (filters.state === 'needs_you' && section !== 'needs_you') return false;
   if (filters.state === 'working' && section !== 'working') return false;
+  if (filters.state === 'pinned' && !(card.marks && card.marks.pinned)) return false;
   if (filters.target !== 'all' && text(card.agent && card.agent.target) !== filters.target) {
     return false;
   }
@@ -1208,6 +1220,13 @@ function renderFilters() {
   chip('All', 'state', 'all', strip);
   chip('Needs you', 'state', 'needs_you', strip);
   chip('Working', 'state', 'working', strip);
+  // Offered only once something is pinned, for the same reason as the host and
+  // agent-kind rows: a filter that can only ever show nothing is not a choice.
+  if (cards.some(card => card.marks && card.marks.pinned)) {
+    chip('Pinned', 'state', 'pinned', strip);
+  } else if (filters.state === 'pinned') {
+    filters.state = 'all';
+  }
 
   // A chip for a dimension with one value would be a control that cannot
   // change anything, so the row appears only once there is a choice to make.
@@ -1229,13 +1248,39 @@ function renderFilters() {
   }
 }
 
+// A mark is Super-Herdr's own opinion about this inbox. It never reaches the
+// host: pinning does not focus a pane, muting does not stop an agent, and a
+// snooze asks the daemon for a duration rather than naming a moment, because a
+// phone with a wrong clock must not be able to silence an agent for a year.
+function markAgent(card, kind, value) {
+  const mark = kind === 'pin'
+    ? { kind: 'pin', pinned: value }
+    : kind === 'mute'
+      ? { kind: 'mute', muted: value }
+      : { kind: 'snooze', minutes: value ? SNOOZE_MINUTES : null };
+  send({ type: 'agents.mark', request: nextCommandRequest++, agent: card.agent, mark });
+}
+
+function markChip(card, kind, label, pressed, container) {
+  const button = document.createElement('button');
+  button.className = 'chip';
+  button.type = 'button';
+  button.dataset.mark = kind;
+  button.textContent = label;
+  button.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+  button.onclick = () => markAgent(card, kind, !pressed);
+  container.append(button);
+}
+
 function renderCard(card, section) {
-  const item = document.createElement('button');
+  const item = document.createElement('div');
   item.className = 'card';
-  item.type = 'button';
   item.dataset.agent = paneKey(card.agent);
   item.dataset.section = section;
   if (card.unread) item.classList.add('unread');
+  const open = document.createElement('button');
+  open.className = 'card-open';
+  open.type = 'button';
   const row = document.createElement('div');
   row.className = 'row';
   const name = document.createElement('span');
@@ -1259,10 +1304,27 @@ function renderCard(card, section) {
     text(card.pane_label),
   ].filter(Boolean).join(' · ');
   meta.append(where);
-  item.append(row, meta);
+  open.append(row, meta);
+  item.append(open);
+
+  const marks = card.marks || {};
+  // A gone agent has nothing left to pin, mute or snooze, and storing a mark
+  // against an identity that no longer exists would only keep it alive in a
+  // file. Live cards keep their controls even while their host is away.
+  if (card.activity !== 'gone') {
+    const strip = document.createElement('div');
+    strip.className = 'card-marks';
+    markChip(card, 'pin', marks.pinned ? 'Pinned' : 'Pin', Boolean(marks.pinned), strip);
+    markChip(card, 'mute', marks.muted ? 'Muted' : 'Mute', Boolean(marks.muted), strip);
+    markChip(
+      card, 'snooze', marks.snoozed_until_ms ? 'Snoozed' : 'Snooze',
+      Boolean(marks.snoozed_until_ms), strip,
+    );
+    item.append(strip);
+  }
 
   if (card.actionable && card.pane) {
-    item.onclick = () => {
+    open.onclick = () => {
       if (card.unread) send({ type: 'attention.mark_seen', pane: card.pane });
       observe(card.pane, `${qualify(card.pane)}/${text(card.title)}`);
     };
@@ -1272,8 +1334,8 @@ function renderCard(card, section) {
   // A card that cannot resolve is shown and not offered. The daemon refuses a
   // stale route anyway; this is so a person is told why rather than tapping
   // something that silently does nothing.
-  item.setAttribute('aria-disabled', 'true');
-  item.disabled = true;
+  open.setAttribute('aria-disabled', 'true');
+  open.disabled = true;
   const why = document.createElement('span');
   why.className = 'note';
   why.textContent = card.stale ? 'host not connected' : 'no longer running';

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -22,6 +22,7 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 
+use crate::agent_card::AgentCardProjection;
 use crate::attention::AttentionEvent;
 use crate::model::{PaneId, TargetSession};
 use crate::operation::Operation;
@@ -236,6 +237,7 @@ struct Route {
 struct Client {
     greeted: bool,
     state_subscribed: bool,
+    agent_cards_subscribed: bool,
     panes: BTreeMap<PaneId, PaneSubscription>,
 }
 
@@ -244,6 +246,7 @@ impl Client {
         Self {
             greeted: false,
             state_subscribed: false,
+            agent_cards_subscribed: false,
             panes: BTreeMap::new(),
         }
     }
@@ -291,6 +294,10 @@ pub struct Broker {
     routes: BTreeMap<PaneId, Route>,
     screens: BTreeMap<PaneId, ScreenState>,
     state: FederationState,
+    /// The inbox as last published. Kept so a client subscribing between two
+    /// federation updates is given the current one instead of waiting for the
+    /// next change, and so a rebuild that changed nothing sends nothing.
+    agent_cards: Option<AgentCardProjection>,
     next_client: u64,
 }
 
@@ -349,6 +356,7 @@ impl Broker {
             routes: BTreeMap::new(),
             screens: BTreeMap::new(),
             state: FederationState::default(),
+            agent_cards: None,
             next_client: 0,
         }
     }
@@ -450,6 +458,21 @@ impl Broker {
                 // A client renders attention it did not derive, so it needs the
                 // history before the next event rather than after it.
                 effects.push(Effect::SendAttentionHistory { client });
+            }
+            ClientMessage::SubscribeAgentCards => {
+                if let Some(session) = self.clients.get_mut(&client) {
+                    session.agent_cards_subscribed = true;
+                }
+                // Only if the daemon has projected once. Before that there is
+                // no inbox to describe, and an empty one would be a claim that
+                // no agent needs anything — which is a different statement from
+                // "not known yet".
+                if let Some(projection) = self.agent_cards.clone() {
+                    effects.push(Effect::Send {
+                        client,
+                        message: ServerMessage::AgentCards { projection },
+                    });
+                }
             }
             ClientMessage::SubscribePane {
                 pane,
@@ -993,6 +1016,35 @@ impl Broker {
             .collect()
     }
 
+    /// Publish a freshly built inbox.
+    ///
+    /// The daemon rebuilds the projection whenever the federation or attention
+    /// history moves; this only fans it out, and only when it differs from what
+    /// subscribers were last sent. A person watching a busy federation gets one
+    /// message per real change to their inbox rather than one per refresh.
+    pub fn agent_cards_updated(&mut self, projection: AgentCardProjection) -> Vec<Effect> {
+        if self.agent_cards.as_ref() == Some(&projection) {
+            return Vec::new();
+        }
+        self.agent_cards = Some(projection.clone());
+        let mut effects = Vec::new();
+        for client in self
+            .clients
+            .iter()
+            .filter(|(_, session)| session.agent_cards_subscribed)
+            .map(|(client, _)| *client)
+            .collect::<Vec<_>>()
+        {
+            effects.push(Effect::Send {
+                client,
+                message: ServerMessage::AgentCards {
+                    projection: projection.clone(),
+                },
+            });
+        }
+        effects
+    }
+
     pub fn attention_observed(&mut self, event: AttentionEvent) -> Vec<Effect> {
         let mut effects = Vec::new();
         self.broadcast_state(ServerMessage::Attention { event }, &mut effects);
@@ -1371,6 +1423,7 @@ mod tests {
     use super::{
         Broker, ClientId, Effect, MAX_OUTSTANDING_SCREEN_UPDATES, PaneSubscription, Rendered,
     };
+    use crate::agent_card::{AGENT_CARD_PROJECTION_VERSION, AgentCardProjection};
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{PaneId, TargetSession};
     use crate::operation::Operation;
@@ -3286,6 +3339,85 @@ mod tests {
             [ServerMessage::AttentionHistory { .. }]
         ));
         assert!(messages_for(&effects, silent).is_empty());
+    }
+
+    #[test]
+    fn the_inbox_reaches_only_the_clients_that_asked_for_it() {
+        let mut broker = broker();
+        let subscriber = greet(&mut broker);
+        let bystander = greet(&mut broker);
+        broker.handle(subscriber, ClientMessage::SubscribeAgentCards);
+
+        let effects = broker.agent_cards_updated(projection(1));
+
+        let recipients = effects
+            .iter()
+            .filter_map(|effect| match effect {
+                Effect::Send {
+                    client,
+                    message: ServerMessage::AgentCards { .. },
+                } => Some(*client),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(recipients, vec![subscriber]);
+        assert!(
+            !recipients.contains(&bystander),
+            "a client that did not ask for the inbox is not sent one"
+        );
+    }
+
+    #[test]
+    fn a_late_subscriber_is_given_the_inbox_that_already_exists() {
+        let mut broker = broker();
+        let early = greet(&mut broker);
+        broker.handle(early, ClientMessage::SubscribeAgentCards);
+        broker.agent_cards_updated(projection(1));
+
+        let late = greet(&mut broker);
+        let effects = broker.handle(late, ClientMessage::SubscribeAgentCards);
+
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Send {
+                message: ServerMessage::AgentCards { .. },
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn a_subscriber_that_arrives_before_the_first_projection_is_told_nothing() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+
+        assert!(
+            broker
+                .handle(client, ClientMessage::SubscribeAgentCards)
+                .is_empty(),
+            "an empty inbox and an unknown one are different claims"
+        );
+    }
+
+    #[test]
+    fn republishing_an_unchanged_inbox_sends_nothing() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+        broker.handle(client, ClientMessage::SubscribeAgentCards);
+        assert!(!broker.agent_cards_updated(projection(1)).is_empty());
+
+        assert!(broker.agent_cards_updated(projection(1)).is_empty());
+        assert!(!broker.agent_cards_updated(projection(2)).is_empty());
+    }
+
+    fn projection(revision: u64) -> AgentCardProjection {
+        AgentCardProjection {
+            version: AGENT_CARD_PROJECTION_VERSION,
+            revision,
+            needs_you: Vec::new(),
+            working: Vec::new(),
+            recent: Vec::new(),
+        }
     }
 
     #[test]

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -23,8 +23,9 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 
 use crate::agent_card::AgentCardProjection;
+use crate::agent_marks::AgentMarkRequest;
 use crate::attention::AttentionEvent;
-use crate::model::{PaneId, TargetSession};
+use crate::model::{AgentId, PaneId, TargetSession};
 use crate::operation::Operation;
 use crate::plugin::{PluginRun, PluginRunId};
 use crate::protocol::{ClientMessage, PROTOCOL_VERSION, PaneRepresentation, ServerMessage};
@@ -163,6 +164,15 @@ pub enum Effect {
         path: String,
         destination: PaneId,
         name: Option<String>,
+    },
+    /// Pin, mute, or snooze one agent. The daemon owns the durable marks, for
+    /// the same reason it owns attention history: two writers would overwrite
+    /// each other's file.
+    MarkAgent {
+        client: ClientId,
+        request: u64,
+        agent: AgentId,
+        mark: AgentMarkRequest,
     },
     MarkAttentionSeen {
         pane: PaneId,
@@ -459,6 +469,16 @@ impl Broker {
                 // history before the next event rather than after it.
                 effects.push(Effect::SendAttentionHistory { client });
             }
+            ClientMessage::MarkAgent {
+                request,
+                agent,
+                mark,
+            } => effects.push(Effect::MarkAgent {
+                client,
+                request,
+                agent,
+                mark,
+            }),
             ClientMessage::SubscribeAgentCards => {
                 if let Some(session) = self.clients.get_mut(&client) {
                     session.agent_cards_subscribed = true;
@@ -1424,8 +1444,9 @@ mod tests {
         Broker, ClientId, Effect, MAX_OUTSTANDING_SCREEN_UPDATES, PaneSubscription, Rendered,
     };
     use crate::agent_card::{AGENT_CARD_PROJECTION_VERSION, AgentCardProjection};
+    use crate::agent_marks::AgentMarkRequest;
     use crate::attention::{AttentionEvent, AttentionEventKind};
-    use crate::model::{PaneId, TargetSession};
+    use crate::model::{AgentId, PaneId, TargetSession};
     use crate::operation::Operation;
     use crate::plugin::PluginRunId;
     use crate::protocol::{ClientMessage, PROTOCOL_VERSION, PaneRepresentation, ServerMessage};
@@ -3408,6 +3429,33 @@ mod tests {
 
         assert!(broker.agent_cards_updated(projection(1)).is_empty());
         assert!(!broker.agent_cards_updated(projection(2)).is_empty());
+    }
+
+    #[test]
+    fn a_mark_is_carried_to_the_daemon_with_its_qualified_agent() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+        let agent = AgentId::new("first", "main", "w1:p1");
+
+        let effects = broker.handle(
+            client,
+            ClientMessage::MarkAgent {
+                request: 3,
+                agent: agent.clone(),
+                mark: AgentMarkRequest::Snooze { minutes: Some(30) },
+            },
+        );
+
+        assert_eq!(
+            effects,
+            vec![Effect::MarkAgent {
+                client,
+                request: 3,
+                agent,
+                mark: AgentMarkRequest::Snooze { minutes: Some(30) },
+            }],
+            "the broker routes a mark and never decides one"
+        );
     }
 
     fn projection(revision: u64) -> AgentCardProjection {

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -35,6 +35,7 @@ use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
+use crate::agent_card::AgentCardIndex;
 use crate::attention::{AttentionIndex, AttentionStore};
 use crate::clipboard;
 use crate::config::{Config, Device, Target, TransportConfig};
@@ -685,6 +686,10 @@ struct Daemon {
     attention: AttentionIndex,
     attention_store: Option<AttentionStore>,
     attention_cursor: Option<u64>,
+    /// The inbox projection. It lives beside the attention index because it
+    /// reads from it, and beside the federation state because it summarises
+    /// it — the one place in the process that holds both.
+    agent_cards: AgentCardIndex,
     command_timeout: Duration,
     inputs: mpsc::UnboundedSender<Input>,
     /// Queues handed over by connections, waiting for the broker to say whether
@@ -968,7 +973,11 @@ async fn run(
     let mut daemon = Daemon {
         broker: Broker::new(
             env!("CARGO_PKG_VERSION"),
-            vec!["terminal".to_owned(), "plugin_actions".to_owned()],
+            vec![
+                "terminal".to_owned(),
+                "plugin_actions".to_owned(),
+                "agent_cards".to_owned(),
+            ],
         ),
         web_url: options.web_url.clone(),
         bridge_pairing: options.web_bridge.as_ref().map(|_| bridge_pairing.clone()),
@@ -980,6 +989,7 @@ async fn run(
         attention,
         attention_store,
         attention_cursor,
+        agent_cards: AgentCardIndex::default(),
         command_timeout: Duration::from_secs(active.transport.command_timeout_seconds),
         inputs: inputs.clone(),
         offers: BTreeMap::new(),
@@ -1493,6 +1503,10 @@ impl Daemon {
                 self.state = state.clone();
                 let mut effects = self.broker.federation_updated(state);
                 effects.extend(self.observe_attention());
+                // After attention, not before: a card carries the attention
+                // state of its agent, so projecting first would publish an
+                // inbox that disagreed with the events sent alongside it.
+                effects.extend(self.project_agent_cards());
                 effects
             }
             Input::Frame {
@@ -2810,7 +2824,23 @@ impl Daemon {
     fn attention_changed(&mut self) -> Vec<Effect> {
         self.persist_attention();
         let events = self.attention.events().cloned().collect();
-        self.broker.attention_changed(events)
+        let mut effects = self.broker.attention_changed(events);
+        // Marking history seen changes what the inbox should show, so the
+        // cards are rebuilt from the same act rather than waiting for whatever
+        // federation refresh happens to come next.
+        effects.extend(self.project_agent_cards());
+        effects
+    }
+
+    /// Rebuild the inbox and publish it if it moved.
+    ///
+    /// The projection is derived, never stored durably: it is a view of the
+    /// federation and the attention index, both of which already survive a
+    /// restart on their own terms. Rebuilding it is cheap and keeps one
+    /// authority for each fact.
+    fn project_agent_cards(&mut self) -> Vec<Effect> {
+        let projection = self.agent_cards.project(&self.state, &self.attention);
+        self.broker.agent_cards_updated(projection)
     }
 
     fn persist_attention(&self) {

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -36,7 +36,8 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
 use crate::agent_card::AgentCardIndex;
-use crate::attention::{AttentionIndex, AttentionStore};
+use crate::agent_marks::{AgentMarkStore, AgentMarks};
+use crate::attention::{AttentionIndex, AttentionStore, unix_time_ms};
 use crate::clipboard;
 use crate::config::{Config, Device, Target, TransportConfig};
 use crate::daemon::broker::{Broker, ClientId, Effect};
@@ -65,6 +66,9 @@ const MAX_PENDING_PAIRING_APPROVALS: usize = 16;
 #[derive(Debug, Clone)]
 pub struct DaemonOptions {
     pub socket: PathBuf,
+    /// Where the durable agent marks live. `None` discovers the standard
+    /// location; a test points this somewhere disposable.
+    pub agent_marks: Option<PathBuf>,
     /// Where the durable attention index lives. `None` discovers the standard
     /// state path.
     pub attention_state: Option<PathBuf>,
@@ -102,6 +106,7 @@ impl DaemonOptions {
         };
         Ok(Self {
             socket: root.join("super-herdr/daemon.sock"),
+            agent_marks: None,
             attention_state: None,
             refresh_interval: CONFIG_REFRESH_INTERVAL,
             web_port: None,
@@ -690,6 +695,8 @@ struct Daemon {
     /// reads from it, and beside the federation state because it summarises
     /// it — the one place in the process that holds both.
     agent_cards: AgentCardIndex,
+    agent_marks: AgentMarks,
+    agent_mark_store: Option<AgentMarkStore>,
     command_timeout: Duration,
     inputs: mpsc::UnboundedSender<Input>,
     /// Queues handed over by connections, waiting for the broker to say whether
@@ -970,6 +977,14 @@ async fn run(
         .and_then(|store| store.load().ok())
         .unwrap_or_default();
     let attention_cursor = attention.events().next_back().map(|event| event.id);
+    let agent_mark_store = match options.agent_marks.clone() {
+        Some(path) => Some(AgentMarkStore::at(path)),
+        None => AgentMarkStore::discover().ok(),
+    };
+    let agent_marks = agent_mark_store
+        .as_ref()
+        .and_then(|store| store.load().ok())
+        .unwrap_or_default();
     let mut daemon = Daemon {
         broker: Broker::new(
             env!("CARGO_PKG_VERSION"),
@@ -990,6 +1005,8 @@ async fn run(
         attention_store,
         attention_cursor,
         agent_cards: AgentCardIndex::default(),
+        agent_marks,
+        agent_mark_store,
         command_timeout: Duration::from_secs(active.transport.command_timeout_seconds),
         inputs: inputs.clone(),
         offers: BTreeMap::new(),
@@ -1758,6 +1775,29 @@ impl Daemon {
                     destination,
                     name,
                 } => self.begin_between(client, request, source, path, destination, name),
+                Effect::MarkAgent {
+                    client,
+                    request,
+                    agent,
+                    mark,
+                } => {
+                    let changed = self.agent_marks.apply(&agent, mark, unix_time_ms());
+                    if changed {
+                        self.persist_agent_marks();
+                        pending.extend(self.project_agent_cards());
+                    }
+                    // Answered either way. A mark that was already set is not
+                    // a failure, and a client that heard nothing back could
+                    // not tell that from a request that never arrived.
+                    if let Some(outbox) = self.outboxes.get(&client) {
+                        let _ = outbox.send(ServerMessage::OperationResult {
+                            request,
+                            applied: true,
+                            message: String::new(),
+                            plugin_run: None,
+                        });
+                    }
+                }
                 Effect::MarkAttentionSeen { pane } => {
                     if self.attention.mark_seen_for_pane(&pane) {
                         pending.extend(self.attention_changed());
@@ -2839,8 +2879,27 @@ impl Daemon {
     /// restart on their own terms. Rebuilding it is cheap and keeps one
     /// authority for each fact.
     fn project_agent_cards(&mut self) -> Vec<Effect> {
-        let projection = self.agent_cards.project(&self.state, &self.attention);
+        let now_ms = unix_time_ms();
+        // A snooze that has run out stops being carried before anything is
+        // built from it. This runs on the projection path rather than on a
+        // timer of its own: the federation refreshes on a bounded interval
+        // anyway, so an expiry surfaces within one refresh without another
+        // clock in the process to keep correct.
+        if self.agent_marks.expire(now_ms) {
+            self.persist_agent_marks();
+        }
+        let projection =
+            self.agent_cards
+                .project(&self.state, &self.attention, &self.agent_marks, now_ms);
         self.broker.agent_cards_updated(projection)
+    }
+
+    fn persist_agent_marks(&self) {
+        if let Some(store) = self.agent_mark_store.as_ref() {
+            // As with attention: a failed write costs the next restart these
+            // marks and nothing else, and must not interrupt supervision.
+            let _ = store.save(&self.agent_marks);
+        }
     }
 
     fn persist_attention(&self) {
@@ -2982,6 +3041,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let options = DaemonOptions {
             socket: directory.path().join("daemon.sock"),
+            agent_marks: None,
             attention_state: Some(directory.path().join("attention.json")),
             refresh_interval: Duration::from_secs(3600),
             web_port: Some(port),
@@ -3079,6 +3139,7 @@ mod tests {
             let directory = tempfile::tempdir().expect("a temporary directory");
             let options = DaemonOptions {
                 socket: directory.path().join("daemon.sock"),
+                agent_marks: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 // Pinned: these tests are about the socket, not the file.
                 refresh_interval: Duration::from_secs(3600),
@@ -3332,6 +3393,7 @@ mod tests {
             Some(path.clone()),
             DaemonOptions {
                 socket: socket.clone(),
+                agent_marks: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_millis(50),
                 web_port: None,
@@ -3607,6 +3669,7 @@ mod tests {
             None,
             DaemonOptions {
                 socket: socket.clone(),
+                agent_marks: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
@@ -3973,6 +4036,7 @@ mod tests {
                 None,
                 DaemonOptions {
                     socket: socket.clone(),
+                    agent_marks: None,
                     attention_state: Some(directory.path().join("attention.json")),
                     refresh_interval: Duration::from_secs(3600),
                     web_port: None,
@@ -4042,6 +4106,7 @@ mod tests {
             Some(config_path.clone()),
             DaemonOptions {
                 socket: socket.clone(),
+                agent_marks: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: Some(port),
@@ -4691,6 +4756,7 @@ mod tests {
             None,
             DaemonOptions {
                 socket: socket.clone(),
+                agent_marks: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
@@ -4769,6 +4835,7 @@ mod tests {
             None,
             DaemonOptions {
                 socket: socket.clone(),
+                agent_marks: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
@@ -4809,6 +4876,7 @@ mod tests {
 
         let options = DaemonOptions {
             socket: harness.socket(),
+            agent_marks: None,
             attention_state: Some(harness.directory.path().join("attention.json")),
             refresh_interval: Duration::from_secs(3600),
             web_port: None,
@@ -4836,6 +4904,7 @@ mod tests {
             None,
             DaemonOptions {
                 socket: socket.clone(),
+                agent_marks: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -729,6 +729,7 @@ mod tests {
             None,
             DaemonOptions {
                 socket: directory.path().join("unused.sock"),
+                agent_marks: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_card;
 pub mod attention;
 pub use super_herdr_bridge as bridge;
 pub mod client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent_card;
+pub mod agent_marks;
 pub mod attention;
 pub use super_herdr_bridge as bridge;
 pub mod client;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -38,8 +38,9 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::agent_card::AgentCardProjection;
+use crate::agent_marks::AgentMarkRequest;
 use crate::attention::AttentionEvent;
-use crate::model::{PaneId, TargetSession};
+use crate::model::{AgentId, PaneId, TargetSession};
 use crate::operation::Operation;
 use crate::plugin::{PluginAction, PluginRun, PluginRunId};
 use crate::screen::{Diff as ScreenDiff, Snapshot};
@@ -318,6 +319,20 @@ pub enum ClientMessage {
     /// to be sent every layout rectangle in the federation.
     #[serde(rename = "agents.subscribe")]
     SubscribeAgentCards,
+    /// Pin, mute, or snooze one agent.
+    ///
+    /// A mark is Super-Herdr's own opinion about a person's inbox and never
+    /// reaches the host: nothing here renames, focuses, stops, or otherwise
+    /// touches a Herdr object. A snooze asks for a duration rather than a
+    /// moment, because the daemon owns the clock — a phone whose clock is
+    /// wrong would otherwise silence an agent until next year, and the daemon
+    /// could not tell that from a deliberate request.
+    #[serde(rename = "agents.mark")]
+    MarkAgent {
+        request: u64,
+        agent: AgentId,
+        mark: AgentMarkRequest,
+    },
 }
 
 /// Sent by the daemon.
@@ -605,6 +620,7 @@ mod tests {
         AGENT_CARD_PROJECTION_VERSION, AgentActivity, AgentCard, AgentCardProjection,
         AgentCardSection,
     };
+    use crate::agent_marks::{AgentMarkRequest, AgentMarkState};
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{AgentId, PaneId, TargetSession, WorkspaceId};
     use crate::operation::Operation;
@@ -744,6 +760,21 @@ mod tests {
         round_trip_client(ClientMessage::MarkAllAttentionSeen);
         round_trip_client(ClientMessage::ClearSeenAttention);
         round_trip_client(ClientMessage::SubscribeAgentCards);
+        round_trip_client(ClientMessage::MarkAgent {
+            request: 11,
+            agent: AgentId::new("first", "default", "w1:p1"),
+            mark: AgentMarkRequest::Pin { pinned: true },
+        });
+        round_trip_client(ClientMessage::MarkAgent {
+            request: 12,
+            agent: AgentId::new("first", "default", "w1:p1"),
+            mark: AgentMarkRequest::Snooze { minutes: Some(60) },
+        });
+        round_trip_client(ClientMessage::MarkAgent {
+            request: 13,
+            agent: AgentId::new("first", "default", "w1:p1"),
+            mark: AgentMarkRequest::Mute { muted: false },
+        });
         round_trip_client(ClientMessage::RequestPairingCode { request: 9 });
         round_trip_client(ClientMessage::DecidePairing {
             attempt: "a".repeat(64),
@@ -777,6 +808,11 @@ mod tests {
                     stale: false,
                     actionable: true,
                     last_change_ms: Some(1_700_000_000_000),
+                    marks: AgentMarkState {
+                        pinned: true,
+                        muted: false,
+                        snoozed_until_ms: None,
+                    },
                 }],
                 working: Vec::new(),
                 recent: Vec::new(),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -37,6 +37,7 @@ use anyhow::{Result, bail};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+use crate::agent_card::AgentCardProjection;
 use crate::attention::AttentionEvent;
 use crate::model::{PaneId, TargetSession};
 use crate::operation::Operation;
@@ -308,6 +309,15 @@ pub enum ClientMessage {
     /// forgetting part of it is a request like any other mutation.
     #[serde(rename = "attention.clear_seen")]
     ClearSeenAttention,
+    /// Begin the agent-card stream: one `agents.cards` at once, then one more
+    /// whenever the projection actually changes.
+    ///
+    /// Separate from `state.subscribe` because the two answer different
+    /// questions and a client may want either. The TUI renders the hierarchy
+    /// and can want both; a phone that only ever shows the inbox has no reason
+    /// to be sent every layout rectangle in the federation.
+    #[serde(rename = "agents.subscribe")]
+    SubscribeAgentCards,
 }
 
 /// Sent by the daemon.
@@ -389,6 +399,16 @@ pub enum ServerMessage {
     },
     #[serde(rename = "plugin.run")]
     PluginRun { request: u64, run: PluginRun },
+    /// The agent inbox, whole.
+    ///
+    /// Sent complete rather than as a diff. The projection is bounded by the
+    /// number of agents a person is running, its ordering is the daemon's
+    /// answer and not something a client should be reassembling from
+    /// fragments, and a card that arrived without the section it belongs to
+    /// would be a card a client had to place itself — which is the disagreement
+    /// this projection exists to prevent.
+    #[serde(rename = "agents.cards")]
+    AgentCards { projection: AgentCardProjection },
     /// A pairing code and how long it lasts. Never persisted: a code that
     /// survived a restart would be a credential nobody knew was outstanding.
     #[serde(rename = "pairing.code")]
@@ -581,8 +601,12 @@ mod tests {
         ClientMessage, MAX_MESSAGE_BYTES, PROTOCOL_VERSION, PaneRepresentation, ServerMessage,
         decode, encode,
     };
+    use crate::agent_card::{
+        AGENT_CARD_PROJECTION_VERSION, AgentActivity, AgentCard, AgentCardProjection,
+        AgentCardSection,
+    };
     use crate::attention::{AttentionEvent, AttentionEventKind};
-    use crate::model::{PaneId, TargetSession, WorkspaceId};
+    use crate::model::{AgentId, PaneId, TargetSession, WorkspaceId};
     use crate::operation::Operation;
     use crate::plugin::{
         PluginAction, PluginActionContext, PluginActionId, PluginRun, PluginRunId, PluginRunStatus,
@@ -719,6 +743,7 @@ mod tests {
         round_trip_client(ClientMessage::MarkAttentionSeen { pane: pane() });
         round_trip_client(ClientMessage::MarkAllAttentionSeen);
         round_trip_client(ClientMessage::ClearSeenAttention);
+        round_trip_client(ClientMessage::SubscribeAgentCards);
         round_trip_client(ClientMessage::RequestPairingCode { request: 9 });
         round_trip_client(ClientMessage::DecidePairing {
             attempt: "a".repeat(64),
@@ -732,6 +757,30 @@ mod tests {
             protocol: PROTOCOL_VERSION,
             server_version: "0.3.1".to_owned(),
             features: vec!["terminal".to_owned()],
+        });
+        round_trip_server(ServerMessage::AgentCards {
+            projection: AgentCardProjection {
+                version: AGENT_CARD_PROJECTION_VERSION,
+                revision: 4,
+                needs_you: vec![AgentCard {
+                    agent: AgentId::new("first", "default", "w1:p1"),
+                    pane: Some(pane()),
+                    title: "reviewer".to_owned(),
+                    workspace: "compiler".to_owned(),
+                    tab: "build".to_owned(),
+                    pane_label: "left".to_owned(),
+                    provider: Some("claude".to_owned()),
+                    activity: AgentActivity::NeedsInput,
+                    status: "blocked".to_owned(),
+                    section: AgentCardSection::NeedsYou,
+                    unread: true,
+                    stale: false,
+                    actionable: true,
+                    last_change_ms: Some(1_700_000_000_000),
+                }],
+                working: Vec::new(),
+                recent: Vec::new(),
+            },
         });
         round_trip_server(ServerMessage::PaneClosed { pane: pane() });
         round_trip_server(ServerMessage::PaneLease {

--- a/src/resource_action.rs
+++ b/src/resource_action.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use crate::model::{PaneId, TabId, TargetSession, WorkspaceId};
+use crate::agent_marks::AgentMarkRequest;
+use crate::model::{AgentId, PaneId, TabId, TargetSession, WorkspaceId};
 use crate::plugin::{PluginAction, PluginInvocationTarget};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -98,6 +99,16 @@ pub enum ResourceAction {
         action: PluginAction,
         context: PluginInvocationTarget,
     },
+    /// Pin, mute, or snooze one agent in Super-Herdr's own inbox.
+    ///
+    /// Listed among the Herdr actions because that is where a person looks for
+    /// something to do to an agent, and deliberately not one of them: it
+    /// changes nothing on the host. See [`ResourceAction::mutates_herdr`].
+    MarkAgent {
+        agent: AgentId,
+        mark: AgentMarkRequest,
+        label: String,
+    },
 }
 
 impl ResourceAction {
@@ -108,6 +119,7 @@ impl ResourceAction {
                 | Self::OpenTargetManager
                 | Self::OpenAgentNavigator
                 | Self::OpenAttentionCenter
+                | Self::MarkAgent { .. }
         )
     }
 
@@ -132,6 +144,7 @@ impl ResourceAction {
             | Self::CreateTab { workspace } => Some(workspace.target_session()),
             Self::RenameTab { tab, .. } | Self::CloseTab { tab, .. } => Some(tab.target_session()),
             Self::InvokePluginAction { action, .. } => Some(action.id.target.clone()),
+            Self::MarkAgent { agent, .. } => Some(agent.target_session()),
             Self::OpenTargetManager | Self::OpenAgentNavigator | Self::OpenAttentionCenter => None,
         }
     }
@@ -164,6 +177,16 @@ impl ResourceAction {
             Self::InvokePluginAction { action, .. } => {
                 format!("Plugin: {}", action.title)
             }
+            Self::MarkAgent { mark, label, .. } => match mark {
+                AgentMarkRequest::Pin { pinned: true } => format!("Pin agent {label:?}"),
+                AgentMarkRequest::Pin { pinned: false } => format!("Unpin agent {label:?}"),
+                AgentMarkRequest::Mute { muted: true } => format!("Mute agent {label:?}"),
+                AgentMarkRequest::Mute { muted: false } => format!("Unmute agent {label:?}"),
+                AgentMarkRequest::Snooze {
+                    minutes: Some(minutes),
+                } => format!("Snooze agent {label:?} for {minutes} minutes"),
+                AgentMarkRequest::Snooze { minutes: None } => format!("Wake agent {label:?}"),
+            },
         }
     }
 
@@ -191,7 +214,8 @@ impl ResourceAction {
 #[cfg(test)]
 mod tests {
     use super::{ResourceAction, SplitDirection};
-    use crate::model::{PaneId, TargetSession, WorkspaceId};
+    use crate::agent_marks::AgentMarkRequest;
+    use crate::model::{AgentId, PaneId, TargetSession, WorkspaceId};
 
     #[test]
     fn actions_keep_server_local_ids_qualified() {
@@ -228,6 +252,30 @@ mod tests {
             action.palette_label(),
             "Move workspace \"compiler\" into \"archive\""
         );
+    }
+
+    #[test]
+    fn a_mark_is_qualified_and_never_a_herdr_mutation() {
+        let action = ResourceAction::MarkAgent {
+            agent: AgentId::new("build", "toolchains", "w2:p1"),
+            mark: AgentMarkRequest::Snooze { minutes: Some(60) },
+            label: "reviewer".to_owned(),
+        };
+
+        assert_eq!(
+            action.target_session(),
+            Some(TargetSession::new("build", "toolchains"))
+        );
+        assert!(
+            !action.mutates_herdr(),
+            "pinning, muting and snoozing are this inbox's opinions, not the host's"
+        );
+        assert!(!action.is_destructive());
+        assert_eq!(
+            action.palette_label(),
+            "Snooze agent \"reviewer\" for 60 minutes"
+        );
+        assert!(action.search_text().contains("build/toolchains"));
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -140,6 +140,36 @@ pub struct LayoutState {
     pub panes: Vec<LayoutPane>,
 }
 
+/// The separator between the parts of an agent key.
+///
+/// A key is assembled from several fields, so no field may contain it: a value
+/// carrying one could otherwise be written so that two different agents
+/// produce the same key, and the whole point of the key is that they cannot.
+pub const AGENT_KEY_SEPARATOR: char = '\u{1f}';
+
+/// How long any one part of an agent session reference may be. Session ids and
+/// paths are short; a target that sends something long is not describing one.
+const MAX_AGENT_SESSION_FIELD_BYTES: usize = 256;
+
+/// The agent session a pane is running, as Herdr reports it.
+///
+/// Optional in Herdr's documented snapshot and, at protocol 19, absent in
+/// practice — so nothing may depend on having one. What it buys where it is
+/// present is an identity that survives the agent moving to another pane,
+/// which a pane id cannot express.
+///
+/// All four fields take part in identity. `kind` distinguishes an `id` from a
+/// `path`, which could otherwise collide; `source` and `agent` say who
+/// reported it and which program it is, and two reporters describing the same
+/// value are not self-evidently the same session.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AgentSessionRef {
+    pub source: String,
+    pub agent: String,
+    pub kind: String,
+    pub value: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentState {
     pub pane: PaneId,
@@ -148,6 +178,8 @@ pub struct AgentState {
     pub status: Option<String>,
     pub interactive_ready: Option<bool>,
     pub revision: Option<u64>,
+    /// Absent whenever Herdr did not report one, which is the common case.
+    pub session: Option<AgentSessionRef>,
 }
 
 impl Keyed for WorkspaceState {
@@ -809,10 +841,39 @@ fn agent_states(snapshot: &Value, target: &TargetSession) -> BTreeMap<PaneId, Ag
                     status: optional_string(item, "agent_status"),
                     interactive_ready: optional_bool(item, "interactive_ready"),
                     revision: optional_u64(item, "revision"),
+                    session: agent_session(item.get("agent_session")),
                 },
             ))
         })
         .collect()
+}
+
+/// Read an agent session reference, and only a complete one.
+///
+/// Every field is required by Herdr's schema, so a record missing one is not a
+/// session this can identify anything by. Taking a partial one would produce a
+/// key that two different sessions could share, which is the exact failure a
+/// qualified identity exists to prevent — so a partial record is treated as no
+/// record and the pane remains the identity.
+fn agent_session(value: Option<&Value>) -> Option<AgentSessionRef> {
+    let value = value?;
+    Some(AgentSessionRef {
+        source: bounded_identity(value.get("source")?.as_str()?)?,
+        agent: bounded_identity(value.get("agent")?.as_str()?)?,
+        kind: bounded_identity(value.get("kind")?.as_str()?)?,
+        value: bounded_identity(value.get("value")?.as_str()?)?,
+    })
+}
+
+/// An identity component crosses this boundary only if it is short, printable,
+/// and free of the separator the key is built with. A target that sent
+/// something else does not get to shape another target's keys.
+fn bounded_identity(value: &str) -> Option<String> {
+    (!value.is_empty()
+        && value.len() <= MAX_AGENT_SESSION_FIELD_BYTES
+        && !value.contains(AGENT_KEY_SEPARATOR)
+        && !value.chars().any(char::is_control))
+    .then(|| value.to_owned())
 }
 
 fn collection<'a>(value: &'a Value, key: &str) -> impl Iterator<Item = &'a Value> {
@@ -869,7 +930,7 @@ mod tests {
     use tokio::time::timeout;
 
     use super::{
-        FederationState, FederationStore, NormalizedSnapshot, SupervisorOptions,
+        AgentSessionRef, FederationState, FederationStore, NormalizedSnapshot, SupervisorOptions,
         TargetConnectionState,
     };
     use crate::config::{Config, Target, TransportConfig};
@@ -1183,5 +1244,48 @@ mod tests {
             super::TargetUpdateMode::Events
         );
         store.shutdown().await;
+    }
+
+    #[test]
+    fn reads_a_complete_agent_session_and_refuses_a_partial_one() {
+        let key = crate::model::TargetSession::new("host-a", "work");
+        let snapshot = NormalizedSnapshot::from_value(
+            &key,
+            &json!({
+                "panes": [{"pane_id": "p1"}, {"pane_id": "p2"}, {"pane_id": "p3"}],
+                "agents": [
+                    {
+                        "pane_id": "p1",
+                        "agent_session": {
+                            "source": "herdr", "agent": "claude",
+                            "kind": "id", "value": "abc123"
+                        }
+                    },
+                    {"pane_id": "p2", "agent_session": {"kind": "id", "value": "abc123"}},
+                    {"pane_id": "p3"}
+                ]
+            }),
+        );
+
+        let session = |resource: &str| {
+            snapshot
+                .agents
+                .get(&crate::model::PaneId::new("host-a", "work", resource))
+                .and_then(|agent| agent.session.clone())
+        };
+        assert_eq!(
+            session("p1"),
+            Some(AgentSessionRef {
+                source: "herdr".to_owned(),
+                agent: "claude".to_owned(),
+                kind: "id".to_owned(),
+                value: "abc123".to_owned(),
+            })
+        );
+        assert!(
+            session("p2").is_none(),
+            "a partial reference would key two different sessions the same way"
+        );
+        assert!(session("p3").is_none());
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5263,7 +5263,12 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
         ServerMessage::AttentionHistory { events } => {
             app.attention = AttentionIndex::mirror(events);
         }
-        ServerMessage::Hello { .. }
+        // The TUI navigates the hierarchy and derives its own agent list from
+        // federation state, so it does not subscribe to the inbox projection
+        // and is never sent one. Named rather than caught by a wildcard, so
+        // adding a message a client must handle stays a compile error.
+        ServerMessage::AgentCards { .. }
+        | ServerMessage::Hello { .. }
         | ServerMessage::FederationState { .. }
         | ServerMessage::TargetState { .. }
         | ServerMessage::PluginRun { .. } => {}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -24,6 +24,7 @@ use ratatui::{Frame, Terminal};
 use tokio::sync::mpsc;
 use tokio::time::{interval, sleep_until};
 
+use crate::agent_card::agent_key;
 use crate::agent_marks::{AgentMarkRequest, AgentMarkState};
 use crate::attention::{AttentionEvent, AttentionEventKind, AttentionIndex};
 use crate::client::{Client, ClientCommands};
@@ -2949,10 +2950,13 @@ fn agent_mark_actions(
     label: &str,
     agent_marks: &BTreeMap<AgentId, AgentMarkState>,
 ) -> Vec<ResourceAction> {
-    if !snapshot.agents.contains_key(pane) {
+    let Some(state) = snapshot.agents.get(pane) else {
         return Vec::new();
-    }
-    let agent = AgentId::new(&pane.target, &pane.session, &pane.resource);
+    };
+    // The one key builder, so a menu entry names the same agent the daemon's
+    // projection does. Deriving it here from the pane would silently miss an
+    // agent that reports a session and disagree with every card.
+    let agent = agent_key(state);
     let marked = agent_marks.get(&agent).copied().unwrap_or_default();
     let mark = |mark| ResourceAction::MarkAgent {
         agent: agent.clone(),
@@ -7851,6 +7855,7 @@ mod tests {
     use crate::model::{AgentId, PaneId, TargetSession, WorkspaceId};
     use crate::plugin::{PluginAction, PluginActionContext, PluginActionId};
     use crate::resource_action::ResourceAction;
+    use crate::state::AGENT_KEY_SEPARATOR;
     use crate::state::{
         FederationState, NormalizedSnapshot, TargetConnectionState, TargetRuntimeState,
     };
@@ -8118,6 +8123,7 @@ mod tests {
         )
         .unwrap();
 
+        let expected = AgentId::new("host-b", "work", &format!("pane{AGENT_KEY_SEPARATOR}w2:p1"));
         let marks = menu
             .actions
             .iter()
@@ -8129,16 +8135,10 @@ mod tests {
         assert_eq!(
             marks,
             vec![
+                (expected.clone(), AgentMarkRequest::Pin { pinned: true }),
+                (expected.clone(), AgentMarkRequest::Mute { muted: true }),
                 (
-                    AgentId::new("host-b", "work", "w2:p1"),
-                    AgentMarkRequest::Pin { pinned: true }
-                ),
-                (
-                    AgentId::new("host-b", "work", "w2:p1"),
-                    AgentMarkRequest::Mute { muted: true }
-                ),
-                (
-                    AgentId::new("host-b", "work", "w2:p1"),
+                    expected,
                     AgentMarkRequest::Snooze {
                         minutes: Some(TUI_SNOOZE_MINUTES)
                     }
@@ -8208,7 +8208,7 @@ mod tests {
             runtime(key, TargetConnectionState::Live, Some(snapshot)),
         );
         let marks = BTreeMap::from([(
-            AgentId::new("host-b", "work", "w2:p1"),
+            AgentId::new("host-b", "work", &format!("pane{AGENT_KEY_SEPARATOR}w2:p1")),
             AgentMarkState {
                 pinned: true,
                 muted: false,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -24,12 +24,13 @@ use ratatui::{Frame, Terminal};
 use tokio::sync::mpsc;
 use tokio::time::{interval, sleep_until};
 
+use crate::agent_marks::{AgentMarkRequest, AgentMarkState};
 use crate::attention::{AttentionEvent, AttentionEventKind, AttentionIndex};
 use crate::client::{Client, ClientCommands};
 use crate::clipboard;
 use crate::config::{Config, Target, TransportConfig};
 use crate::daemon::server::{DaemonOptions, spawn_in_process};
-use crate::model::{PaneId, TabId, TargetSession, WorkspaceId};
+use crate::model::{AgentId, PaneId, TabId, TargetSession, WorkspaceId};
 use crate::notifications::{self, NotificationDelivery, NotificationQueue};
 use crate::operation::Operation;
 use crate::plugin::{PluginAction, PluginActionContext, PluginInvocationTarget};
@@ -838,6 +839,11 @@ struct App {
     client: Option<ClientCommands>,
     pending_operations: BTreeMap<u64, PendingOperation>,
     plugin_catalogs: BTreeMap<TargetSession, PluginCatalog>,
+    /// What a person marked on each agent, taken from the daemon's inbox
+    /// projection. Held so a context menu can offer the toggle that is
+    /// actually available rather than both halves of it; the daemon remains
+    /// the authority, and this is a mirror of its answer.
+    agent_marks: BTreeMap<AgentId, AgentMarkState>,
     pending_plugin_catalogs: BTreeMap<u64, PendingPluginCatalog>,
     pending_uploads: BTreeMap<u64, PendingUpload>,
     last_frame_area: Option<Rect>,
@@ -897,6 +903,7 @@ impl Default for App {
             client: None,
             pending_operations: BTreeMap::new(),
             plugin_catalogs: BTreeMap::new(),
+            agent_marks: BTreeMap::new(),
             pending_plugin_catalogs: BTreeMap::new(),
             pending_uploads: BTreeMap::new(),
             last_frame_area: None,
@@ -973,6 +980,7 @@ pub async fn run(config: Config, config_path: PathBuf) -> Result<()> {
     );
     let (client, mut daemon_events) = Client::attach(&daemon, "super-herdr-tui").await?;
     client.subscribe_state();
+    client.subscribe_agent_cards();
     let mut updates = client.state();
     let (input_sender, mut input) = mpsc::unbounded_channel();
     let (config_refresh_sender, mut config_refreshes) = mpsc::unbounded_channel();
@@ -2593,6 +2601,7 @@ fn command_palette_actions(
     state: &FederationState,
     selected: Option<&PaneId>,
     plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
+    agent_marks: &BTreeMap<AgentId, AgentMarkState>,
 ) -> Vec<ResourceAction> {
     let mut actions = vec![
         ResourceAction::OpenTargetManager,
@@ -2658,9 +2667,15 @@ fn command_palette_actions(
             },
             ResourceAction::ClosePane {
                 pane: pane.id.clone(),
-                label: pane_label,
+                label: pane_label.clone(),
             },
         ]);
+        actions.extend(agent_mark_actions(
+            snapshot,
+            &pane.id,
+            &pane_label,
+            agent_marks,
+        ));
     }
 
     for runtime in state.targets.values() {
@@ -2916,11 +2931,56 @@ fn workspace_recreate_actions(
         .collect()
 }
 
+/// How long the TUI's snooze lasts. One duration rather than a submenu: the
+/// daemon clamps anything longer, and a menu of lengths is more to read than
+/// the choice is worth.
+const TUI_SNOOZE_MINUTES: u32 = 60;
+
+/// The marks a person can put on the agent in one pane.
+///
+/// Offered only where there is an agent to mark: a pane running a shell has
+/// nothing to pin, and an entry that did nothing would be one more line to read
+/// past. Each entry names the state it would move to rather than toggling, so
+/// the same menu item chosen twice is idempotent rather than a flip a person
+/// has to track.
+fn agent_mark_actions(
+    snapshot: &NormalizedSnapshot,
+    pane: &PaneId,
+    label: &str,
+    agent_marks: &BTreeMap<AgentId, AgentMarkState>,
+) -> Vec<ResourceAction> {
+    if !snapshot.agents.contains_key(pane) {
+        return Vec::new();
+    }
+    let agent = AgentId::new(&pane.target, &pane.session, &pane.resource);
+    let marked = agent_marks.get(&agent).copied().unwrap_or_default();
+    let mark = |mark| ResourceAction::MarkAgent {
+        agent: agent.clone(),
+        mark,
+        label: label.to_owned(),
+    };
+    vec![
+        mark(AgentMarkRequest::Pin {
+            pinned: !marked.pinned,
+        }),
+        mark(AgentMarkRequest::Mute {
+            muted: !marked.muted,
+        }),
+        mark(AgentMarkRequest::Snooze {
+            minutes: marked
+                .snoozed_until_ms
+                .is_none()
+                .then_some(TUI_SNOOZE_MINUTES),
+        }),
+    ]
+}
+
 fn context_menu_for_target(
     state: &FederationState,
     target: ContextTarget,
     anchor: Position,
     plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
+    agent_marks: &BTreeMap<AgentId, AgentMarkState>,
 ) -> Option<ContextMenu> {
     let (title, mut actions, invocation_target) = match &target {
         ContextTarget::Session(target) => {
@@ -2994,23 +3054,25 @@ fn context_menu_for_target(
             let snapshot = actionable_snapshot(state, &pane.target_session())?;
             let resource = snapshot.panes.get(pane)?;
             let label = display_label(&resource.id.resource, resource.label.as_deref());
+            let mut actions = vec![
+                ResourceAction::SplitPane {
+                    pane: pane.clone(),
+                    direction: SplitDirection::Right,
+                },
+                ResourceAction::SplitPane {
+                    pane: pane.clone(),
+                    direction: SplitDirection::Down,
+                },
+                ResourceAction::TogglePaneZoom { pane: pane.clone() },
+                ResourceAction::ClosePane {
+                    pane: pane.clone(),
+                    label: label.clone(),
+                },
+            ];
+            actions.extend(agent_mark_actions(snapshot, pane, &label, agent_marks));
             (
                 format!("pane {label} · {}", pane.target_session()),
-                vec![
-                    ResourceAction::SplitPane {
-                        pane: pane.clone(),
-                        direction: SplitDirection::Right,
-                    },
-                    ResourceAction::SplitPane {
-                        pane: pane.clone(),
-                        direction: SplitDirection::Down,
-                    },
-                    ResourceAction::TogglePaneZoom { pane: pane.clone() },
-                    ResourceAction::ClosePane {
-                        pane: pane.clone(),
-                        label,
-                    },
-                ],
+                actions,
                 PluginInvocationTarget::Pane { pane: pane.clone() },
             )
         }
@@ -3047,7 +3109,13 @@ fn open_context_menu(
     app.selection = None;
     app.selection_autoscroll = None;
     ensure_plugin_catalog(state, &target.target_session(), app);
-    if let Some(menu) = context_menu_for_target(state, target, anchor, &app.plugin_catalogs) {
+    if let Some(menu) = context_menu_for_target(
+        state,
+        target,
+        anchor,
+        &app.plugin_catalogs,
+        &app.agent_marks,
+    ) {
         app.context_menu = Some(menu);
         app.message = None;
     } else {
@@ -3086,8 +3154,9 @@ fn filtered_palette_actions(
     selected: Option<&PaneId>,
     query: &str,
     plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
+    agent_marks: &BTreeMap<AgentId, AgentMarkState>,
 ) -> Vec<ResourceAction> {
-    let mut actions = command_palette_actions(state, selected, plugin_catalogs)
+    let mut actions = command_palette_actions(state, selected, plugin_catalogs, agent_marks)
         .into_iter()
         .filter_map(|action| fuzzy_score(&action.search_text(), query).map(|score| (score, action)))
         .collect::<Vec<_>>();
@@ -3109,6 +3178,7 @@ fn handle_command_palette_input(key: u8, state: &FederationState, app: &mut App)
         app.selected_pane.as_ref(),
         &palette.query,
         &app.plugin_catalogs,
+        &app.agent_marks,
     );
     match key {
         0x1b => return Ok(false),
@@ -3147,6 +3217,7 @@ fn handle_command_palette_input(key: u8, state: &FederationState, app: &mut App)
         app.selected_pane.as_ref(),
         &palette.query,
         &app.plugin_catalogs,
+        &app.agent_marks,
     )
     .len();
     palette.selected = palette.selected.min(count.saturating_sub(1));
@@ -3335,6 +3406,14 @@ fn execute_resource_action(action: ResourceAction, state: &FederationState, app:
                 format!("split pane {} on {target_session}", direction.label()),
                 true,
             );
+        }
+        ResourceAction::MarkAgent { agent, mark, .. } => {
+            // No confirmation and no Herdr operation: a mark changes what this
+            // inbox shows and nothing on the host, and the daemon answers by
+            // republishing the projection this mirror is built from.
+            if let Some(client) = app.client.as_ref() {
+                client.mark_agent(agent, mark);
+            }
         }
         ResourceAction::TogglePaneZoom { pane } => {
             let target_session = pane.target_session();
@@ -5263,12 +5342,17 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
         ServerMessage::AttentionHistory { events } => {
             app.attention = AttentionIndex::mirror(events);
         }
-        // The TUI navigates the hierarchy and derives its own agent list from
-        // federation state, so it does not subscribe to the inbox projection
-        // and is never sent one. Named rather than caught by a wildcard, so
-        // adding a message a client must handle stays a compile error.
-        ServerMessage::AgentCards { .. }
-        | ServerMessage::Hello { .. }
+        // The hierarchy stays the TUI's navigation, and the agent list it
+        // renders is still its own. What the projection is read for here is
+        // the marks a person put on a card, so a context menu can offer the
+        // toggle that is available instead of both halves of it.
+        ServerMessage::AgentCards { projection } => {
+            app.agent_marks = projection
+                .cards()
+                .map(|card| (card.agent.clone(), card.marks))
+                .collect();
+        }
+        ServerMessage::Hello { .. }
         | ServerMessage::FederationState { .. }
         | ServerMessage::TargetState { .. }
         | ServerMessage::PluginRun { .. } => {}
@@ -5367,6 +5451,7 @@ fn render(frame: &mut Frame, state: &FederationState, app: &App) {
             app.selected_pane.as_ref(),
             palette,
             &app.plugin_catalogs,
+            &app.agent_marks,
         );
     } else if let Some(prompt) = app.text_prompt.as_ref() {
         render_text_prompt(frame, prompt);
@@ -5472,6 +5557,7 @@ fn render_command_palette(
     selected: Option<&PaneId>,
     palette: &CommandPalette,
     plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
+    agent_marks: &BTreeMap<AgentId, AgentMarkState>,
 ) {
     let area = centered_popup(frame.area(), 82, 22);
     frame.render_widget(Clear, area);
@@ -5482,7 +5568,13 @@ fn render_command_palette(
         .padding(Padding::horizontal(1));
     let inner = block.inner(area);
     frame.render_widget(block, area);
-    let actions = filtered_palette_actions(state, selected, &palette.query, plugin_catalogs);
+    let actions = filtered_palette_actions(
+        state,
+        selected,
+        &palette.query,
+        plugin_catalogs,
+        agent_marks,
+    );
     let mut lines = vec![
         Line::from(vec![
             Span::styled("> ", Style::default().fg(Color::Cyan)),
@@ -7738,8 +7830,8 @@ mod tests {
         ClipboardFeedback, ContextTarget, DecodedInput, HERDR_PREFIX_KEY, InputDecoder, InputMode,
         MAX_CLIPBOARD_BYTES, MAX_CONTEXT_MENU_MOVE_DESTINATIONS, MOUSE_CAPTURE_ENABLE, MouseInput,
         PREFIX_KEY, PaneDirection, PluginCatalog, SIDEBAR_WIDTH, SelectionAutoscroll,
-        SelectionAutoscrollDirection, SelectionFinish, TargetForm, TargetManager,
-        TargetManagerControl, TargetManagerMode, TargetTestEvent, TargetTestState,
+        SelectionAutoscrollDirection, SelectionFinish, TUI_SNOOZE_MINUTES, TargetForm,
+        TargetManager, TargetManagerControl, TargetManagerMode, TargetTestEvent, TargetTestState,
         TerminalSelection, agent_jump_entries, capture_screen_rows, capture_selection_viewport,
         clamped_pane_position, command_palette_actions, context_menu_for_target, cycle_tab,
         desired_access, displayed_message, encode_mouse_event, federation_routes_changed,
@@ -7754,8 +7846,9 @@ mod tests {
         update_selection_after_frame, update_sidebar_hit_areas, viewport_shift_distance,
         visible_pane_areas,
     };
+    use crate::agent_marks::{AgentMarkRequest, AgentMarkState};
     use crate::config::{Config, Target};
-    use crate::model::{PaneId, TargetSession, WorkspaceId};
+    use crate::model::{AgentId, PaneId, TargetSession, WorkspaceId};
     use crate::plugin::{PluginAction, PluginActionContext, PluginActionId};
     use crate::resource_action::ResourceAction;
     use crate::state::{
@@ -7926,6 +8019,7 @@ mod tests {
             app.selected_pane.as_ref(),
             "jump second",
             &app.plugin_catalogs,
+            &app.agent_marks,
         );
         assert_eq!(actions.len(), 1);
         let ResourceAction::JumpToPane { pane, .. } = &actions[0] else {
@@ -7975,7 +8069,7 @@ mod tests {
             target.clone(),
             runtime(target, TargetConnectionState::Live, Some(snapshot)),
         );
-        let actions = command_palette_actions(&state, Some(&pane), &catalogs);
+        let actions = command_palette_actions(&state, Some(&pane), &catalogs, &BTreeMap::new());
         assert!(actions.iter().any(|action| {
             matches!(
                 action,
@@ -7991,6 +8085,155 @@ mod tests {
                     if action.id.action_id == "translate-selection"
             )
         }));
+    }
+
+    #[test]
+    fn a_pane_running_an_agent_can_be_pinned_muted_and_snoozed() {
+        let key = TargetSession::new("host-b", "work");
+        let pane = PaneId::new("host-b", "work", "w2:p1");
+        let snapshot = NormalizedSnapshot::from_value(
+            &key,
+            &json!({
+                "workspaces": [{"workspace_id": "w2"}],
+                "tabs": [{"tab_id": "w2:t1", "workspace_id": "w2"}],
+                "panes": [
+                    {"pane_id": "w2:p1", "workspace_id": "w2", "tab_id": "w2:t1"},
+                    {"pane_id": "w2:p2", "workspace_id": "w2", "tab_id": "w2:t1"}
+                ],
+                "agents": [{"pane_id": "w2:p1", "name": "reviewer", "agent_status": "blocked"}]
+            }),
+        );
+        let mut state = FederationState::default();
+        state.targets.insert(
+            key.clone(),
+            runtime(key, TargetConnectionState::Live, Some(snapshot)),
+        );
+
+        let menu = context_menu_for_target(
+            &state,
+            ContextTarget::Pane(pane.clone()),
+            ratatui::layout::Position::new(1, 1),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        let marks = menu
+            .actions
+            .iter()
+            .filter_map(|action| match action {
+                ResourceAction::MarkAgent { agent, mark, .. } => Some((agent.clone(), *mark)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            marks,
+            vec![
+                (
+                    AgentId::new("host-b", "work", "w2:p1"),
+                    AgentMarkRequest::Pin { pinned: true }
+                ),
+                (
+                    AgentId::new("host-b", "work", "w2:p1"),
+                    AgentMarkRequest::Mute { muted: true }
+                ),
+                (
+                    AgentId::new("host-b", "work", "w2:p1"),
+                    AgentMarkRequest::Snooze {
+                        minutes: Some(TUI_SNOOZE_MINUTES)
+                    }
+                ),
+            ]
+        );
+        assert!(
+            menu.actions
+                .iter()
+                .filter(|action| matches!(action, ResourceAction::MarkAgent { .. }))
+                .all(|action| !action.mutates_herdr()),
+            "a mark is Super-Herdr's own inbox state and must not reach the host"
+        );
+    }
+
+    #[test]
+    fn a_pane_without_an_agent_is_offered_nothing_to_mark() {
+        let key = TargetSession::new("host-b", "work");
+        let snapshot = NormalizedSnapshot::from_value(
+            &key,
+            &json!({
+                "workspaces": [{"workspace_id": "w2"}],
+                "tabs": [{"tab_id": "w2:t1", "workspace_id": "w2"}],
+                "panes": [{"pane_id": "w2:p2", "workspace_id": "w2", "tab_id": "w2:t1"}]
+            }),
+        );
+        let mut state = FederationState::default();
+        state.targets.insert(
+            key.clone(),
+            runtime(key, TargetConnectionState::Live, Some(snapshot)),
+        );
+
+        let menu = context_menu_for_target(
+            &state,
+            ContextTarget::Pane(PaneId::new("host-b", "work", "w2:p2")),
+            ratatui::layout::Position::new(1, 1),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(
+            !menu
+                .actions
+                .iter()
+                .any(|action| matches!(action, ResourceAction::MarkAgent { .. })),
+            "a shell has nothing to pin, and an entry that did nothing is one more line to read past"
+        );
+    }
+
+    #[test]
+    fn a_marked_agent_is_offered_the_toggle_that_is_available() {
+        let key = TargetSession::new("host-b", "work");
+        let pane = PaneId::new("host-b", "work", "w2:p1");
+        let snapshot = NormalizedSnapshot::from_value(
+            &key,
+            &json!({
+                "workspaces": [{"workspace_id": "w2"}],
+                "tabs": [{"tab_id": "w2:t1", "workspace_id": "w2"}],
+                "panes": [{"pane_id": "w2:p1", "workspace_id": "w2", "tab_id": "w2:t1"}],
+                "agents": [{"pane_id": "w2:p1", "agent_status": "blocked"}]
+            }),
+        );
+        let mut state = FederationState::default();
+        state.targets.insert(
+            key.clone(),
+            runtime(key, TargetConnectionState::Live, Some(snapshot)),
+        );
+        let marks = BTreeMap::from([(
+            AgentId::new("host-b", "work", "w2:p1"),
+            AgentMarkState {
+                pinned: true,
+                muted: false,
+                snoozed_until_ms: Some(1_700_000_000_000),
+            },
+        )]);
+
+        let menu = context_menu_for_target(
+            &state,
+            ContextTarget::Pane(pane),
+            ratatui::layout::Position::new(1, 1),
+            &BTreeMap::new(),
+            &marks,
+        )
+        .unwrap();
+
+        let labels = menu
+            .actions
+            .iter()
+            .filter(|action| matches!(action, ResourceAction::MarkAgent { .. }))
+            .map(ResourceAction::palette_label)
+            .collect::<Vec<_>>();
+        assert!(labels.iter().any(|label| label.starts_with("Unpin agent")));
+        assert!(labels.iter().any(|label| label.starts_with("Mute agent")));
+        assert!(labels.iter().any(|label| label.starts_with("Wake agent")));
     }
 
     #[test]
@@ -8015,6 +8258,7 @@ mod tests {
             &state,
             ContextTarget::Workspace(workspace.clone()),
             ratatui::layout::Position::new(4, 5),
+            &BTreeMap::new(),
             &BTreeMap::new(),
         )
         .unwrap();
@@ -8067,6 +8311,7 @@ mod tests {
             &state,
             ContextTarget::Workspace(workspace.clone()),
             ratatui::layout::Position::new(4, 5),
+            &BTreeMap::new(),
             &BTreeMap::new(),
         )
         .unwrap();
@@ -8183,6 +8428,7 @@ mod tests {
             ContextTarget::Workspace(workspace.clone()),
             ratatui::layout::Position::new(4, 5),
             &BTreeMap::new(),
+            &BTreeMap::new(),
         )
         .unwrap();
 
@@ -8230,6 +8476,7 @@ mod tests {
             ContextTarget::Workspace(WorkspaceId::new("host-b", "work", "w1")),
             ratatui::layout::Position::new(0, 0),
             &BTreeMap::new(),
+            &BTreeMap::new(),
         )
         .unwrap();
         let menu_moves = menu
@@ -8242,6 +8489,7 @@ mod tests {
         let palette = command_palette_actions(
             &state,
             Some(&PaneId::new("host-b", "work", "w1:p1")),
+            &BTreeMap::new(),
             &BTreeMap::new(),
         );
         let palette_moves = palette

--- a/tools/page-harness.mjs
+++ b/tools/page-harness.mjs
@@ -368,6 +368,12 @@ const projection = overrides => ({
   },
 });
 const sections = () => page.el('inbox-sections').children;
+// A card is a container: the primary action first, then the marks a person can
+// put on it. Reaching through it here keeps the assertions about behaviour
+// rather than about which element happens to carry the handler.
+const openOf = one => one.children[0];
+const marksOf = one => (one.children[1] ? one.children[1].children : []);
+const markChip = (one, kind) => marksOf(one).find(chip => chip.dataset.mark === kind);
 const cardsIn = index => sections()[index].children.slice(1);
 const chipFor = (group, value) => page.el('inbox-filters').children
   .find(one => one.dataset.group === group && one.dataset.value === value);
@@ -426,15 +432,20 @@ deliver(projection({
     card('p7', { section: 'recent', actionable: false, stale: true, status: 'blocked' }),
   ],
 }));
-check('history is not clickable', typeof cardsIn(0)[0].onclick !== 'function');
-check('history says so to a screen reader', cardsIn(0)[0]['aria-disabled'] === 'true');
-check('history is disabled', cardsIn(0)[0].disabled === true);
-check('a stale card explains the host, not the agent', cardsIn(0)[1].children[1].children[1].textContent === 'host not connected');
+check('history is not clickable', typeof openOf(cardsIn(0)[0]).onclick !== 'function');
+check('history says so to a screen reader', openOf(cardsIn(0)[0])['aria-disabled'] === 'true');
+check('history is disabled', openOf(cardsIn(0)[0]).disabled === true);
+check(
+  'a stale card explains the host, not the agent',
+  openOf(cardsIn(0)[1]).children[1].children[1].textContent === 'host not connected',
+);
+check('a gone agent offers nothing to mark', marksOf(cardsIn(0)[0]).length === 0);
+check('a stale card still offers its marks', marksOf(cardsIn(0)[1]).length === 3);
 
 // Opening a card routes to its own qualified pane and settles its attention.
 deliver(projection({ needs_you: [card('p1', { unread: true })] }));
 sent.length = 0;
-cardsIn(0)[0].onclick();
+openOf(cardsIn(0)[0]).onclick();
 check(
   'opening a card marks its attention seen',
   sent.some(one => one.body.type === 'attention.mark_seen' && one.body.pane.resource === 'p1'),
@@ -459,6 +470,45 @@ deliver(projection({
 check('a repaint keeps watching the same pane', page.el('viewing').textContent === watched);
 check('a repaint subscribes to nothing', sent.every(one => one.body.type !== 'pane.subscribe'));
 check('a repaint takes no focus', page.el('line').focused === false);
+
+// Pins, mutes and snoozes are requests to the daemon, and never anything that
+// reaches the host.
+deliver(projection({ needs_you: [card('p1'), card('p2')] }));
+sent.length = 0;
+markChip(cardsIn(0)[1], 'pin').onclick();
+const pinRequest = sent.find(one => one.body.type === 'agents.mark');
+check('pinning names the qualified agent', pinRequest.body.agent.resource === 'p2'
+  && pinRequest.body.agent.target === 'first' && pinRequest.body.agent.session === 'main');
+check('pinning asks for a pin', pinRequest.body.mark.kind === 'pin' && pinRequest.body.mark.pinned === true);
+check('a mark is the only thing sent', sent.length === 1);
+
+sent.length = 0;
+markChip(cardsIn(0)[0], 'snooze').onclick();
+const snoozeRequest = sent.find(one => one.body.type === 'agents.mark');
+check('a snooze asks for a duration, never a moment',
+  snoozeRequest.body.mark.kind === 'snooze' && snoozeRequest.body.mark.minutes === 60);
+
+// The daemon answers by republishing the inbox; the page renders that and
+// never assumes its own request landed.
+deliver(projection({
+  needs_you: [
+    card('p2', { marks: { pinned: true, muted: false } }),
+    card('p1'),
+  ],
+}));
+check('a pinned card reports itself pressed', markChip(cardsIn(0)[0], 'pin')['aria-pressed'] === 'true');
+check('a pinned card names the state it is in', markChip(cardsIn(0)[0], 'pin').textContent === 'Pinned');
+check('an unpinned card stays unpressed', markChip(cardsIn(0)[1], 'pin')['aria-pressed'] === 'false');
+check('a pinned agent offers a pinned filter', chipFor('state', 'pinned') !== undefined);
+chipFor('state', 'pinned').onclick();
+check('the pinned filter keeps only pinned cards', cardsIn(0).length === 1);
+check('the pinned filter keeps the qualified identity', cardsIn(0)[0].dataset.agent === 'first/main/p2');
+sent.length = 0;
+markChip(cardsIn(0)[0], 'pin').onclick();
+check('unpinning asks to clear the pin',
+  sent.find(one => one.body.type === 'agents.mark').body.mark.pinned === false);
+deliver(projection({ needs_you: [card('p2'), card('p1')] }));
+check('a filter that can no longer match anything steps aside', cardsIn(0).length === 2);
 
 // A reconnect asks for the inbox again, because the daemon remembers nothing
 // about what this page held.

--- a/tools/page-harness.mjs
+++ b/tools/page-harness.mjs
@@ -16,7 +16,7 @@ let created = 0;
 const node = id => {
   if (!nodes.has(id)) {
     const held = {
-      id, hidden: false, textContent: '', innerHTML: '', value: '',
+      id, hidden: false, textContent: '', value: '',
       className: '', style: {}, dataset: {}, children: [], disabled: false,
       append(...children) { this.children.push(...children); },
       remove() {},
@@ -34,6 +34,18 @@ const node = id => {
           .filter(Boolean).join(' ');
       },
     };
+    // A real element drops its children when its markup is replaced. The stub
+    // has to as well: rendering a list twice would otherwise report the sum of
+    // both renders, and every count assertion below would be measuring a bug
+    // that does not exist in a browser.
+    let markup = '';
+    Object.defineProperty(held, 'innerHTML', {
+      get: () => markup,
+      set(value) {
+        markup = value;
+        if (value === '') held.children = [];
+      },
+    });
     held.querySelector = selector => node(`${id}-${selector}`);
     nodes.set(id, held);
   }
@@ -330,3 +342,135 @@ check(
   'utf-8 survives',
   Buffer.from(sent.at(-1).body.bytes, 'base64').toString('utf8') === 'echo Sønderborg\r',
 );
+
+// The agent inbox. Sections, ordering and membership are the daemon's answer;
+// this page renders it and is checked for exactly that.
+const card = (resource, overrides = {}) => ({
+  agent: { target: 'first', session: 'main', resource },
+  pane: { target: 'first', session: 'main', resource },
+  title: resource,
+  workspace: 'compiler',
+  tab: 'build',
+  pane_label: resource,
+  provider: 'claude',
+  activity: 'needs_input',
+  status: 'blocked',
+  section: 'needs_you',
+  unread: false,
+  stale: false,
+  actionable: true,
+  ...overrides,
+});
+const projection = overrides => ({
+  type: 'agents.cards',
+  projection: {
+    version: 1, revision: 1, needs_you: [], working: [], recent: [], ...overrides,
+  },
+});
+const sections = () => page.el('inbox-sections').children;
+const cardsIn = index => sections()[index].children.slice(1);
+const chipFor = (group, value) => page.el('inbox-filters').children
+  .find(one => one.dataset.group === group && one.dataset.value === value);
+
+deliver(projection({
+  needs_you: [card('p2'), card('p1')],
+  working: [card('p3', { status: 'working', activity: 'working', section: 'working' })],
+}));
+check('renders one block per non-empty section', sections().length === 2);
+check(
+  'keeps the order the daemon published',
+  cardsIn(0).map(one => one.dataset.agent).join() === 'first/main/p2,first/main/p1',
+);
+check('titles a section with its count', sections()[0].children[0].textContent === 'Needs you (2)');
+check('reports how many agents are waiting', page.el('inbox-count').textContent === '2 waiting');
+check('offers the hierarchy as a way back', page.el('hierarchy') !== undefined);
+
+// Filtering is a view of the same projection. It never asks the daemon for a
+// different one, and it never changes what is being watched.
+sent.length = 0;
+chipFor('state', 'working').onclick();
+check('a state filter narrows to one section', sections().length === 1);
+check('a state filter keeps its section intact', cardsIn(0).length === 1);
+check('filtering asks the daemon for nothing', sent.length === 0);
+check(
+  'a chip reports its own pressed state',
+  chipFor('state', 'working')['aria-pressed'] === 'true'
+    && chipFor('state', 'all')['aria-pressed'] === 'false',
+);
+chipFor('state', 'all').onclick();
+check('clearing a filter restores every section', sections().length === 2);
+
+// A dimension with one value offers no chip, because a control that cannot
+// change anything is only something else to read on a phone.
+check('offers no host chips for a single host', chipFor('target', 'all') === undefined);
+deliver(projection({
+  needs_you: [
+    card('p1'),
+    { ...card('p9'), agent: { target: 'second', session: 'main', resource: 'p9' },
+      pane: { target: 'second', session: 'main', resource: 'p9' }, provider: 'codex' },
+  ],
+}));
+check('offers host chips once there are two hosts', chipFor('target', 'second') !== undefined);
+chipFor('target', 'second').onclick();
+check('a host filter keeps only that host', cardsIn(0).length === 1);
+check('a host filter keeps the qualified identity', cardsIn(0)[0].dataset.agent === 'second/main/p9');
+chipFor('provider', 'codex') && chipFor('provider', 'codex').onclick();
+check('an agent-kind filter composes with a host filter', cardsIn(0).length === 1);
+chipFor('target', 'all').onclick();
+chipFor('provider', 'all').onclick();
+
+// A card that cannot resolve is shown and not offered.
+deliver(projection({
+  recent: [
+    card('p8', { section: 'recent', actionable: false, pane: undefined, activity: 'gone', status: 'idle' }),
+    card('p7', { section: 'recent', actionable: false, stale: true, status: 'blocked' }),
+  ],
+}));
+check('history is not clickable', typeof cardsIn(0)[0].onclick !== 'function');
+check('history says so to a screen reader', cardsIn(0)[0]['aria-disabled'] === 'true');
+check('history is disabled', cardsIn(0)[0].disabled === true);
+check('a stale card explains the host, not the agent', cardsIn(0)[1].children[1].children[1].textContent === 'host not connected');
+
+// Opening a card routes to its own qualified pane and settles its attention.
+deliver(projection({ needs_you: [card('p1', { unread: true })] }));
+sent.length = 0;
+cardsIn(0)[0].onclick();
+check(
+  'opening a card marks its attention seen',
+  sent.some(one => one.body.type === 'attention.mark_seen' && one.body.pane.resource === 'p1'),
+);
+check(
+  'opening a card subscribes to its exact qualified pane',
+  sent.some(one => one.body.type === 'pane.subscribe'
+    && one.body.pane.target === 'first' && one.body.pane.resource === 'p1'),
+);
+const watched = page.el('viewing').textContent;
+
+// Background churn repaints the inbox and must not move what a person is
+// reading. The daemon re-resolves before it routes; the page must not
+// re-route on its own.
+sent.length = 0;
+page.el('line').focused = false;
+deliver(projection({
+  revision: 2,
+  needs_you: [card('p4'), card('p1', { unread: true })],
+  working: [card('p5', { status: 'working', section: 'working' })],
+}));
+check('a repaint keeps watching the same pane', page.el('viewing').textContent === watched);
+check('a repaint subscribes to nothing', sent.every(one => one.body.type !== 'pane.subscribe'));
+check('a repaint takes no focus', page.el('line').focused === false);
+
+// A reconnect asks for the inbox again, because the daemon remembers nothing
+// about what this page held.
+sent.length = 0;
+deliver({ type: 'server.hello', protocol: 3, server_version: '0.7.20', features: ['terminal', 'agent_cards'] });
+check('a reconnect resubscribes to the inbox', sent.some(one => one.body.type === 'agents.subscribe'));
+
+// An older daemon has no inbox to send. Say so instead of waiting forever.
+sent.length = 0;
+deliver({ type: 'server.hello', protocol: 3, server_version: '0.7.20', features: ['terminal'] });
+check('an older daemon asks for no inbox', sent.every(one => one.body.type !== 'agents.subscribe'));
+check('an older daemon hides the inbox', page.el('inbox').hidden === true);
+check('an older daemon opens the hierarchy instead', page.el('hierarchy').open === true);
+deliver({ type: 'server.hello', protocol: 3, server_version: '0.7.20', features: ['terminal', 'agent_cards'] });
+page.el('inbox').hidden = false;


### PR DESCRIPTION
The agent inbox: a task-oriented view of the federation, for a screen where the hierarchy does not fit.

Reviewing in commit order works well here — each commit is one decision.

## What changes

**`src/agent_card.rs`** — a daemon-owned projection of agents into `Needs you` / `Working` / `Recent`. The daemon builds it rather than each client deriving one, because two clients deriving sections independently disagree the moment their snapshots differ by a refresh, and a person moving between the TUI and a phone would read two different inboxes.

**The browser** opens on it, with the hierarchy one tap away behind "All targets and panes".

**Pins, mutes and snoozes** (`src/agent_marks.rs`) let a person shape that order. A mute or snooze quiets an agent everywhere but does not deny what it is — the card still says `needs_input`, because a card claiming otherwise is one somebody could act on wrongly. A snooze is a duration from the client and a deadline computed by the daemon: a phone with a wrong clock must not be able to silence an agent for a year.

## The two things most worth your attention

**A card is not a route.** It records what was true when it was built; the live pane is re-derived from the current federation before anything is sent, and refuses when the target is not live, the agent is gone, its pane is missing, or a snapshot disagrees with itself. That is what lets a one-refresh-stale card be rendered safely.

**The identity commit (`Key an agent card by the session Herdr reports`) corrects the two before it.** I originally keyed cards by pane, on the stated grounds that a pane was the only identity Herdr gives an agent. That was wrong: `AgentInfo` carries an optional `agent_session`, and Super-Herdr's parser simply never read it. Under the old key an agent moving pane read as one agent dying and another being born — retiring the card, sending the new one to the back of the queue, and stranding any pin. It is folded into this PR rather than left as a later fix so the branch never contains the wrong model.

That field is **absent in practice at protocol 19** (verified against a live 0.8.0 snapshot), so panes remain the fallback and the session path is proven by tests only. It needs a Herdr build that populates the field to confirm end to end.

## Checks

352 tests · 110 page-harness assertions · `fmt`, `clippy --all-targets -D warnings` on host and `x86_64-apple-darwin`, `check-docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdRHimPZdtFsZgAnmpCRUE
