### PR TITLE
Configurable quick replies and paired-device alerts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -539,6 +539,47 @@ A reply becomes terminal input like any other, which means it needs the pane's
 control lease and is refused by the daemon without one. An armed confirmation
 belongs to the moment it was armed in, so losing the lease disarms it.
 
+Alerting a paired device is a second sink beside the desktop's own, and it
+lives in the daemon rather than in the frontend. The desktop's queue belongs to
+the machine somebody is sitting at; this one exists precisely for the case
+where they are not, so it runs where the attention index is derived and needs
+no client awake to produce it. It reuses that queue's filters, coalescing
+window and rate limit rather than inventing a second set, and is switched on
+separately, because wanting alerts on a phone is not the same request as
+wanting them on the laptop.
+
+Three consents are kept distinct, because they are granted at different moments
+and one must never stand in for another: the operator enables the sink in
+configuration, the browser grants its own notification permission, and the page
+subscribes. Rendering the inbox subscribes to nothing — showing somebody their
+agents is not the same as interrupting them about one — and an alert reaching a
+page that has turned them off is discarded there as well as not sent. A device
+that subscribes late is not caught up: an interruption about a moment already
+over is only noise.
+
+Per-agent modes are the marks that already exist plus one more. Muting or
+snoozing an agent quiets it everywhere, because an agent somebody removed from
+their inbox has not asked to keep calling their phone, and the only new mode is
+the narrow one — tell me when this agent is blocked on me and never otherwise.
+
+A payload carries bounded metadata by construction rather than by filtering. It
+is built from an attention event, which holds an agent name, a workspace label,
+a qualified pane and a transition kind; terminal contents never reach one. That
+is worth stating as a rule rather than an accident, because Herdr's snapshot
+does carry `terminal_title` — an agent's current sentence, often a paraphrase
+of somebody's prompt — and nothing here reads it. An alert names an identity
+rather than a route, so tapping one re-resolves the live pane against the inbox
+as it is now and refuses when the agent has gone, distinguishing an agent that
+ended from one whose host is unreachable.
+
+What this does not yet do is reach a device whose browser is closed. That needs
+Web Push: a service worker, VAPID signing, and a third-party push service as a
+new outbound trust boundary — the endpoint is supplied by the browser, so it
+also needs bounding against being pointed somewhere else. The design that would
+fit here sends no payload at all and lets the woken service worker ask the
+daemon, so the push service learns that something happened and never what. That
+is a separate decision about dependencies and trust, not a detail of this sink.
+
 Delivering a notification is a separate question from owning the index, and it
 divides the way the clipboard does. Native desktop delivery is a desktop-session
 capability: it belongs to the client, because a daemon on another machine

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -512,6 +512,33 @@ without another clock in the process to keep correct. The file is bounded in
 every direction — how many agents may be marked, how large it may be, how far a
 snooze may reach — because it is written by a request from a paired device.
 
+One-tap replies on a paired device are configuration, not interpretation. The
+distinction is forced by what Herdr documents: its API reports an agent's
+status and whether it is ready for input, and nothing anywhere in its request
+or event schemas describes the options a blocked agent is offering. There is
+therefore no structured prompt metadata to render a semantic Yes, No, Approve
+or numbered-choice button from, and the only way to produce one would be to
+read the terminal and guess. Super-Herdr does not: a button that types `y`
+because the screen looked like a yes/no prompt is a keystroke sent on the
+strength of a pattern match, and the person holding the phone cannot see the
+match that produced it.
+
+So the replies are what somebody wrote down in their own configuration. The
+daemon sends the list in the handshake, because it is constant for the process
+and a client needs it before it can draw controls, and a client renders exactly
+that list — an empty one draws no buttons rather than falling back to a guess.
+Each reply carries its own text, whether Enter follows it, and whether it wants
+confirming; with no structured metadata to learn that a response is
+irreversible from, the person who wrote the reply is the one who declares it,
+and confirming is a second tap on the button rather than a dialog a phone
+dismisses by reflex. Control characters are refused in a reply's text, so a
+configuration cannot smuggle an escape sequence into a pane: Enter, Escape, Tab
+and Ctrl-C are separate, explicitly labelled keys.
+
+A reply becomes terminal input like any other, which means it needs the pane's
+control lease and is refused by the daemon without one. An armed confirmation
+belongs to the moment it was armed in, so losing the lease disarms it.
+
 Delivering a notification is a separate question from owning the index, and it
 divides the way the clipboard does. Native desktop delivery is a desktop-session
 capability: it belongs to the client, because a daemon on another machine

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -140,28 +140,35 @@ no connection event can redirect input.
 
 ### 2. Structured response actions
 
-- [ ] Define a protocol representation for bounded response choices with a
-      stable action ID, label, qualified agent route, expiry, and action kind.
-- [ ] Accept structured choices only from documented Herdr or plugin metadata.
-- [ ] Do not infer buttons by scraping or parsing terminal output.
-- [ ] Render common choices as compact buttons: yes, no, approve, deny, and
-      numbered selections.
-- [ ] Keep Enter, Escape, Tab, Ctrl-C, history arrows, and customizable quick
+**The dependency below resolved against structured choices.** Herdr's API
+schema (checked at protocol 19, `herdr api schema --json`) reports an agent's
+status and whether it is ready for input, and describes nowhere what a blocked
+agent is asking: there is no choice, option, confirm, or approve concept in its
+request or event schemas. Semantic response buttons therefore stay blocked, and
+this step ships user-configured quick replies instead.
+
+- [x] Do not infer buttons by scraping or parsing terminal output.
+- [x] Keep Enter, Escape, Tab, Ctrl-C, history arrows, and customizable quick
       replies as explicit terminal controls.
-- [ ] Require the pane control lease for any response that becomes terminal
+- [x] Require the pane control lease for any response that becomes terminal
       input.
-- [ ] Expire buttons when the prompt, agent, session, or control lease changes.
-- [ ] Confirm actions whose structured metadata declares a destructive or
-      irreversible effect.
-- [ ] Test stale choices, duplicate IDs across targets, lease loss, retries,
-      and partial target failure.
+- [x] Confirm actions whose structured metadata declares a destructive or
+      irreversible effect. With no such metadata to read, the person who wrote
+      the reply declares it with `confirm`.
+- [x] Test stale choices, lease loss, and retries.
+- [ ] Blocked on Herdr: a protocol representation for bounded response choices
+      with a stable action ID, label, qualified agent route, expiry, and action
+      kind.
+- [ ] Blocked on Herdr: accept structured choices only from documented Herdr or
+      plugin metadata.
+- [ ] Blocked on Herdr: render common choices as compact buttons — yes, no,
+      approve, deny, and numbered selections.
+- [ ] Blocked on Herdr: expire buttons when the prompt changes. Agent, session
+      and lease changes already disarm a waiting reply.
 
-Dependency: if the documented Herdr/plugin interfaces cannot supply structured
-prompt choices, ship only user-configured quick replies and keep semantic
-choices blocked rather than guessing from terminal contents.
-
-Exit condition: a phone can answer a supported prompt with one tap, while a
-stale or ambiguous action reaches no pane.
+Exit condition: a phone can answer with one configured tap, a reply that
+declares itself irreversible takes two, and nothing reaches a pane without the
+control lease.
 
 ### 3. Paired-device notifications
 

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -172,21 +172,29 @@ control lease.
 
 ### 3. Paired-device notifications
 
-- [ ] Add opt-in push delivery as another sink under the existing attention
-      filters, coalescing, and rate limits.
-- [ ] Add per-agent modes: default, needs-attention only, muted, and temporary
+- [x] Add opt-in delivery as another sink under the existing attention filters,
+      coalescing, and rate limits.
+- [x] Add per-agent modes: default, needs-attention only, muted, and temporary
       snooze.
-- [ ] Put only bounded metadata in notification payloads.
-- [ ] Make a notification open the exact qualified live card or report that it
+- [x] Put only bounded metadata in notification payloads.
+- [x] Make a notification open the exact qualified live card or report that it
       is no longer available.
-- [ ] Never embed terminal output, clipboard data, filenames, pairing material,
+- [x] Never embed terminal output, clipboard data, filenames, pairing material,
       or secrets in a notification.
-- [ ] Document browser/platform requirements and a deterministic test path.
-- [ ] Test delayed delivery, duplicate delivery, revoked devices, expired
-      routes, target disconnects, and notification-click races.
+- [x] Document browser/platform requirements and a deterministic test path.
+- [x] Test duplicate delivery, unsubscribed devices, expired routes, target
+      disconnects, and notification-click races.
+- [ ] Reach a device whose browser is closed. This needs Web Push: a service
+      worker, VAPID signing, and a third-party push service as a new outbound
+      trust boundary whose endpoint the browser supplies. The design that fits
+      here sends no payload and lets the woken service worker ask the daemon,
+      so the push service learns that something happened and never what. It is
+      a dependency and trust decision, not a detail of the sink, and wants its
+      own branch.
 
-Exit condition: the user can leave the browser closed, receive one useful
-attention alert, and return to the correct agent without exposing payloads.
+Exit condition: a paired device receives one useful attention alert under the
+same filters as the desktop and returns to the correct agent without exposing
+payloads. Receiving one with the browser closed waits on the item above.
 
 ### 4. Remote files and artifacts
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ so a reconnect can never redirect your next keystroke.
 - Explicit control leases: background panes and newly opened browser panes are
   read-only until control is granted
 - Desktop selection, clipboard paste, drag-and-drop, and verified uploads
-- Browser quick replies, terminal keys, a soft-keyboard dock, and a file picker
+- Configurable browser quick replies, terminal keys, a soft-keyboard dock, and
+  a file picker
 - Digest-verified local-to-host, host-to-local, and host-to-host file transfer
 - Bounded reconnects and per-target failure isolation
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ naming the host and Herdr session it belongs to. Tap one to open that exact
 pane. Chips filter by state, host, and agent kind, and **All targets and
 panes** is always one tap away when you want the hierarchy instead.
 
+Turn on **Alerts** in the browser to be told when an agent wants you, under the
+same filters, coalescing and rate limit as the desktop notifications — opt in
+with `notifications.devices` and grant the browser's own permission. An alert
+carries a label and a status word, never terminal contents, and tapping it
+opens that exact agent or says it has gone. It reaches a device while the page
+is running; waking a closed browser needs Web Push and is not built yet.
+
 Pin an agent to keep it at the top, or mute or snooze one to move it out of the
 way for a while — in the browser on the card itself, in the TUI from the same
 right-click menus and action palette. These are Super-Herdr's own view of your
@@ -156,6 +163,8 @@ so a reconnect can never redirect your next keystroke.
   tap to the exact pane that needs you
 - Per-agent pins, mutes, and snoozes that order your own inbox and never touch
   a Herdr session
+- Opt-in paired-device alerts carrying bounded metadata, with per-agent
+  needs-you-only, mute, and snooze modes
 - A live, clickable TUI with tabs, split panes, search, and agent attention
 - Qualified plugin actions in the TUI and browser, with sanitized run status
   and explicit routing to any newly opened pane

--- a/config.example.toml
+++ b/config.example.toml
@@ -26,6 +26,23 @@ command_timeout_seconds = 5
 [transfers]
 max_bytes = 1073741824
 
+# One-tap replies offered on a paired device.
+#
+# These are replies you decided you send often, not choices read off a screen.
+# Herdr's API reports that an agent is ready for input, never what it is
+# asking, so Super-Herdr will not show a Yes button because a terminal looked
+# like a yes/no prompt — that would be a keystroke sent on a pattern match.
+#
+# Leaving this out offers Yes, No, Continue and Retry. An empty list
+# (quick_replies = []) offers none. At most eight, each sending 1 to 256 bytes
+# of text with no control characters: Enter, Escape, Tab and Ctrl-C are their
+# own keys, and `submit` is what appends the Enter.
+#[[quick_replies]]
+#label = "Approve"
+#send = "approve"
+#submit = true      # append Enter; on by default
+#confirm = false    # ask for a second tap before sending
+
 [[targets]]
 name = "development"
 ssh = "development-host"

--- a/config.example.toml
+++ b/config.example.toml
@@ -17,6 +17,13 @@ completed = true
 disappeared = true
 working = false
 status_changed = false
+# Also alert paired devices, under the same filters, coalescing and rate limit.
+# Separate from `enabled`, which is this machine's own desktop notifications:
+# wanting alerts on a phone is not the same request as wanting them on the
+# laptop you are sitting at. A device still has to grant its browser's
+# notification permission and turn Alerts on in the page, and today it is
+# alerted while that page is running — see ARCHITECTURE.md.
+devices = false
 minimum_interval_seconds = 5
 command_timeout_seconds = 5
 

--- a/examples/qualify-upload.rs
+++ b/examples/qualify-upload.rs
@@ -214,6 +214,7 @@ async fn relay(
                 ],
             }],
             devices: Vec::new(),
+            quick_replies: None,
         },
         None,
         DaemonOptions {

--- a/src/agent_card.rs
+++ b/src/agent_card.rs
@@ -576,6 +576,32 @@ impl AgentCardIndex {
     }
 }
 
+/// The identity of whichever agent is in this pane right now, or the identity
+/// a pane-keyed agent there would have.
+///
+/// Used where something holds a pane and needs the identity that names it — an
+/// attention event, for instance, which records where a transition happened.
+/// The fallback is not a guess: it is exactly the key an agent without a
+/// reported session gets, so an identity derived here and one derived from the
+/// snapshot agree.
+pub fn agent_key_for_pane(state: &FederationState, pane: &PaneId) -> AgentId {
+    state
+        .targets
+        .get(&pane.target_session())
+        .and_then(|target| target.snapshot.as_deref())
+        .and_then(|snapshot| snapshot.agents.get(pane))
+        .map(agent_key)
+        .unwrap_or_else(|| pane_agent_key(pane))
+}
+
+fn pane_agent_key(pane: &PaneId) -> AgentId {
+    AgentId::new(
+        &pane.target,
+        &pane.session,
+        &format!("pane{AGENT_KEY_SEPARATOR}{}", pane.resource),
+    )
+}
+
 /// The identity of one agent, qualified by target and Herdr session.
 ///
 /// Herdr reports an optional `agent_session` for a pane, and where it is
@@ -596,7 +622,7 @@ pub fn agent_key(agent: &AgentState) -> AgentId {
             "session{separator}{}{separator}{}{separator}{}{separator}{}",
             session.kind, session.value, session.source, session.agent
         ),
-        None => format!("pane{separator}{}", agent.pane.resource),
+        None => return pane_agent_key(&agent.pane),
     };
     AgentId::new(&agent.pane.target, &agent.pane.session, &resource)
 }

--- a/src/agent_marks.rs
+++ b/src/agent_marks.rs
@@ -51,6 +51,23 @@ const MAX_MARKED_AGENTS: usize = 512;
 /// enough that a forgotten snooze surfaces again by itself.
 pub const MAX_SNOOZE_MINUTES: u32 = 24 * 60;
 
+/// When an agent may reach a paired device.
+///
+/// Muting and snoozing already quiet an agent everywhere, so the only mode
+/// left to name is the narrow one: tell me when this agent is blocked on me,
+/// and never for anything else. It is per-agent because the useful setting
+/// differs by agent — the one running a long build is worth a completion
+/// alert, the chatty one is not.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotifyMode {
+    /// Whatever the daemon's notification filters allow.
+    #[default]
+    Default,
+    /// Only when the agent is blocked on a person.
+    NeedsYouOnly,
+}
+
 /// One agent's marks. All-default means "not marked", which is why an unmarked
 /// agent costs nothing to describe and nothing to store.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -62,6 +79,8 @@ pub struct AgentMarkState {
     /// means not snoozed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snoozed_until_ms: Option<u64>,
+    #[serde(default)]
+    pub notify: NotifyMode,
 }
 
 impl AgentMarkState {
@@ -77,6 +96,20 @@ impl AgentMarkState {
     /// Whether this agent should stop competing for the top of the inbox.
     pub fn quiet_at(&self, now_ms: u64) -> bool {
         self.muted || self.snoozed_at(now_ms)
+    }
+
+    /// Whether an attention event about this agent may reach a paired device.
+    ///
+    /// Quiet means quiet everywhere: an agent somebody muted or snoozed to get
+    /// it out of their inbox has not asked to keep hearing from it on a phone.
+    pub fn may_notify(&self, needs_attention: bool, now_ms: u64) -> bool {
+        if self.quiet_at(now_ms) {
+            return false;
+        }
+        match self.notify {
+            NotifyMode::Default => true,
+            NotifyMode::NeedsYouOnly => needs_attention,
+        }
     }
 }
 
@@ -97,6 +130,10 @@ pub enum AgentMarkRequest {
     /// the bound is the daemon's business rather than an error to explain.
     Snooze {
         minutes: Option<u32>,
+    },
+    /// When this agent may reach a paired device.
+    Notify {
+        mode: NotifyMode,
     },
 }
 
@@ -122,6 +159,7 @@ impl AgentMarks {
         match request {
             AgentMarkRequest::Pin { pinned } => state.pinned = pinned,
             AgentMarkRequest::Mute { muted } => state.muted = muted,
+            AgentMarkRequest::Notify { mode } => state.notify = mode,
             AgentMarkRequest::Snooze { minutes } => {
                 state.snoozed_until_ms = minutes.map(|minutes| {
                     let bounded = u64::from(minutes.min(MAX_SNOOZE_MINUTES));
@@ -349,7 +387,8 @@ impl AgentMarkStore {
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentMarkRequest, AgentMarkStore, AgentMarks, MAX_MARKED_AGENTS, MAX_SNOOZE_MINUTES,
+        AgentMarkRequest, AgentMarkState, AgentMarkStore, AgentMarks, MAX_MARKED_AGENTS,
+        MAX_SNOOZE_MINUTES, NotifyMode,
     };
     use crate::model::AgentId;
 
@@ -484,6 +523,45 @@ mod tests {
                 ))
                 .pinned,
             "the newest request is the one that survives"
+        );
+    }
+
+    #[test]
+    fn a_quieted_agent_reaches_no_device_either() {
+        let mut marks = AgentMarks::default();
+        let muted = AgentId::new("host-a", "work", "p1");
+        let snoozed = AgentId::new("host-a", "work", "p2");
+        marks.apply(&muted, AgentMarkRequest::Mute { muted: true }, NOW);
+        marks.apply(&snoozed, AgentMarkRequest::Snooze { minutes: Some(5) }, NOW);
+
+        assert!(
+            !marks.state(&muted).may_notify(true, NOW),
+            "an agent muted out of the inbox has not asked to keep calling a phone"
+        );
+        assert!(!marks.state(&snoozed).may_notify(true, NOW));
+        assert!(
+            marks.state(&snoozed).may_notify(true, NOW + 6 * 60_000),
+            "a snooze that ran out stops quieting anything"
+        );
+    }
+
+    #[test]
+    fn needs_you_only_admits_exactly_one_kind_of_interruption() {
+        let mut marks = AgentMarks::default();
+        let agent = AgentId::new("host-a", "work", "p1");
+        marks.apply(
+            &agent,
+            AgentMarkRequest::Notify {
+                mode: NotifyMode::NeedsYouOnly,
+            },
+            NOW,
+        );
+
+        assert!(marks.state(&agent).may_notify(true, NOW));
+        assert!(!marks.state(&agent).may_notify(false, NOW));
+        assert!(
+            AgentMarkState::default().may_notify(false, NOW),
+            "an unmarked agent is whatever the daemon's own filters allow"
         );
     }
 

--- a/src/attention.rs
+++ b/src/attention.rs
@@ -618,6 +618,53 @@ mod tests {
     }
 
     #[test]
+    fn a_terminal_title_never_becomes_attention_metadata() {
+        // Herdr reports `terminal_title` on panes and agents, and it is
+        // derived from what the terminal drew — an agent's current sentence,
+        // often a paraphrase of somebody's prompt. Attention events are what a
+        // notification is built from, so anything that reached one would end
+        // up on a lock screen.
+        let key = TargetSession::new("host-a", "work");
+        let snapshot = NormalizedSnapshot::from_value(
+            &key,
+            &json!({
+                "workspaces": [{"workspace_id": "w1", "label": "compiler"}],
+                "panes": [{
+                    "pane_id": "w1:p1",
+                    "workspace_id": "w1",
+                    "agent": "builder",
+                    "agent_status": "blocked",
+                    "terminal_title": "Deleting the production database"
+                }],
+                "agents": [{
+                    "pane_id": "w1:p1",
+                    "name": "builder",
+                    "agent_status": "blocked",
+                    "terminal_title": "Deleting the production database",
+                    "terminal_title_stripped": "Deleting the production database"
+                }]
+            }),
+        );
+        let mut index = AttentionIndex::default();
+        // A first sighting is a baseline, not a transition, so the agent is
+        // observed working before it blocks.
+        index.observe(&state_with_agent("working", false));
+        assert!(index.observe(&state_with_snapshot(
+            key,
+            TargetConnectionState::Live,
+            snapshot
+        )));
+
+        let event = index.events().next().unwrap();
+        for field in [&event.agent, &event.workspace, &event.status] {
+            assert!(
+                !field.contains("production"),
+                "terminal contents must not reach an attention event: {field:?}"
+            );
+        }
+    }
+
+    #[test]
     fn atomically_round_trips_metadata_only_attention_state() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("attention-state.json");

--- a/src/client.rs
+++ b/src/client.rs
@@ -532,6 +532,7 @@ mod tests {
             web: Default::default(),
             targets,
             devices: Vec::new(),
+            quick_replies: None,
         };
         let options = DaemonOptions {
             // No socket is bound in this mode; the path is never used.

--- a/src/config.rs
+++ b/src/config.rs
@@ -523,6 +523,12 @@ pub struct NotificationsConfig {
     pub working: bool,
     #[serde(default)]
     pub status_changed: bool,
+    /// Also deliver to paired devices. Off by default and separate from
+    /// `enabled`, which turns on this machine's own desktop notifications: a
+    /// person who wants alerts on their phone has not thereby asked for them
+    /// on the laptop they are sitting at, or the other way round.
+    #[serde(default)]
+    pub devices: bool,
     #[serde(default = "default_notification_interval")]
     pub minimum_interval_seconds: u64,
     #[serde(default = "default_notification_timeout")]
@@ -538,6 +544,7 @@ impl Default for NotificationsConfig {
             disappeared: true,
             working: false,
             status_changed: false,
+            devices: false,
             minimum_interval_seconds: default_notification_interval(),
             command_timeout_seconds: default_notification_timeout(),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,76 @@ pub struct Config {
     /// which is why a daemon with no paired device serves loopback only.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub devices: Vec<Device>,
+    /// One-tap replies offered on a paired device. Absent means the built-in
+    /// set; an explicit empty list means none, because turning them off has to
+    /// be expressible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quick_replies: Option<Vec<QuickReply>>,
+}
+
+/// How many replies a control strip may offer.
+///
+/// They share one row on a phone. Past this the row wraps into something a
+/// person scans rather than taps, which is the opposite of the point.
+const MAX_QUICK_REPLIES: usize = 8;
+const MAX_QUICK_REPLY_LABEL_CHARACTERS: usize = 24;
+const MAX_QUICK_REPLY_SEND_BYTES: usize = 256;
+
+/// One configured, one-tap reply.
+///
+/// Deliberately a *reply* and not a *choice*. Herdr's documented API reports an
+/// agent's status and whether it is ready for input; it does not describe the
+/// options a blocked agent is offering, so there is nothing to render a
+/// semantic Yes/No/Approve button from. The alternative would be reading the
+/// terminal and guessing, which is exactly the thing Super-Herdr refuses to do:
+/// a button that types "y" because the screen looked like a yes/no prompt is a
+/// keystroke sent on the strength of a pattern match.
+///
+/// So these are what a person decided they send often, written down in their
+/// own configuration. Nothing here is inferred, and nothing here claims to know
+/// what the agent asked.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QuickReply {
+    /// What the button says.
+    pub label: String,
+    /// The text it types. Control characters are refused: a reply is short
+    /// text, and the escape, tab and interrupt keys are their own explicit
+    /// controls rather than something a configuration can smuggle into a pane.
+    pub send: String,
+    /// Whether a carriage return follows, submitting the line. On by default,
+    /// because a reply that has to be confirmed with a second tap is two taps.
+    #[serde(default = "default_true")]
+    pub submit: bool,
+    /// Ask before sending. There is no structured metadata to learn that a
+    /// response is destructive from, so the person who wrote the reply is the
+    /// one who declares it.
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+impl QuickReply {
+    fn new(label: &str, send: &str) -> Self {
+        Self {
+            label: label.to_owned(),
+            send: send.to_owned(),
+            submit: true,
+            confirm: false,
+        }
+    }
+}
+
+/// The replies offered when a configuration says nothing.
+///
+/// Short, common, and unambiguous to type by hand. They are a default rather
+/// than a meaning: none of them is chosen by looking at what an agent asked.
+pub fn default_quick_replies() -> Vec<QuickReply> {
+    vec![
+        QuickReply::new("Yes", "y"),
+        QuickReply::new("No", "n"),
+        QuickReply::new("Continue", "continue"),
+        QuickReply::new("Retry", "retry"),
+    ]
 }
 
 /// What the daemon will move on someone's behalf.
@@ -561,6 +631,7 @@ impl Config {
                 web: Default::default(),
                 targets: vec![target],
                 devices: Vec::new(),
+                quick_replies: None,
             };
             config.validate()?;
             toml::to_string_pretty(&config)?
@@ -680,6 +751,34 @@ impl Config {
             || self.notifications.command_timeout_seconds > 30
         {
             bail!("notifications.command_timeout_seconds must be between 1 and 30");
+        }
+        if let Some(replies) = self.quick_replies.as_deref() {
+            if replies.len() > MAX_QUICK_REPLIES {
+                bail!("at most {MAX_QUICK_REPLIES} [[quick_replies]] entries are supported");
+            }
+            for reply in replies {
+                let label = reply.label.trim();
+                if label.is_empty()
+                    || label.chars().count() > MAX_QUICK_REPLY_LABEL_CHARACTERS
+                    || label.chars().any(char::is_control)
+                {
+                    bail!(
+                        "a quick reply label must be 1 to {MAX_QUICK_REPLY_LABEL_CHARACTERS} \
+                         characters and contain no control characters"
+                    );
+                }
+                if reply.send.is_empty() || reply.send.len() > MAX_QUICK_REPLY_SEND_BYTES {
+                    bail!(
+                        "quick reply {label:?} must send 1 to {MAX_QUICK_REPLY_SEND_BYTES} bytes"
+                    );
+                }
+                if reply.send.chars().any(char::is_control) {
+                    bail!(
+                        "quick reply {label:?} must not send control characters; Enter, Escape, \
+                         Tab and Ctrl-C are separate terminal keys"
+                    );
+                }
+            }
         }
 
         let mut names = HashSet::new();
@@ -1073,6 +1172,124 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     use super::{Config, Device, ResolvedWeb, Target, WebConfig};
+
+    #[test]
+    fn quick_replies_default_to_a_short_built_in_set() {
+        let config = Config::parse(
+            r#"
+[[targets]]
+name = "one"
+ssh = "host"
+"#,
+        )
+        .unwrap();
+
+        assert!(config.quick_replies.is_none());
+        assert_eq!(
+            super::default_quick_replies()
+                .iter()
+                .map(|reply| reply.label.as_str())
+                .collect::<Vec<_>>(),
+            ["Yes", "No", "Continue", "Retry"]
+        );
+    }
+
+    #[test]
+    fn quick_replies_can_be_configured_and_turned_off() {
+        let configured = Config::parse(
+            r#"
+[[targets]]
+name = "one"
+ssh = "host"
+
+[[quick_replies]]
+label = "Approve"
+send = "approve"
+confirm = true
+
+[[quick_replies]]
+label = "Path"
+send = "/srv/build"
+submit = false
+"#,
+        )
+        .unwrap();
+
+        let replies = configured.quick_replies.as_deref().unwrap();
+        assert_eq!(replies[0].label, "Approve");
+        assert!(replies[0].submit, "submitting is the default");
+        assert!(replies[0].confirm);
+        assert!(!replies[1].submit);
+        assert!(!replies[1].confirm, "confirming is not");
+
+        // An empty list is how somebody turns them off. Absent means the
+        // built-in set, so the two must stay distinguishable.
+        let none = Config::parse(
+            r#"
+quick_replies = []
+
+[[targets]]
+name = "one"
+ssh = "host"
+"#,
+        )
+        .unwrap();
+        assert_eq!(none.quick_replies.as_deref(), Some(&[][..]));
+    }
+
+    #[test]
+    fn a_quick_reply_may_not_smuggle_control_characters_into_a_pane() {
+        // TOML decodes the escape, so what reaches validation is a real
+        // escape character — the thing a reply must never carry.
+        let error = Config::parse(
+            "\n[[targets]]\nname = \"one\"\nssh = \"host\"\n\n\
+             [[quick_replies]]\nlabel = \"Escape\"\nsend = \"\\u001B[A\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("control characters"),
+            "Escape, Tab and Ctrl-C are separate keys, not something a reply carries: {error}"
+        );
+    }
+
+    #[test]
+    fn a_quick_reply_is_bounded_in_label_and_payload() {
+        let long_label = Config::parse(&format!(
+            r#"
+[[targets]]
+name = "one"
+ssh = "host"
+
+[[quick_replies]]
+label = "{}"
+send = "y"
+"#,
+            "x".repeat(25)
+        ));
+        assert!(long_label.is_err());
+
+        let empty_send = Config::parse(
+            r#"
+[[targets]]
+name = "one"
+ssh = "host"
+
+[[quick_replies]]
+label = "Nothing"
+send = ""
+"#,
+        );
+        assert!(empty_send.is_err());
+
+        let too_many = Config::parse(&format!(
+            "\n[[targets]]\nname = \"one\"\nssh = \"host\"\n{}",
+            (0..9)
+                .map(|index| format!("\n[[quick_replies]]\nlabel = \"r{index}\"\nsend = \"y\"\n"))
+                .collect::<String>()
+        ));
+        assert!(too_many.is_err());
+    }
 
     #[test]
     fn a_transfer_ceiling_is_configurable_and_has_a_default() {

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -268,7 +268,9 @@
     <div class="inbox-head">
       <h2>Agents</h2>
       <span id="inbox-count" class="note"></span>
+      <button id="alerts" type="button" class="chip" aria-pressed="false" hidden>Alerts</button>
     </div>
+    <p id="alert-note" class="note" role="status"></p>
     <div id="inbox-filters" class="chips" role="group" aria-label="Filter agents"></div>
     <div id="inbox-sections"></div>
     <p id="inbox-empty" class="empty">waiting for the daemon…</p>
@@ -1218,6 +1220,76 @@ function resync() {
   subscribeScreen(pane);
 }
 
+// Whether this device has been asked to be interrupted, and has agreed.
+//
+// Two separate permissions that a person grants at different moments: the
+// browser's own notification permission, and this page's subscription to the
+// daemon. Neither implies the other, and rendering the inbox implies neither —
+// showing somebody their agents is not the same as interrupting them about one.
+let alertsOn = false;
+
+function alertsAvailable() {
+  return typeof Notification === 'function';
+}
+
+function renderAlerts() {
+  const button = el('alerts');
+  button.hidden = !alertsAvailable();
+  button.setAttribute('aria-pressed', alertsOn ? 'true' : 'false');
+  button.textContent = alertsOn ? 'Alerts on' : 'Alerts';
+}
+
+async function toggleAlerts() {
+  if (!alertsAvailable()) return;
+  if (alertsOn) {
+    // The browser keeps its permission; what this turns off is the daemon
+    // sending anything, which is the part this page controls.
+    alertsOn = false;
+    send({ type: 'notifications.unsubscribe' });
+    renderAlerts();
+    return;
+  }
+  const permission = Notification.permission === 'granted'
+    ? 'granted'
+    : await Notification.requestPermission();
+  alertsOn = permission === 'granted';
+  if (alertsOn) send({ type: 'notifications.subscribe' });
+  else el('alert-note').textContent = 'This browser is not allowing notifications.';
+  renderAlerts();
+}
+
+function showAlert(message) {
+  // Belt and braces: the daemon sends these only to a subscriber, and a page
+  // that has turned them off ignores one that arrives anyway rather than
+  // interrupting somebody who asked it not to.
+  if (!alertsOn || !alertsAvailable()) return;
+  const alert = new Notification(text(message.title), {
+    body: text(message.body),
+    // One agent replaces its own previous alert instead of stacking: a phone
+    // holding six notices about one agent is a phone somebody stops reading.
+    tag: paneKey(message.agent),
+  });
+  alert.onclick = () => openAgentFromAlert(message.agent);
+}
+
+// A tap on an alert is acted on against the inbox as it is now, not as it was
+// when the alert was sent. An agent that has since gone is reported rather than
+// approximated: there is no nearby pane that will do.
+function openAgentFromAlert(agent) {
+  if (typeof window.focus === 'function') window.focus();
+  const wanted = paneKey(agent);
+  const card = inboxCards().find(one => one.agent && paneKey(one.agent) === wanted);
+  if (card && card.actionable && card.pane) {
+    el('alert-note').textContent = '';
+    if (card.unread) send({ type: 'attention.mark_seen', pane: card.pane });
+    observe(card.pane, `${qualify(card.pane)}/${text(card.title)}`);
+    return;
+  }
+  el('alert-note').textContent = card
+    ? 'That agent is no longer reachable.'
+    : 'That agent is no longer running.';
+}
+
 // The inbox exactly as the daemon built it. This page renders that answer and
 // never derives a second one: sections and ordering are the daemon's, so a
 // person moving between the TUI and this phone reads one inbox rather than two
@@ -1625,7 +1697,17 @@ function apply(message) {
       }
       quickReplies = Array.isArray(message.quick_replies) ? message.quick_replies : [];
       renderQuickReplies();
+      // A reconnect is a new client to the daemon, which is not holding this
+      // page's subscription any more. Permission already granted is not asked
+      // for again; the subscription is.
+      if (alertsAvailable() && Notification.permission === 'granted' && alertsOn) {
+        send({ type: 'notifications.subscribe' });
+      }
+      renderAlerts();
       schedulePluginPoll();
+      break;
+    case 'notification':
+      showAlert(message);
       break;
     case 'agents.cards':
       inbox = message.projection;
@@ -1832,6 +1914,7 @@ for (const button of document.querySelectorAll('.keys button')) {
     el('line').focus();
   };
 }
+el('alerts').onclick = () => { void toggleAlerts(); };
 el('stop').onclick = () => stopWatching('');
 
 // A rotation or a resize changes how much of the pane fits, not the pane.

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -306,12 +306,7 @@
                  enterkeyhint="send">
           <button id="send" type="submit">Send</button>
         </form>
-        <div class="quick-replies control-strip" aria-label="Quick replies">
-          <button type="button" data-reply="yes" aria-label="Send y and Enter">Yes</button>
-          <button type="button" data-reply="no" aria-label="Send n and Enter">No</button>
-          <button type="button" data-reply="continue" aria-label="Send continue and Enter">Continue</button>
-          <button type="button" data-reply="retry" aria-label="Send retry and Enter">Retry</button>
-        </div>
+        <div id="quick-replies" class="quick-replies control-strip" aria-label="Quick replies"></div>
         <div class="tool-row">
           <div class="keys control-strip" aria-label="Terminal keys">
             <button data-key="enter">Enter</button>
@@ -1002,17 +997,75 @@ const KEYS = {
   backspace: '\x7f',
 };
 
+// Replies the daemon is configured to offer, and the buttons drawn from them.
+//
+// They arrive in the handshake and are rendered exactly as sent. Nothing here
+// reads the terminal to decide what an agent is asking: Herdr reports that an
+// agent is ready for input, never what it wants, so a Yes button that appeared
+// because the screen looked like a prompt would be a keystroke sent on the
+// strength of a pattern match. An empty list draws no buttons rather than
+// falling back to a guess.
+let quickReplies = [];
+let quickReplyButtons = [];
+// The reply waiting for its second tap, when one declared that it needs one.
+let armedReply = null;
+
+function renderQuickReplies() {
+  const strip = el('quick-replies');
+  strip.innerHTML = '';
+  quickReplyButtons = [];
+  armedReply = null;
+  strip.hidden = quickReplies.length === 0;
+  for (const [index, reply] of quickReplies.entries()) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'reply';
+    button.dataset.reply = String(index);
+    button.textContent = text(reply.label);
+    button.setAttribute(
+      'aria-label',
+      `Send ${text(reply.send)}${reply.submit === false ? '' : ' and Enter'}`,
+    );
+    // Keeping the tap off the text field is what stops a phone keyboard
+    // opening for a reply that needs no typing.
+    button.onpointerdown = event => event.preventDefault();
+    button.onclick = () => tapReply(index);
+    strip.append(button);
+    quickReplyButtons.push(button);
+  }
+  renderKeyboard();
+}
+
+// A reply that declared it needs confirming arms on the first tap and sends on
+// the second. Two taps on the button itself rather than a dialog: a modal on a
+// phone is dismissed by the same reflex that opened it, and there is no
+// structured metadata to learn that a response is destructive from — the person
+// who wrote the reply is the one who said so.
+function tapReply(index) {
+  const reply = quickReplies[index];
+  if (!reply) return;
+  if (reply.confirm && armedReply !== index) {
+    armReply(index);
+    return;
+  }
+  armReply(null);
+  sendText(`${text(reply.send)}${reply.submit === false ? '' : '\r'}`);
+}
+
+function armReply(index) {
+  armedReply = index;
+  for (const [position, button] of quickReplyButtons.entries()) {
+    const reply = quickReplies[position];
+    const armed = position === index;
+    button.setAttribute('aria-pressed', armed ? 'true' : 'false');
+    button.textContent = armed ? 'Tap again' : text(reply.label);
+  }
+}
+
 // These are deliberately short, fixed replies rather than inferred actions.
 // Reading terminal output to guess a response would be both brittle and a
 // surprising authority boundary. The arrow in the button label tells the user
 // each explicit tap sends the reply immediately with Enter.
-const QUICK_REPLIES = {
-  yes: 'y\r',
-  no: 'n\r',
-  continue: 'continue\r',
-  retry: 'retry\r',
-};
-
 // Reveal the input during the tap that requests control, but enable every send
 // action only after the daemon grants the lease. This opens a phone keyboard
 // without turning an optimistic UI transition into authorization.
@@ -1026,9 +1079,12 @@ function renderKeyboard() {
   for (const button of document.querySelectorAll('.keys button')) {
     button.disabled = !holding;
   }
-  for (const button of document.querySelectorAll('.quick-replies button')) {
+  for (const button of quickReplyButtons) {
     button.disabled = !holding;
   }
+  // A reply waiting for its second tap is a decision that belonged to the
+  // moment it was armed in. Losing the lease ends that moment.
+  if (!holding && armedReply !== null) armReply(null);
 }
 
 async function uploadBrowserFile(file, pane) {
@@ -1567,6 +1623,8 @@ function apply(message) {
         cell = null;
         subscribeScreen(watching);
       }
+      quickReplies = Array.isArray(message.quick_replies) ? message.quick_replies : [];
+      renderQuickReplies();
       schedulePluginPoll();
       break;
     case 'agents.cards':
@@ -1773,10 +1831,6 @@ for (const button of document.querySelectorAll('.keys button')) {
     sendText(KEYS[button.dataset.key] || '');
     el('line').focus();
   };
-}
-for (const button of document.querySelectorAll('.quick-replies button')) {
-  button.onpointerdown = event => event.preventDefault();
-  button.onclick = () => sendText(QUICK_REPLIES[button.dataset.reply] || '');
 }
 el('stop').onclick = () => stopWatching('');
 

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -249,6 +249,7 @@ struct Client {
     greeted: bool,
     state_subscribed: bool,
     agent_cards_subscribed: bool,
+    notifications_subscribed: bool,
     panes: BTreeMap<PaneId, PaneSubscription>,
 }
 
@@ -258,6 +259,7 @@ impl Client {
             greeted: false,
             state_subscribed: false,
             agent_cards_subscribed: false,
+            notifications_subscribed: false,
             panes: BTreeMap::new(),
         }
     }
@@ -487,6 +489,19 @@ impl Broker {
                 agent,
                 mark,
             }),
+            ClientMessage::SubscribeNotifications => {
+                if let Some(session) = self.clients.get_mut(&client) {
+                    session.notifications_subscribed = true;
+                }
+                // Nothing is replayed. An alert is about a moment, and one
+                // delivered late enough to have been asked for afterwards is
+                // an interruption about something already over.
+            }
+            ClientMessage::UnsubscribeNotifications => {
+                if let Some(session) = self.clients.get_mut(&client) {
+                    session.notifications_subscribed = false;
+                }
+            }
             ClientMessage::SubscribeAgentCards => {
                 if let Some(session) = self.clients.get_mut(&client) {
                     session.agent_cards_subscribed = true;
@@ -1071,6 +1086,22 @@ impl Broker {
             });
         }
         effects
+    }
+
+    /// Send one coalesced alert to every device that asked for them.
+    ///
+    /// Only to subscribers, and only ever forward: a device that connects
+    /// after the fact is not caught up, because an alert is an interruption
+    /// and one about a finished moment is only noise.
+    pub fn notify_devices(&mut self, notification: ServerMessage) -> Vec<Effect> {
+        self.clients
+            .iter()
+            .filter(|(_, session)| session.notifications_subscribed)
+            .map(|(client, _)| Effect::Send {
+                client: *client,
+                message: notification.clone(),
+            })
+            .collect()
     }
 
     pub fn attention_observed(&mut self, event: AttentionEvent) -> Vec<Effect> {
@@ -3442,6 +3473,63 @@ mod tests {
 
         assert!(broker.agent_cards_updated(projection(1)).is_empty());
         assert!(!broker.agent_cards_updated(projection(2)).is_empty());
+    }
+
+    #[test]
+    fn an_alert_reaches_only_devices_that_asked_to_be_interrupted() {
+        let mut broker = broker();
+        let subscriber = greet(&mut broker);
+        let watcher = greet(&mut broker);
+        // Rendering the inbox is not asking to be interrupted by it.
+        broker.handle(watcher, ClientMessage::SubscribeAgentCards);
+        broker.handle(subscriber, ClientMessage::SubscribeNotifications);
+
+        let effects = broker.notify_devices(alert());
+
+        assert_eq!(
+            effects,
+            vec![Effect::Send {
+                client: subscriber,
+                message: alert(),
+            }]
+        );
+    }
+
+    #[test]
+    fn turning_alerts_off_stops_them_arriving() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+        broker.handle(client, ClientMessage::SubscribeNotifications);
+        assert!(!broker.notify_devices(alert()).is_empty());
+
+        broker.handle(client, ClientMessage::UnsubscribeNotifications);
+
+        assert!(broker.notify_devices(alert()).is_empty());
+    }
+
+    #[test]
+    fn a_device_that_subscribes_late_is_not_caught_up() {
+        let mut broker = broker();
+        let early = greet(&mut broker);
+        broker.handle(early, ClientMessage::SubscribeNotifications);
+        broker.notify_devices(alert());
+
+        let late = greet(&mut broker);
+
+        assert!(
+            broker
+                .handle(late, ClientMessage::SubscribeNotifications)
+                .is_empty(),
+            "an interruption about a finished moment is only noise"
+        );
+    }
+
+    fn alert() -> ServerMessage {
+        ServerMessage::Notification {
+            agent: AgentId::new("first", "main", "w1:p1"),
+            title: "Agent needs attention".to_owned(),
+            body: "reviewer · compiler".to_owned(),
+        }
     }
 
     #[test]

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use crate::agent_card::AgentCardProjection;
 use crate::agent_marks::AgentMarkRequest;
 use crate::attention::AttentionEvent;
+use crate::config::QuickReply;
 use crate::model::{AgentId, PaneId, TargetSession};
 use crate::operation::Operation;
 use crate::plugin::{PluginRun, PluginRunId};
@@ -300,6 +301,7 @@ struct Rendered {
 pub struct Broker {
     server_version: String,
     features: Vec<String>,
+    quick_replies: Vec<QuickReply>,
     clients: BTreeMap<ClientId, Client>,
     routes: BTreeMap<PaneId, Route>,
     screens: BTreeMap<PaneId, ScreenState>,
@@ -358,10 +360,15 @@ impl ScreenState {
 }
 
 impl Broker {
-    pub fn new(server_version: impl Into<String>, features: Vec<String>) -> Self {
+    pub fn new(
+        server_version: impl Into<String>,
+        features: Vec<String>,
+        quick_replies: Vec<QuickReply>,
+    ) -> Self {
         Self {
             server_version: server_version.into(),
             features,
+            quick_replies,
             clients: BTreeMap::new(),
             routes: BTreeMap::new(),
             screens: BTreeMap::new(),
@@ -412,6 +419,7 @@ impl Broker {
                             protocol: PROTOCOL_VERSION,
                             server_version: self.server_version.clone(),
                             features: self.features.clone(),
+                            quick_replies: self.quick_replies.clone(),
                         },
                     });
                 }
@@ -1446,6 +1454,7 @@ mod tests {
     use crate::agent_card::{AGENT_CARD_PROJECTION_VERSION, AgentCardProjection};
     use crate::agent_marks::AgentMarkRequest;
     use crate::attention::{AttentionEvent, AttentionEventKind};
+    use crate::config::QuickReply;
     use crate::model::{AgentId, PaneId, TargetSession};
     use crate::operation::Operation;
     use crate::plugin::PluginRunId;
@@ -1459,7 +1468,11 @@ mod tests {
     use crate::terminal::{TerminalAccess, TerminalScrollDirection};
 
     fn broker() -> Broker {
-        Broker::new("0.3.1", vec!["terminal".to_owned()])
+        Broker::new(
+            "0.3.1",
+            vec!["terminal".to_owned()],
+            crate::config::default_quick_replies(),
+        )
     }
 
     /// Every test starts from a completed handshake, because nothing else is
@@ -3429,6 +3442,43 @@ mod tests {
 
         assert!(broker.agent_cards_updated(projection(1)).is_empty());
         assert!(!broker.agent_cards_updated(projection(2)).is_empty());
+    }
+
+    #[test]
+    fn the_handshake_carries_the_replies_this_daemon_offers() {
+        let mut broker = Broker::new(
+            "0.3.1",
+            vec!["terminal".to_owned()],
+            vec![QuickReply {
+                label: "Approve".to_owned(),
+                send: "approve".to_owned(),
+                submit: true,
+                confirm: true,
+            }],
+        );
+        let client = broker.connect();
+
+        let effects = broker.handle(
+            client,
+            ClientMessage::Hello {
+                protocol: PROTOCOL_VERSION,
+                client: "test".to_owned(),
+            },
+        );
+
+        let Some(Effect::Send {
+            message: ServerMessage::Hello { quick_replies, .. },
+            ..
+        }) = effects.first()
+        else {
+            panic!("expected a hello");
+        };
+        assert_eq!(quick_replies.len(), 1);
+        assert_eq!(quick_replies[0].label, "Approve");
+        assert!(
+            quick_replies[0].confirm,
+            "a reply's own configuration is what says it needs confirming"
+        );
     }
 
     #[test]

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -993,6 +993,10 @@ async fn run(
                 "plugin_actions".to_owned(),
                 "agent_cards".to_owned(),
             ],
+            active
+                .quick_replies
+                .clone()
+                .unwrap_or_else(crate::config::default_quick_replies),
         ),
         web_url: options.web_url.clone(),
         bridge_pairing: options.web_bridge.as_ref().map(|_| bridge_pairing.clone()),
@@ -3088,6 +3092,7 @@ mod tests {
             web: Default::default(),
             targets: Vec::new(),
             devices: Vec::new(),
+            quick_replies: None,
         }
     }
 
@@ -3663,6 +3668,7 @@ mod tests {
                 herdr_bins: vec!["/nonexistent/herdr".to_owned()],
             }],
             devices: Vec::new(),
+            quick_replies: None,
         };
         let server = tokio::spawn(serve(
             config,

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -35,14 +35,15 @@ use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
-use crate::agent_card::AgentCardIndex;
+use crate::agent_card::{AgentCardIndex, agent_key_for_pane};
 use crate::agent_marks::{AgentMarkStore, AgentMarks};
-use crate::attention::{AttentionIndex, AttentionStore, unix_time_ms};
+use crate::attention::{AttentionEventKind, AttentionIndex, AttentionStore, unix_time_ms};
 use crate::clipboard;
 use crate::config::{Config, Device, Target, TransportConfig};
 use crate::daemon::broker::{Broker, ClientId, Effect};
 use crate::daemon::web;
 use crate::model::{PaneId, TargetSession};
+use crate::notifications::NotificationQueue;
 use crate::operation::Operation;
 use crate::pairing::{self, PendingPairing};
 use crate::plugin;
@@ -61,6 +62,11 @@ use crate::workspace_move;
 /// discovery. This matches the frontend's own refresh cadence, because both are
 /// bounded reads of the same durable file.
 pub const CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
+
+/// How often the device sink looks for a delivery whose coalescing window has
+/// closed. The window is half a second, so an alert waits at most one tick
+/// past the moment it became due.
+const NOTIFICATION_TICK: Duration = Duration::from_millis(500);
 const MAX_PENDING_PAIRING_APPROVALS: usize = 16;
 
 #[derive(Debug, Clone)]
@@ -120,6 +126,8 @@ impl DaemonOptions {
 /// Everything the broker loop reacts to, from clients and from the federation
 /// alike, so ordering is decided in one place.
 enum Input {
+    /// A coalescing window may have closed.
+    NotificationsDue,
     Connected {
         outbox: mpsc::UnboundedSender<ServerMessage>,
         reply: oneshot::Sender<ClientId>,
@@ -697,6 +705,11 @@ struct Daemon {
     agent_cards: AgentCardIndex,
     agent_marks: AgentMarks,
     agent_mark_store: Option<AgentMarkStore>,
+    /// Alerts for paired devices. A second sink beside the desktop's own,
+    /// which the frontend runs against its attention mirror — this one lives
+    /// here because the point of it is a phone learning that an agent is
+    /// waiting while the desktop is asleep.
+    device_notifications: NotificationQueue,
     command_timeout: Duration,
     inputs: mpsc::UnboundedSender<Input>,
     /// Queues handed over by connections, waiting for the broker to say whether
@@ -985,6 +998,12 @@ async fn run(
         .as_ref()
         .and_then(|store| store.load().ok())
         .unwrap_or_default();
+    // The device sink borrows the desktop's filters, coalescing and rate
+    // limits, and is switched on separately: wanting alerts on a phone is not
+    // the same request as wanting them on the laptop being sat at.
+    let mut device_notifications = active.notifications.clone();
+    device_notifications.enabled = device_notifications.devices;
+    let notify_devices = device_notifications.enabled;
     let mut daemon = Daemon {
         broker: Broker::new(
             env!("CARGO_PKG_VERSION"),
@@ -1011,6 +1030,7 @@ async fn run(
         agent_cards: AgentCardIndex::default(),
         agent_marks,
         agent_mark_store,
+        device_notifications: NotificationQueue::new(device_notifications, None),
         command_timeout: Duration::from_secs(active.transport.command_timeout_seconds),
         inputs: inputs.clone(),
         offers: BTreeMap::new(),
@@ -1038,6 +1058,23 @@ async fn run(
             loop {
                 ticks.tick().await;
                 if inputs.send(Input::RefreshDue).is_err() {
+                    return;
+                }
+            }
+        })
+    });
+
+    // Coalescing means a delivery becomes due after the event that started it,
+    // so something has to come back and look. Spawned only when the sink is on,
+    // so a daemon nobody asked to notify has no timer at all.
+    let notifying = notify_devices.then(|| {
+        let inputs = inputs.clone();
+        tokio::spawn(async move {
+            let mut ticks = tokio::time::interval(NOTIFICATION_TICK);
+            ticks.tick().await;
+            loop {
+                ticks.tick().await;
+                if inputs.send(Input::NotificationsDue).is_err() {
                     return;
                 }
             }
@@ -1077,6 +1114,9 @@ async fn run(
         accepting.abort();
     }
     signalled.abort();
+    if let Some(notifying) = notifying {
+        notifying.abort();
+    }
     if let Some(refreshing) = refreshing {
         refreshing.abort();
     }
@@ -1520,6 +1560,7 @@ impl Daemon {
                 self.offers.insert((client, request), chunks);
                 Vec::new()
             }
+            Input::NotificationsDue => self.device_alerts(),
             Input::Federation(state) => {
                 self.state = state.clone();
                 let mut effects = self.broker.federation_updated(state);
@@ -2857,6 +2898,24 @@ impl Daemon {
         if let Some(newest) = fresh.last() {
             self.attention_cursor = Some(newest.id);
         }
+        // Each fresh event is offered to the device sink before it is
+        // broadcast. The per-agent mark decides: an agent somebody muted or
+        // snoozed to get it out of their inbox has not asked to keep hearing
+        // from it on a phone, and one set to needs-you-only has asked for
+        // exactly one kind of interruption.
+        let now_ms = unix_time_ms();
+        let at = Instant::now();
+        for event in &fresh {
+            let agent = agent_key_for_pane(&self.state, &event.pane);
+            let needs_attention = event.kind == AttentionEventKind::NeedsAttention;
+            if self
+                .agent_marks
+                .state(&agent)
+                .may_notify(needs_attention, now_ms)
+            {
+                self.device_notifications.enqueue(event, at);
+            }
+        }
         fresh
             .into_iter()
             .flat_map(|event| self.broker.attention_observed(event))
@@ -2882,6 +2941,25 @@ impl Daemon {
     /// federation and the attention index, both of which already survive a
     /// restart on their own terms. Rebuilding it is cheap and keeps one
     /// authority for each fact.
+    /// Hand one coalesced alert to every subscribed device, if one is due.
+    fn device_alerts(&mut self) -> Vec<Effect> {
+        let Some(delivery) = self.device_notifications.take_ready(Instant::now()) else {
+            return Vec::new();
+        };
+        let Some(pane) = delivery.pane().cloned() else {
+            return Vec::new();
+        };
+        self.broker.notify_devices(ServerMessage::Notification {
+            // Resolved now rather than when the event was recorded: the
+            // identity a person taps should name the agent as it currently is,
+            // and if it has gone the tap is refused rather than delivered
+            // somewhere else.
+            agent: agent_key_for_pane(&self.state, &pane),
+            title: delivery.title().to_owned(),
+            body: delivery.body().to_owned(),
+        })
+    }
+
     fn project_agent_cards(&mut self) -> Vec<Effect> {
         let now_ms = unix_time_ms();
         // A snooze that has run out stops being carried before anything is

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -698,7 +698,12 @@ mod tests {
         assert!(APP.contains("type=\"file\""));
         assert!(APP.contains("type: 'upload.begin'"));
         assert!(APP.contains("crypto.subtle.digest('SHA-256'"));
-        assert_eq!(APP.matches("data-reply=").count(), 4);
+        // Replies are drawn from what the daemon sends, so the markup holds a
+        // container and no buttons. A hardcoded reply here would be a button
+        // nobody configured.
+        assert!(APP.contains("id=\"quick-replies\""));
+        assert!(!APP.contains("data-reply=\""));
+        assert!(APP.contains("message.quick_replies"));
         assert!(APP.contains("class=\"keys control-strip\""));
         assert!(APP.contains("id=\"plugin-tools\""));
         assert!(APP.contains("type: 'plugin.actions.list'"));
@@ -725,6 +730,7 @@ mod tests {
                 web: Default::default(),
                 targets: Vec::new(),
                 devices: Vec::new(),
+                quick_replies: None,
             },
             None,
             DaemonOptions {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -131,6 +131,25 @@ pub struct NotificationDelivery {
     timeout: Duration,
 }
 
+impl NotificationDelivery {
+    /// What a delivery says, for a sink that renders it somewhere other than
+    /// this machine's desktop. Both are already bounded metadata: an agent
+    /// name, a workspace label, a qualified target and session, and the kind
+    /// of transition. No terminal contents reach either one, because attention
+    /// events carry none.
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn body(&self) -> &str {
+        &self.body
+    }
+
+    pub fn pane(&self) -> Option<&PaneId> {
+        self.pane.as_ref()
+    }
+}
+
 fn notification_title(count: usize, latest: &AttentionEvent) -> String {
     if count > 1 {
         return format!("{count} Super-Herdr agent updates");

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -334,6 +334,19 @@ pub enum ClientMessage {
         agent: AgentId,
         mark: AgentMarkRequest,
     },
+    /// Ask to be told when an agent wants attention.
+    ///
+    /// Opt-in per connection and never implied by any other subscription: a
+    /// device that renders the inbox has not thereby asked to be interrupted
+    /// by it, and on a phone those are different permissions granted at
+    /// different moments.
+    #[serde(rename = "notifications.subscribe")]
+    SubscribeNotifications,
+    /// Stop being told. Separate from revoking the browser's own permission,
+    /// which this daemon neither holds nor can change: what this ends is the
+    /// daemon sending anything to this connection.
+    #[serde(rename = "notifications.unsubscribe")]
+    UnsubscribeNotifications,
 }
 
 /// Sent by the daemon.
@@ -436,6 +449,23 @@ pub enum ServerMessage {
     /// this projection exists to prevent.
     #[serde(rename = "agents.cards")]
     AgentCards { projection: AgentCardProjection },
+    /// One coalesced attention alert for a paired device.
+    ///
+    /// Bounded metadata only, and by construction rather than by filtering
+    /// here: the title and body are built from attention history, which holds
+    /// an agent name, a workspace label, a qualified pane and a transition
+    /// kind, and never terminal contents, clipboard data, file names or
+    /// pairing material.
+    ///
+    /// `agent` is what a click acts on. It is an identity rather than a route,
+    /// so acting on it re-resolves the live pane and can refuse — a person may
+    /// tap an alert long after the agent it named has gone.
+    #[serde(rename = "notification")]
+    Notification {
+        agent: AgentId,
+        title: String,
+        body: String,
+    },
     /// A pairing code and how long it lasts. Never persisted: a code that
     /// survived a restart would be a credential nobody knew was outstanding.
     #[serde(rename = "pairing.code")]
@@ -632,7 +662,7 @@ mod tests {
         AGENT_CARD_PROJECTION_VERSION, AgentActivity, AgentCard, AgentCardProjection,
         AgentCardSection,
     };
-    use crate::agent_marks::{AgentMarkRequest, AgentMarkState};
+    use crate::agent_marks::{AgentMarkRequest, AgentMarkState, NotifyMode};
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{AgentId, PaneId, TargetSession, WorkspaceId};
     use crate::operation::Operation;
@@ -772,6 +802,8 @@ mod tests {
         round_trip_client(ClientMessage::MarkAllAttentionSeen);
         round_trip_client(ClientMessage::ClearSeenAttention);
         round_trip_client(ClientMessage::SubscribeAgentCards);
+        round_trip_client(ClientMessage::SubscribeNotifications);
+        round_trip_client(ClientMessage::UnsubscribeNotifications);
         round_trip_client(ClientMessage::MarkAgent {
             request: 11,
             agent: AgentId::new("first", "default", "w1:p1"),
@@ -825,11 +857,17 @@ mod tests {
                         pinned: true,
                         muted: false,
                         snoozed_until_ms: None,
+                        notify: NotifyMode::Default,
                     },
                 }],
                 working: Vec::new(),
                 recent: Vec::new(),
             },
+        });
+        round_trip_server(ServerMessage::Notification {
+            agent: AgentId::new("first", "default", "w1:p1"),
+            title: "Agent needs attention".to_owned(),
+            body: "reviewer · compiler".to_owned(),
         });
         round_trip_server(ServerMessage::PaneClosed { pane: pane() });
         round_trip_server(ServerMessage::PaneLease {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 use crate::agent_card::AgentCardProjection;
 use crate::agent_marks::AgentMarkRequest;
 use crate::attention::AttentionEvent;
+use crate::config::QuickReply;
 use crate::model::{AgentId, PaneId, TargetSession};
 use crate::operation::Operation;
 use crate::plugin::{PluginAction, PluginRun, PluginRunId};
@@ -344,6 +345,17 @@ pub enum ServerMessage {
         protocol: u32,
         server_version: String,
         features: Vec<String>,
+        /// The one-tap replies this daemon is configured to offer.
+        ///
+        /// Sent here because they are constant for the process and a client
+        /// needs them before it can draw its controls. They are *replies*, not
+        /// choices: Herdr's documented API says whether an agent is ready for
+        /// input, never what it is asking, so there is nothing to derive a
+        /// semantic button from and this daemon will not read a terminal to
+        /// guess one. A client renders exactly this list and invents nothing
+        /// when it is empty.
+        #[serde(default)]
+        quick_replies: Vec<QuickReply>,
     },
     /// The whole federation, sent once per state subscription.
     #[serde(rename = "state.full")]
@@ -788,6 +800,7 @@ mod tests {
             protocol: PROTOCOL_VERSION,
             server_version: "0.3.1".to_owned(),
             features: vec!["terminal".to_owned()],
+            quick_replies: crate::config::default_quick_replies(),
         });
         round_trip_server(ServerMessage::AgentCards {
             projection: AgentCardProjection {

--- a/src/resource_action.rs
+++ b/src/resource_action.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::agent_marks::AgentMarkRequest;
+use crate::agent_marks::{AgentMarkRequest, NotifyMode};
 use crate::model::{AgentId, PaneId, TabId, TargetSession, WorkspaceId};
 use crate::plugin::{PluginAction, PluginInvocationTarget};
 
@@ -186,6 +186,12 @@ impl ResourceAction {
                     minutes: Some(minutes),
                 } => format!("Snooze agent {label:?} for {minutes} minutes"),
                 AgentMarkRequest::Snooze { minutes: None } => format!("Wake agent {label:?}"),
+                AgentMarkRequest::Notify {
+                    mode: NotifyMode::NeedsYouOnly,
+                } => format!("Notify about agent {label:?} only when it needs you"),
+                AgentMarkRequest::Notify {
+                    mode: NotifyMode::Default,
+                } => format!("Notify about agent {label:?} normally"),
             },
         }
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -83,6 +83,7 @@ pub async fn expand_discovered_sessions(config: crate::config::Config) -> crate:
     let transfers = config.transfers.clone();
     let web = config.web.clone();
     let devices = config.devices.clone();
+    let quick_replies = config.quick_replies.clone();
     let originals = config.targets;
     let mut tasks = tokio::task::JoinSet::new();
     for (index, target) in originals.iter().cloned().enumerate() {
@@ -110,6 +111,7 @@ pub async fn expand_discovered_sessions(config: crate::config::Config) -> crate:
         web,
         targets: expanded,
         devices,
+        quick_replies,
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -488,6 +488,7 @@ impl TargetForm {
             web: Default::default(),
             targets,
             devices: Vec::new(),
+            quick_replies: None,
         }
         .validate()
         .err()
@@ -7801,6 +7802,7 @@ mod tests {
             web: Default::default(),
             targets: vec![configured.clone()],
             devices: Vec::new(),
+            quick_replies: None,
         });
         assert!(!super::atomic_paste_available(&unresolved, &key));
 
@@ -7819,6 +7821,7 @@ mod tests {
             web: Default::default(),
             targets: vec![discovered],
             devices: Vec::new(),
+            quick_replies: None,
         });
         assert!(
             super::atomic_paste_available(&resolved, &key),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -25,7 +25,7 @@ use tokio::sync::mpsc;
 use tokio::time::{interval, sleep_until};
 
 use crate::agent_card::agent_key;
-use crate::agent_marks::{AgentMarkRequest, AgentMarkState};
+use crate::agent_marks::{AgentMarkRequest, AgentMarkState, NotifyMode};
 use crate::attention::{AttentionEvent, AttentionEventKind, AttentionIndex};
 use crate::client::{Client, ClientCommands};
 use crate::clipboard;
@@ -2977,6 +2977,12 @@ fn agent_mark_actions(
                 .is_none()
                 .then_some(TUI_SNOOZE_MINUTES),
         }),
+        mark(AgentMarkRequest::Notify {
+            mode: match marked.notify {
+                NotifyMode::Default => NotifyMode::NeedsYouOnly,
+                NotifyMode::NeedsYouOnly => NotifyMode::Default,
+            },
+        }),
     ]
 }
 
@@ -5351,6 +5357,11 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
         // renders is still its own. What the projection is read for here is
         // the marks a person put on a card, so a context menu can offer the
         // toggle that is available instead of both halves of it.
+        // The TUI runs its own notification queue against its attention
+        // mirror, because a desktop alert belongs to the machine somebody is
+        // sitting at. It does not subscribe to the device sink and is never
+        // sent one.
+        ServerMessage::Notification { .. } => {}
         ServerMessage::AgentCards { projection } => {
             app.agent_marks = projection
                 .cards()
@@ -7853,7 +7864,7 @@ mod tests {
         update_selection_after_frame, update_sidebar_hit_areas, viewport_shift_distance,
         visible_pane_areas,
     };
-    use crate::agent_marks::{AgentMarkRequest, AgentMarkState};
+    use crate::agent_marks::{AgentMarkRequest, AgentMarkState, NotifyMode};
     use crate::config::{Config, Target};
     use crate::model::{AgentId, PaneId, TargetSession, WorkspaceId};
     use crate::plugin::{PluginAction, PluginActionContext, PluginActionId};
@@ -8141,9 +8152,15 @@ mod tests {
                 (expected.clone(), AgentMarkRequest::Pin { pinned: true }),
                 (expected.clone(), AgentMarkRequest::Mute { muted: true }),
                 (
-                    expected,
+                    expected.clone(),
                     AgentMarkRequest::Snooze {
                         minutes: Some(TUI_SNOOZE_MINUTES)
+                    }
+                ),
+                (
+                    expected,
+                    AgentMarkRequest::Notify {
+                        mode: NotifyMode::NeedsYouOnly
                     }
                 ),
             ]
@@ -8216,6 +8233,7 @@ mod tests {
                 pinned: true,
                 muted: false,
                 snoozed_until_ms: Some(1_700_000_000_000),
+                notify: NotifyMode::Default,
             },
         )]);
 

--- a/tools/page-harness.mjs
+++ b/tools/page-harness.mjs
@@ -103,6 +103,22 @@ globalThis.fetch = (url, init) => {
   }
   return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
 };
+// A notification the page raised, and the permission it was raised under.
+const alerts = [];
+class StubNotification {
+  constructor(title, options) {
+    this.title = title;
+    this.options = options;
+    alerts.push(this);
+  }
+}
+StubNotification.permission = 'default';
+StubNotification.requestPermission = () => {
+  StubNotification.permission = StubNotification.granting ? 'granted' : 'denied';
+  return Promise.resolve(StubNotification.permission);
+};
+globalThis.Notification = StubNotification;
+
 class StubEventSource {
   constructor() { StubEventSource.latest = this; }
   close() {}
@@ -580,3 +596,81 @@ check('an older daemon hides the inbox', page.el('inbox').hidden === true);
 check('an older daemon opens the hierarchy instead', page.el('hierarchy').open === true);
 deliver({ type: 'server.hello', protocol: 3, server_version: '0.7.20', features: ['terminal', 'agent_cards'] });
 page.el('inbox').hidden = false;
+
+// Alerts are two permissions, granted at different moments: the browser's, and
+// this page's subscription to the daemon. Rendering the inbox is neither.
+StubNotification.granting = false;
+alerts.length = 0;
+sent.length = 0;
+await page.el('alerts').onclick();
+check('a refused browser permission subscribes to nothing',
+  sent.every(one => one.body.type !== 'notifications.subscribe'));
+check('a refused browser permission says so', page.el('alert-note').textContent.includes('not allowing'));
+check('a refused permission leaves the toggle off', page.el('alerts')['aria-pressed'] === 'false');
+
+StubNotification.granting = true;
+sent.length = 0;
+await page.el('alerts').onclick();
+check('a granted permission subscribes',
+  sent.some(one => one.body.type === 'notifications.subscribe'));
+check('a granted permission shows the toggle on', page.el('alerts')['aria-pressed'] === 'true');
+
+// An alert carries bounded metadata and replaces its own agent's last one.
+deliver(projection({ needs_you: [card('p1', { unread: true })] }));
+alerts.length = 0;
+deliver({
+  type: 'notification',
+  agent: { target: 'first', session: 'main', resource: 'p1' },
+  title: 'Agent needs attention',
+  body: 'reviewer · compiler',
+});
+check('an alert is raised', alerts.length === 1);
+check('an alert carries the daemon title', alerts[0].title === 'Agent needs attention');
+check('an alert is tagged by its agent', alerts[0].options.tag === 'first/main/p1');
+
+// Tapping it opens the agent it names, against the inbox as it is now.
+sent.length = 0;
+alerts[0].onclick();
+check(
+  'tapping an alert opens the agent it names',
+  sent.some(one => one.body.type === 'pane.subscribe' && one.body.pane.resource === 'p1'),
+);
+check('an opened alert clears the note', page.el('alert-note').textContent === '');
+
+// The race the exit condition names: the agent went away between the alert
+// being sent and the tap landing.
+deliver(projection({ needs_you: [] }));
+sent.length = 0;
+alerts[0].onclick();
+check('a tap on a departed agent opens nothing',
+  sent.every(one => one.body.type !== 'pane.subscribe'));
+check('a tap on a departed agent says so',
+  page.el('alert-note').textContent === 'That agent is no longer running.');
+
+// An agent still listed but not reachable — its host dropped — is a different
+// sentence, because the agent has not ended.
+deliver(projection({
+  needs_you: [card('p1', { actionable: false, stale: true })],
+}));
+sent.length = 0;
+alerts[0].onclick();
+check('a tap on an unreachable agent opens nothing',
+  sent.every(one => one.body.type !== 'pane.subscribe'));
+check('a tap on an unreachable agent distinguishes the host',
+  page.el('alert-note').textContent === 'That agent is no longer reachable.');
+
+// Turning them off ends the daemon's side, and a stray alert is ignored.
+sent.length = 0;
+await page.el('alerts').onclick();
+check('turning alerts off unsubscribes',
+  sent.some(one => one.body.type === 'notifications.unsubscribe'));
+alerts.length = 0;
+deliver({
+  type: 'notification',
+  agent: { target: 'first', session: 'main', resource: 'p1' },
+  title: 'Agent needs attention',
+  body: 'reviewer · compiler',
+});
+check('an alert after turning them off raises nothing', alerts.length === 0);
+StubNotification.granting = true;
+await page.el('alerts').onclick();

--- a/tools/page-harness.mjs
+++ b/tools/page-harness.mjs
@@ -59,11 +59,6 @@ const keyButtons = [
   button.dataset = { key };
   return button;
 });
-const quickReplyButtons = ['yes', 'no', 'continue', 'retry'].map(reply => {
-  const button = node(`reply-${reply}`);
-  button.dataset = { reply };
-  return button;
-});
 const codeBoxNodes = Array.from({ length: 8 }, (_, index) => node(`code-${index}`));
 
 globalThis.document = {
@@ -72,7 +67,6 @@ globalThis.document = {
   querySelector: selector => node(`sel-${selector}`),
   querySelectorAll: selector => {
     if (selector === '.keys button') return keyButtons;
-    if (selector === '.quick-replies button') return quickReplyButtons;
     if (selector === '.code-box') return codeBoxNodes;
     return [];
   },
@@ -115,7 +109,7 @@ class StubEventSource {
 }
 globalThis.EventSource = StubEventSource;
 
-const module = new Function(`${script}\nreturn { apply, observe, takeControl, uploadSelectedFiles, shellQuote, el, KEYS, QUICK_REPLIES, endpoint, renderPanes, codeBoxes, enteredCode };`);
+const module = new Function(`${script}\nreturn { apply, observe, takeControl, uploadSelectedFiles, shellQuote, el, KEYS, endpoint, renderPanes, codeBoxes, enteredCode };`);
 const page = module();
 
 const deliver = message => page.apply(message);
@@ -128,6 +122,15 @@ const check = (what, condition) => {
     console.log(`ok: ${what}`);
   }
 };
+const replies = () => page.el('quick-replies').children;
+const configureReplies = quick_replies => deliver({
+  type: 'server.hello',
+  protocol: 3,
+  server_version: '0.7.20',
+  features: ['terminal', 'agent_cards'],
+  quick_replies,
+});
+
 const waitFor = async predicate => {
   for (let attempt = 0; attempt < 100; attempt++) {
     if (predicate()) return;
@@ -221,6 +224,14 @@ sent.length = 0;
 keyButtons[0].onclick();
 check('an observer sends no input', sent.length === 0);
 
+// The daemon said which replies it offers during the handshake.
+configureReplies([
+  { label: 'Yes', send: 'y', submit: true, confirm: false },
+  { label: 'No', send: 'n', submit: true, confirm: false },
+  { label: 'Paste path', send: '/srv/build', submit: false, confirm: false },
+  { label: 'Wipe', send: 'reset --hard', submit: true, confirm: true },
+]);
+
 // Ask for control.
 page.takeControl();
 check('asks for control', sent.at(-1).body.type === 'pane.take_control');
@@ -228,7 +239,10 @@ check('reveals the keyboard during the control tap', page.el('keyboard').hidden 
 check('focuses the line during the control tap', page.el('line').focused === true);
 check('does not enable Send before the lease arrives', page.el('send').disabled === true);
 check('does not enable terminal keys before the lease arrives', keyButtons.every(one => one.disabled));
-check('does not enable quick replies before the lease arrives', quickReplyButtons.every(one => one.disabled));
+check(
+  'does not enable quick replies before the lease arrives',
+  replies().length > 0 && replies().every(one => one.disabled),
+);
 sent.length = 0;
 page.el('line').value = 'typed while waiting';
 page.el('line-form').onsubmit({ preventDefault() {} });
@@ -241,7 +255,10 @@ check('the keyboard appears with control', page.el('keyboard').hidden === false)
 check('control is no longer offered', page.el('control').hidden === true);
 check('enables Send only with control', page.el('send').disabled === false);
 check('enables terminal keys only with control', keyButtons.every(one => !one.disabled));
-check('enables quick replies only with control', quickReplyButtons.every(one => !one.disabled));
+check(
+  'enables quick replies only with control',
+  replies().length > 0 && replies().every(one => !one.disabled),
+);
 
 // A browser file uses the daemon's verified upload protocol. Its MIME can be
 // an Office type the clipboard-media table does not know; the name preserves
@@ -318,16 +335,55 @@ for (const [index, key] of [
   check(`${key} sends ${JSON.stringify(page.KEYS[key])}`, bytes === page.KEYS[key]);
 }
 
-// Quick replies are explicit one-tap submissions, not text inferred from the
-// terminal screen. They include Enter and do not summon the software keyboard.
-for (const [index, reply] of ['yes', 'no', 'continue', 'retry'].entries()) {
+// Quick replies are what the daemon was configured to offer, rendered exactly
+// as sent. Nothing here is inferred from the terminal screen.
+
+check('renders one button per configured reply', replies().length === 4);
+check('a reply is labelled as configured', replies()[0].textContent === 'Yes');
+check(
+  'a reply says what it sends',
+  replies()[0]['aria-label'] === 'Send y and Enter'
+    && replies()[2]['aria-label'] === 'Send /srv/build',
+);
+
+for (const [index, expected] of [['Yes', 'y\r'], ['No', 'n\r'], ['Paste path', '/srv/build']].entries()) {
   sent.length = 0;
   page.el('line').focused = false;
-  quickReplyButtons[index].onclick();
+  replies()[index].onclick();
   const bytes = Buffer.from(sent.at(-1).body.bytes, 'base64').toString('utf8');
-  check(`${reply} is submitted in one tap`, bytes === page.QUICK_REPLIES[reply]);
-  check(`${reply} does not open the software keyboard`, page.el('line').focused === false);
+  check(`${expected[0]} is submitted in one tap`, bytes === expected[1]);
+  check(`${expected[0]} does not open the software keyboard`, page.el('line').focused === false);
 }
+
+// A reply that declared it needs confirming takes two taps, on itself.
+sent.length = 0;
+replies()[3].onclick();
+check('a confirming reply sends nothing on the first tap', sent.length === 0);
+check('a confirming reply says it is armed', replies()[3]['aria-pressed'] === 'true');
+check('a confirming reply asks for the second tap', replies()[3].textContent === 'Tap again');
+replies()[3].onclick();
+check(
+  'a confirming reply sends on the second tap',
+  Buffer.from(sent.at(-1).body.bytes, 'base64').toString('utf8') === 'reset --hard\r',
+);
+check('a sent reply disarms', replies()[3].textContent === 'Wipe');
+
+// Losing the lease ends the moment an armed reply belonged to.
+replies()[3].onclick();
+deliver({ type: 'pane.lease', pane, access: 'observe' });
+check('a lost lease disarms a waiting reply', replies()[3].textContent === 'Wipe');
+sent.length = 0;
+replies()[0].onclick();
+check('an observer sends no reply', sent.length === 0);
+deliver({ type: 'pane.lease', pane, access: 'control' });
+
+// A daemon that offers none draws none. The page does not invent a fallback,
+// because a button nobody configured would be a guess about what to type.
+configureReplies([]);
+check('no configured replies draws no buttons', replies().length === 0);
+check('an empty strip is hidden', page.el('quick-replies').hidden === true);
+configureReplies([{ label: 'Yes', send: 'y', submit: true, confirm: false }]);
+deliver({ type: 'pane.lease', pane, access: 'control' });
 
 // Losing the lease takes the keyboard with it.
 deliver({ type: 'pane.lease', pane, access: 'observe' });


### PR DESCRIPTION
Stacked on #20.

Two ways of answering an agent from a phone, both shaped by the same finding.

## Quick replies are configured, not inferred

The backlog asked for *structured response actions* — buttons rendered from a blocked agent's own prompt metadata. **Herdr does not expose any.** Its API schema, checked against a live install at protocol 19, reports an agent's status and whether it is ready for input, and describes nowhere what it is asking: no choice, option, confirm or approve concept exists in its request or event schemas.

So the backlog's stated fallback applies and semantic buttons stay blocked. The only way to produce one would be to read the terminal and guess, and a button that types `y` because the screen looked like a yes/no prompt is a keystroke sent on the strength of a pattern match the person holding the phone cannot see.

What ships is `[[quick_replies]]` in configuration — the four that were hardcoded in the page, now with the same four as the default so nothing regresses, and an empty list as the way to turn them off. The daemon sends the list in the handshake; the page renders exactly it and invents no fallback. A reply's text may not contain control characters, so a config cannot smuggle an escape sequence into a pane.

With no metadata to learn irreversibility from, **the person who wrote the reply declares it** with `confirm`, and confirming is a second tap on the button rather than a dialog a phone dismisses by reflex.

## Alerts live in the daemon

The desktop's notification queue is run by the frontend against its attention mirror. That is right for the machine somebody is sitting at and useless for the case this exists for, so the device sink lives in the daemon, reusing the same filters, coalescing window and rate limit.

Three consents stay distinct because they are granted at different moments: the operator enables `notifications.devices`, the browser grants its own permission, and the page subscribes. **Rendering the inbox subscribes to nothing** — showing somebody their agents is not the same as interrupting them about one.

Payloads are bounded by construction, not by filtering: they are built from attention events. A test now pins that down, because Herdr's snapshot *does* carry `terminal_title` — on my own machine that field currently reads `"◑ Pick up where we were"`, a paraphrase of somebody's prompt — and nothing reads it.

## Known limit

This alerts a device while its page is running. **Waking a closed browser needs Web Push** — a service worker, VAPID signing, and a third-party push service as a new outbound trust boundary whose endpoint the browser supplies. That is a dependency and trust decision rather than a detail of this sink, so it is written up in `ARCHITECTURE.md` and left as a marked backlog item. The design I would argue for sends no payload at all and lets the woken worker ask the daemon, so the push service learns that something happened and never what.

## Checks

363 tests · 136 page-harness assertions · fmt, clippy (host + macOS target), check-docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdRHimPZdtFsZgAnmpCRUE
