### PR TITLE
File transfer surfaces: browser fetch, remote picker, desktop save and host-to-host

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -580,6 +580,25 @@ fit here sends no payload at all and lets the woken service worker ask the
 daemon, so the push service learns that something happened and never what. That
 is a separate decision about dependencies and trust, not a detail of this sink.
 
+The desktop reaches the same two directions from its own menus. Right-clicking
+a pane offers to save a file from that host onto this machine, and to send one
+from that host to each other live host — one destination per host rather than
+one per pane, because the choice that matters is which machine, and a menu
+listing every pane on every host is the hierarchy this is meant to save
+somebody from walking. A host that is not connected is not offered as a
+destination.
+
+Saving writes nowhere a person would look for a finished file until it is
+finished. Bytes go to a temporary file beside the destination and are renamed
+into place only once the length and the digest both check out, so an
+interrupted transfer leaves nothing rather than something that looks complete,
+and a failed digest takes the temporary file with it. The host's name for the
+file is reduced to its last component before it is used: the protocol promises
+a name rather than a path, and this is the place where trusting that promise
+would cost somebody a file written outside the directory they chose. An
+existing file is refused rather than renamed around, because a download that
+quietly became `report (2).txt` is one somebody opens the old copy of.
+
 Finding the file is a separate surface from fetching it, and a narrower one. A
 target declares the directories its picker may look inside; a target that
 declares none offers no picker, because a browser starting at `/` is one nobody

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -580,6 +580,37 @@ fit here sends no payload at all and lets the woken service worker ask the
 daemon, so the push service learns that something happened and never what. That
 is a separate decision about dependencies and trust, not a detail of this sink.
 
+Finding the file is a separate surface from fetching it, and a narrower one. A
+target declares the directories its picker may look inside; a target that
+declares none offers no picker, because a browser starting at `/` is one nobody
+asked for. A client names a root rather than describing one — it must be a path
+the configuration wrote down, compared exactly — so asking about a parent or a
+deeper path does not widen what a client may see.
+
+Nothing is interpolated into a shell. Every parameter travels on the remote
+script's stdin and is read into a variable, exactly as the file read already
+works, so a path containing a quote, a semicolon or a newline is a path rather
+than a command. Containment is checked on the host by comparing `pwd -P` — the
+physical path, symlinks resolved — against the root's own physical path, which
+is what makes a symlink pointing out of the tree a refusal rather than a
+shortcut; search does not follow symlinks at all. Output is NUL-framed, so a
+file name may contain anything a file name may contain, and a record cut in
+half by the byte cap is dropped rather than half-read.
+
+Everything is bounded: how many roots a target may declare, how deep a search
+descends, how many entries return, how long a query may be, and how many bytes
+the remote may produce. A listing that stopped short says so, because a list
+silently missing the file somebody is looking for is worse than one that admits
+it stopped. Entries carry a name and a kind and no size — size is what the
+transfer offer reports at the moment it matters, and collecting it here would
+mean reading every file in a directory to answer a question the next step
+answers for free.
+
+The roots bound browsing, and deliberately not reading. A paired device already
+holds pane control and can read anything its user can, so a root is a place
+worth looking rather than a permission boundary; saying otherwise would claim a
+guarantee this does not make.
+
 Fetching a file to a paired device is two steps, and the split is the point.
 The daemon answers `download.begin` with what the file is — its own last path
 component, its length, and the digest the host computed — and then sends

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -580,6 +580,36 @@ fit here sends no payload at all and lets the woken service worker ask the
 daemon, so the push service learns that something happened and never what. That
 is a separate decision about dependencies and trust, not a detail of this sink.
 
+Fetching a file to a paired device is two steps, and the split is the point.
+The daemon answers `download.begin` with what the file is — its own last path
+component, its length, and the digest the host computed — and then sends
+nothing until it is pulled. So a person sees the size and the source before a
+byte crosses the link, and a path that turned out to name a core dump is
+refused rather than discovered halfway through. What the browser will hold is
+bounded by the same ceiling as an upload, and an offer above it cannot be
+accepted at all.
+
+The digest is verified at the receiving end, which is the only end that can:
+the daemon carries the host's attestation without checking it, exactly as it
+carries a client's in the other direction. A file that does not match is
+discarded rather than offered with a warning, because a Save button beside a
+warning is a Save button people press.
+
+The path is typed. Nothing reads the terminal to work out which file an agent
+was looking at — a path inferred from what a screen happened to show is a
+guess, and fetching whatever that guess named is a worse failure than asking.
+The same rule is why previews are decided by name and kept narrow: text is
+decoded and shown as text, an image is shown as an image, and anything else is
+saved without being rendered. A PDF is saved rather than previewed, because
+rendering one means handing a file off somebody's host to the browser's
+scripted viewer inside this page; that is a decision worth taking deliberately
+rather than as a side effect of adding a file picker.
+
+A transfer belongs to the pane it was asked for. Watching another pane abandons
+it rather than letting bytes from one host arrive under another host's heading,
+and a reconnect forgets it rather than cancelling a request number the daemon
+has since given to somebody else.
+
 Delivering a notification is a separate question from owning the index, and it
 divides the way the clipboard does. Native desktop delivery is a desktop-session
 capability: it belongs to the client, because a daemon on another machine

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -198,21 +198,25 @@ payloads. Receiving one with the browser closed waits on the item above.
 
 ### 4. Remote files and artifacts
 
-- [ ] Finish browser upload and target-to-device download surfaces on the
+- [x] Finish browser upload and target-to-device download surfaces on the
       existing transfer protocol.
 - [ ] Finish TUI target-to-client save and target-to-target transfer surfaces.
 - [ ] Add an explicit, bounded remote-path picker scoped to one qualified
       target and session.
 - [ ] Support bounded filename, substring, and opt-in glob search without
       traversing beyond configured roots.
-- [ ] Show metadata before transfer: name, type, size, source target, and
+- [x] Show metadata before transfer: name, type, size, source target, and
       digest when available.
-- [ ] Add safe client-side previews for text, images, and PDF files after the
-      normal bounded transfer and digest verification.
+- [x] Add safe client-side previews for text and images after the normal
+      bounded transfer and digest verification. A PDF is saved rather than
+      rendered: previewing one hands a file off somebody's host to the
+      browser's scripted viewer inside this page, which wants its own decision.
 - [ ] Route Git diff, source browsing, Office rendering, and richer review
       experiences through plugin actions rather than duplicating an IDE.
-- [ ] Add cancellation and cleanup tests for every transfer direction.
-- [ ] Never discover "files the agent read" by parsing transcripts or terminal
+- [ ] Add cancellation and cleanup tests for every transfer direction. The
+      browser download direction is covered; TUI save and target-to-target
+      still need their surfaces first.
+- [x] Never discover "files the agent read" by parsing transcripts or terminal
       contents; require an explicit path or structured plugin result.
 
 Exit condition: a phone user can find a permitted remote file, verify its

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -200,7 +200,7 @@ payloads. Receiving one with the browser closed waits on the item above.
 
 - [x] Finish browser upload and target-to-device download surfaces on the
       existing transfer protocol.
-- [ ] Finish TUI target-to-client save and target-to-target transfer surfaces.
+- [x] Finish TUI target-to-client save and target-to-target transfer surfaces.
 - [x] Add an explicit, bounded remote-path picker scoped to one qualified
       target and session.
 - [x] Support bounded filename, substring, and opt-in glob search without
@@ -213,9 +213,7 @@ payloads. Receiving one with the browser closed waits on the item above.
       browser's scripted viewer inside this page, which wants its own decision.
 - [ ] Route Git diff, source browsing, Office rendering, and richer review
       experiences through plugin actions rather than duplicating an IDE.
-- [ ] Add cancellation and cleanup tests for every transfer direction. The
-      browser download direction is covered; TUI save and target-to-target
-      still need their surfaces first.
+- [x] Add cancellation and cleanup tests for every transfer direction.
 - [x] Never discover "files the agent read" by parsing transcripts or terminal
       contents; require an explicit path or structured plugin result.
 

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -201,9 +201,9 @@ payloads. Receiving one with the browser closed waits on the item above.
 - [x] Finish browser upload and target-to-device download surfaces on the
       existing transfer protocol.
 - [ ] Finish TUI target-to-client save and target-to-target transfer surfaces.
-- [ ] Add an explicit, bounded remote-path picker scoped to one qualified
+- [x] Add an explicit, bounded remote-path picker scoped to one qualified
       target and session.
-- [ ] Support bounded filename, substring, and opt-in glob search without
+- [x] Support bounded filename, substring, and opt-in glob search without
       traversing beyond configured roots.
 - [x] Show metadata before transfer: name, type, size, source target, and
       digest when available.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ so a reconnect can never redirect your next keystroke.
   byte moves, verified on arrival, with text and image previews
 - A bounded remote file picker over directories you configure, with literal or
   opt-in pattern search that never leaves those roots
+- Desktop save from a target and host-to-host transfer that never touches this
+  machine, both from the same right-click menus
 - Configurable browser quick replies, terminal keys, a soft-keyboard dock, and
   a file picker
 - Digest-verified local-to-host, host-to-local, and host-to-host file transfer

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ so a reconnect can never redirect your next keystroke.
 - Explicit control leases: background panes and newly opened browser panes are
   read-only until control is granted
 - Desktop selection, clipboard paste, drag-and-drop, and verified uploads
+- Browser file fetch from a target: size, source and digest shown before any
+  byte moves, verified on arrival, with text and image previews
 - Configurable browser quick replies, terminal keys, a soft-keyboard dock, and
   a file picker
 - Digest-verified local-to-host, host-to-local, and host-to-host file transfer

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ so a reconnect can never redirect your next keystroke.
 - Desktop selection, clipboard paste, drag-and-drop, and verified uploads
 - Browser file fetch from a target: size, source and digest shown before any
   byte moves, verified on arrival, with text and image previews
+- A bounded remote file picker over directories you configure, with literal or
+  opt-in pattern search that never leaves those roots
 - Configurable browser quick replies, terminal keys, a soft-keyboard dock, and
   a file picker
 - Digest-verified local-to-host, host-to-local, and host-to-host file transfer

--- a/config.example.toml
+++ b/config.example.toml
@@ -54,6 +54,13 @@ max_bytes = 1073741824
 name = "development"
 ssh = "development-host"
 discover_sessions = true
+# Places the browser's file picker may look on this host. Absent means it
+# offers nothing for this target, which is the default: a browsing surface that
+# starts at / is one nobody asked for. At most eight, each an absolute path
+# with no '..'. This bounds browsing and searching and deliberately not
+# reading — a paired device already holds pane control and can read anything
+# its user can, so a root is a place to look rather than a permission.
+#roots = ["/srv/build", "/home/example/work"]
 # Optional overrides:
 #session = "default"
 #socket = "/absolute/path/to/herdr.sock"

--- a/examples/qualify-upload.rs
+++ b/examples/qualify-upload.rs
@@ -49,6 +49,7 @@ async fn main() -> Result<()> {
         session: None,
         socket: None,
         herdr_bins: vec!["herdr".to_owned()],
+        roots: Vec::new(),
     };
 
     let payload = png(64 * 1024);
@@ -212,6 +213,7 @@ async fn relay(
                     "/home/example/.local/bin/herdr".to_owned(),
                     "herdr".to_owned(),
                 ],
+                roots: Vec::new(),
             }],
             devices: Vec::new(),
             quick_replies: None,

--- a/src/agent_card.rs
+++ b/src/agent_card.rs
@@ -1476,6 +1476,7 @@ mod tests {
             event_error: None,
             connection_generation: 1,
             selected_herdr_bin: Some("herdr".to_owned()),
+            roots: Vec::new(),
             snapshot: snapshot.map(|value| Arc::new(NormalizedSnapshot::from_value(&key, &value))),
             last_error: None,
             last_success: None,

--- a/src/attention.rs
+++ b/src/attention.rs
@@ -732,6 +732,7 @@ mod tests {
                 event_error: None,
                 connection_generation: 1,
                 selected_herdr_bin: Some("herdr".to_owned()),
+                roots: Vec::new(),
                 snapshot: Some(Arc::new(snapshot)),
                 last_error: None,
                 last_success: None,

--- a/src/client.rs
+++ b/src/client.rs
@@ -520,6 +520,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
+            roots: Vec::new(),
         }
     }
 
@@ -607,6 +608,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
+            roots: Vec::new(),
         }]);
         let _ = directory;
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -2310,6 +2310,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,10 @@ pub struct Config {
 /// They share one row on a phone. Past this the row wraps into something a
 /// person scans rather than taps, which is the opposite of the point.
 const MAX_QUICK_REPLIES: usize = 8;
+
+/// How many places one target may offer to look in. A picker with a screenful
+/// of roots is a hierarchy again, which is the thing it exists to avoid.
+const MAX_TARGET_ROOTS: usize = 8;
 const MAX_QUICK_REPLY_LABEL_CHARACTERS: usize = 24;
 const MAX_QUICK_REPLY_SEND_BYTES: usize = 256;
 
@@ -574,6 +578,15 @@ pub struct Target {
     /// Ordered client candidates. A protocol mismatch advances to the next one.
     #[serde(default = "default_herdr_bins")]
     pub herdr_bins: Vec<String>,
+    /// Directories the remote file picker may look inside on this host.
+    ///
+    /// Empty means the picker offers nothing for this target, which is the
+    /// default: a browsing surface that starts at `/` is one nobody asked for.
+    /// This bounds browsing and searching, and deliberately not reading — a
+    /// paired device already holds pane control and can read anything its user
+    /// can, so a root here is a place to look rather than a permission.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roots: Vec<String>,
 }
 
 impl Target {
@@ -806,6 +819,23 @@ impl Config {
                     .any(|binary| binary.trim().is_empty())
             {
                 bail!("target {:?} has an empty herdr_bins entry", target.name);
+            }
+            if target.roots.len() > MAX_TARGET_ROOTS {
+                bail!(
+                    "target {:?} declares more than {MAX_TARGET_ROOTS} roots",
+                    target.name
+                );
+            }
+            for root in &target.roots {
+                if !root.starts_with('/')
+                    || root.chars().any(char::is_control)
+                    || root.split('/').any(|part| part == "..")
+                {
+                    bail!(
+                        "target {:?} has a root that is not an absolute path without '..'",
+                        target.name
+                    );
+                }
             }
             if let Some(destination) = &target.ssh
                 && (destination.is_empty()
@@ -1299,6 +1329,47 @@ send = ""
     }
 
     #[test]
+    fn a_target_root_must_be_an_absolute_path_without_a_climb() {
+        let good = Config::parse(
+            r#"
+[[targets]]
+name = "one"
+ssh = "host"
+roots = ["/srv/build", "/home/example/work"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(good.targets[0].roots.len(), 2);
+
+        for bad in ["\"srv/build\"", "\"/srv/../etc\"", "\"\""] {
+            assert!(
+                Config::parse(&format!(
+                    "\n[[targets]]\nname = \"one\"\nssh = \"host\"\nroots = [{bad}]\n"
+                ))
+                .is_err(),
+                "a picker root must be somewhere it cannot climb out of: {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_target_offers_no_roots_by_default() {
+        let config = Config::parse(
+            r#"
+[[targets]]
+name = "one"
+ssh = "host"
+"#,
+        )
+        .unwrap();
+
+        assert!(
+            config.targets[0].roots.is_empty(),
+            "a browsing surface that starts at / is one nobody asked for"
+        );
+    }
+
+    #[test]
     fn a_transfer_ceiling_is_configurable_and_has_a_default() {
         // Absent is the common case, and it must not mean zero: a missing
         // section that refused every transfer would be a silent outage.
@@ -1461,6 +1532,7 @@ name = "local"
                 session: None,
                 socket: None,
                 herdr_bins: vec!["herdr".to_owned()],
+                roots: Vec::new(),
             },
         )
         .unwrap();
@@ -1832,6 +1904,7 @@ name = "local"
             session: None,
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
         Config::add_target_file(Some(&path), first).unwrap();
 
@@ -1846,6 +1919,7 @@ name = "local"
             session: Some("toolchains".to_owned()),
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
         Config::add_target_file(Some(&path), second).unwrap();
 
@@ -1867,6 +1941,7 @@ name = "local"
             session: None,
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
         Config::add_target_file(Some(&path), target.clone()).unwrap();
         let before = fs::read(&path).unwrap();
@@ -1904,6 +1979,7 @@ ssh = "build-host"
             session: None,
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
 
         Config::replace_target_file(Some(&path), "development", replacement).unwrap();
@@ -2028,6 +2104,7 @@ ssh = "build-host"
                 session: None,
                 socket: None,
                 herdr_bins: vec!["herdr".to_owned()],
+                roots: Vec::new(),
             },
         )
         .unwrap();

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -116,6 +116,16 @@
   .card-marks .chip { padding: .25rem .6rem; font-size: .76rem; min-height: 1.9rem; }
   .card[aria-disabled="true"] { color: var(--dim); }
   .card-meta { display: flex; gap: .4rem; color: var(--dim); font-size: .78rem; margin-top: .25rem; }
+  #picker { margin-top: .7rem; }
+  #picker-search-form { flex-wrap: wrap; }
+  #picker-query { flex: 1 1 10rem; min-width: 0; }
+  #picker-entries { list-style: none; margin: .35rem 0 0; padding: 0; max-height: 32vh; overflow-y: auto; }
+  #picker-entries li { border-bottom: 1px solid var(--line); }
+  #picker-entries button {
+    display: block; width: 100%; text-align: left; background: none; border: 0;
+    color: inherit; padding: .5rem .2rem; min-height: 2.4rem;
+  }
+  #picker-note:empty, #picker-where:empty { display: none; }
   #fetch-form { flex-wrap: wrap; }
   #fetch-path { flex: 1 1 12rem; min-width: 0; }
   #fetch-text { max-height: 40vh; white-space: pre-wrap; word-break: break-word; }
@@ -331,6 +341,19 @@
           </label>
         </div>
         <span id="upload-note" class="note" role="status"></span>
+        <div id="picker" hidden>
+          <div id="picker-roots" class="chips" role="group" aria-label="Places to look"></div>
+          <form id="picker-search-form" class="actions">
+            <input id="picker-query" class="field-input" placeholder="Find by name"
+                   autocomplete="off" autocorrect="off" spellcheck="false" enterkeyhint="search">
+            <button id="picker-glob" type="button" class="chip" aria-pressed="false"
+                    title="Treat the search as a pattern">Pattern</button>
+            <button id="picker-search" type="submit">Find</button>
+          </form>
+          <div id="picker-where" class="card-meta"></div>
+          <ul id="picker-entries"></ul>
+          <p id="picker-note" class="note" role="status"></p>
+        </div>
         <form id="fetch-form" class="actions">
           <input id="fetch-path" class="field-input" placeholder="Path on this host"
                  autocomplete="off" autocorrect="off" spellcheck="false" enterkeyhint="go">
@@ -966,6 +989,11 @@ function observe(pane, label) {
   if (!uploadBusy) el('upload-note').textContent = DEFAULT_UPLOAD_NOTE;
   el('screen').innerHTML = '';
   renderPluginTools();
+  picker = null;
+  el('picker-entries').innerHTML = '';
+  el('picker-where').textContent = '';
+  el('picker-note').textContent = '';
+  renderPicker();
   subscribeScreen(pane);
 }
 
@@ -1124,6 +1152,132 @@ function renderKeyboard() {
   // A reply waiting for its second tap is a decision that belonged to the
   // moment it was armed in. Losing the lease ends that moment.
   if (!holding && armedReply !== null) armReply(null);
+}
+
+// Looking for a file, inside the places somebody configured.
+//
+// A picker rather than a file manager: it lists one directory and searches for
+// names under one root, and what it produces is a path for the fetch below it.
+// The roots come from the daemon's configuration and are the only places it
+// will look; a target that declares none offers no picker at all, because a
+// browser starting at / is one nobody asked for.
+let picker = null;
+let pickerGlob = false;
+
+function pickerTarget() {
+  if (!watching) return null;
+  const runtime = targets.get(targetKey(watching));
+  const roots = runtime && Array.isArray(runtime.roots) ? runtime.roots : [];
+  return roots.length ? { key: targetKey(watching), roots } : null;
+}
+
+function renderPicker() {
+  const held = pickerTarget();
+  el('picker').hidden = !held;
+  if (!held) return;
+  const strip = el('picker-roots');
+  strip.innerHTML = '';
+  for (const root of held.roots) {
+    const button = document.createElement('button');
+    button.className = 'chip';
+    button.type = 'button';
+    button.dataset.root = root;
+    button.textContent = root;
+    button.setAttribute('aria-pressed', picker && picker.root === root ? 'true' : 'false');
+    button.onclick = () => browse(root, '');
+    strip.append(button);
+  }
+  el('picker-glob').setAttribute('aria-pressed', pickerGlob ? 'true' : 'false');
+}
+
+function browse(root, path) {
+  if (!watching) return;
+  picker = { root, path, request: nextCommandRequest++, searching: false };
+  el('picker-note').textContent = 'looking…';
+  send({
+    type: 'files.list',
+    request: picker.request,
+    target: { target: watching.target, session: watching.session },
+    root,
+    path,
+  });
+  renderPicker();
+}
+
+function searchPicker() {
+  const query = el('picker-query').value.trim();
+  const held = pickerTarget();
+  if (!held || !query) return;
+  const root = (picker && picker.root) || held.roots[0];
+  picker = { root, path: '', request: nextCommandRequest++, searching: true };
+  el('picker-note').textContent = 'searching…';
+  send({
+    type: 'files.search',
+    request: picker.request,
+    target: { target: watching.target, session: watching.session },
+    root,
+    query,
+    glob: pickerGlob,
+  });
+  renderPicker();
+}
+
+function showListing(message) {
+  if (!picker || message.request !== picker.request) return;
+  const listing = message.listing || {};
+  picker.root = text(listing.root);
+  picker.path = text(listing.path);
+  const list = el('picker-entries');
+  list.innerHTML = '';
+  el('picker-where').textContent = picker.searching
+    ? `found under ${picker.root}`
+    : `${picker.root}${picker.path ? `/${picker.path}` : ''}`;
+
+  // A way back up, offered only where there is somewhere to go. Built from the
+  // path this listing describes rather than from wherever the page has been,
+  // so it cannot walk out of the root by accident.
+  if (!picker.searching && picker.path) {
+    const parent = picker.path.includes('/')
+      ? picker.path.slice(0, picker.path.lastIndexOf('/'))
+      : '';
+    list.append(entryRow('directory', '..', () => browse(picker.root, parent)));
+  }
+
+  for (const entry of listing.entries || []) {
+    const name = text(entry.name);
+    if (entry.kind === 'directory' && !picker.searching) {
+      const next = picker.path ? `${picker.path}/${name}` : name;
+      list.append(entryRow('directory', name, () => browse(picker.root, next)));
+    } else if (entry.kind === 'file') {
+      const relative = picker.searching ? name : (picker.path ? `${picker.path}/${name}` : name);
+      list.append(entryRow('file', name, () => {
+        // Choosing a file fills the path and stops. Fetching is a separate
+        // decision, and the offer that follows it is where the size and the
+        // digest get looked at.
+        el('fetch-path').value = `${picker.root}/${relative}`;
+        el('picker-note').textContent = 'ready to fetch';
+      }));
+    } else {
+      // Listed so a person can see it is there, and not offered: a socket or a
+      // device is not something to fetch.
+      list.append(entryRow('other', name, null));
+    }
+  }
+  el('picker-note').textContent = listing.truncated
+    ? 'There were more than this list can show; narrow it with a search.'
+    : ((listing.entries || []).length ? '' : 'nothing here');
+}
+
+function entryRow(kind, name, chosen) {
+  const item = document.createElement('li');
+  item.dataset.kind = kind;
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = kind === 'directory' ? `${name}/` : name;
+  if (chosen) button.onclick = chosen;
+  else button.disabled = true;
+  item.append(button);
+  return item;
 }
 
 // Fetching a file off a target.
@@ -1956,6 +2110,9 @@ function apply(message) {
       renderAlerts();
       schedulePluginPoll();
       break;
+    case 'files.listing':
+      showListing(message);
+      break;
     case 'download.offer':
       offerFetch(message);
       break;
@@ -2173,6 +2330,14 @@ for (const button of document.querySelectorAll('.keys button')) {
     el('line').focus();
   };
 }
+el('picker-search-form').onsubmit = event => {
+  event.preventDefault();
+  searchPicker();
+};
+el('picker-glob').onclick = () => {
+  pickerGlob = !pickerGlob;
+  renderPicker();
+};
 el('fetch-form').onsubmit = event => {
   event.preventDefault();
   startFetch();

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -116,6 +116,11 @@
   .card-marks .chip { padding: .25rem .6rem; font-size: .76rem; min-height: 1.9rem; }
   .card[aria-disabled="true"] { color: var(--dim); }
   .card-meta { display: flex; gap: .4rem; color: var(--dim); font-size: .78rem; margin-top: .25rem; }
+  #fetch-form { flex-wrap: wrap; }
+  #fetch-path { flex: 1 1 12rem; min-width: 0; }
+  #fetch-text { max-height: 40vh; white-space: pre-wrap; word-break: break-word; }
+  #fetch-image { max-height: 40vh; border-radius: .4rem; }
+  #fetch-note:empty, #fetch-digest:empty { display: none; }
   .actions { display: flex; gap: .5rem; margin-top: .7rem; }
   #line {
     flex: 1; min-width: 0; padding: .5rem .6rem; font: inherit;
@@ -326,6 +331,32 @@
           </label>
         </div>
         <span id="upload-note" class="note" role="status"></span>
+        <form id="fetch-form" class="actions">
+          <input id="fetch-path" class="field-input" placeholder="Path on this host"
+                 autocomplete="off" autocorrect="off" spellcheck="false" enterkeyhint="go">
+          <button id="fetch" type="submit">Get file</button>
+        </form>
+        <div id="fetch-offer" class="card" hidden>
+          <div class="row">
+            <span id="fetch-name" class="name"></span>
+            <span id="fetch-size" class="badge"></span>
+          </div>
+          <div class="card-meta"><span id="fetch-where"></span></div>
+          <div class="card-meta"><span id="fetch-digest"></span></div>
+          <div class="actions">
+            <button id="fetch-accept" type="button">Fetch</button>
+            <button id="fetch-refuse" type="button">Cancel</button>
+          </div>
+        </div>
+        <div id="fetch-result" hidden>
+          <div class="actions">
+            <a id="fetch-save" class="file-action" download>Save</a>
+            <button id="fetch-discard" type="button">Discard</button>
+          </div>
+          <pre id="fetch-text" class="screen" hidden></pre>
+          <img id="fetch-image" alt="Downloaded image" hidden>
+        </div>
+        <span id="fetch-note" class="note" role="status"></span>
       </div>
     </div>
   </section>
@@ -914,7 +945,13 @@ function acknowledge() {
 }
 
 function observe(pane, label) {
-  if (watching && !sameId(pane, watching)) send({ type: 'pane.unsubscribe', pane: watching });
+  // A fetch belongs to the pane it was asked for. Watching something else
+  // abandons it rather than letting bytes from one host arrive under another
+  // host's heading.
+  if (watching && !sameId(pane, watching)) {
+    cancelFetch('');
+    send({ type: 'pane.unsubscribe', pane: watching });
+  }
   watching = pane;
   screen = null;
   cell = null;
@@ -1089,6 +1126,214 @@ function renderKeyboard() {
   if (!holding && armedReply !== null) armReply(null);
 }
 
+// Fetching a file off a target.
+//
+// Two steps on purpose. The daemon answers `download.begin` with what the file
+// is — its own last path component, its length, and the digest the host
+// computed — and then sends nothing until it is asked to. So a person sees the
+// size and the source before a byte crosses the link, and a path that turned
+// out to name a 4 GiB core dump is refused rather than discovered halfway
+// through.
+//
+// The path is typed. Nothing here reads the terminal to work out which file an
+// agent was looking at: a path inferred from what a screen happened to show is
+// a guess, and acting on it would fetch whatever that guess named.
+let fetching = null;
+
+// The window this page will let the daemon fill. Downloads are flow-controlled
+// the other way from uploads — the daemon is the sender and its queue to a
+// client is unbounded — so peak memory here is this many chunks, not a file.
+const FETCH_WINDOW_CHUNKS = 4;
+
+function fetchNote(message) {
+  el('fetch-note').textContent = message;
+}
+
+function resetFetch(note) {
+  if (fetching && fetching.url) URL.revokeObjectURL(fetching.url);
+  fetching = null;
+  el('fetch-offer').hidden = true;
+  el('fetch-result').hidden = true;
+  el('fetch-text').hidden = true;
+  el('fetch-image').hidden = true;
+  el('fetch-text').textContent = '';
+  el('fetch-image').removeAttribute('src');
+  fetchNote(note || '');
+}
+
+function startFetch() {
+  const path = el('fetch-path').value.trim();
+  if (!watching || !path) return;
+  if (fetching) {
+    fetchNote('One file at a time.');
+    return;
+  }
+  fetching = {
+    request: nextCommandRequest++,
+    pane: watching,
+    path,
+    parts: [],
+    received: 0,
+    outstanding: 0,
+    offer: null,
+    url: null,
+  };
+  fetchNote('asking…');
+  send({ type: 'download.begin', request: fetching.request, pane: watching, path });
+}
+
+function offerFetch(message) {
+  if (!fetching || message.request !== fetching.request) return;
+  fetching.offer = message;
+  el('fetch-name').textContent = text(message.name);
+  el('fetch-size').textContent = readableBytes(message.length);
+  el('fetch-where').textContent = `${qualify(fetching.pane)} · ${text(fetching.path)}`;
+  // Shown before the transfer, because it is what the receiving end will check
+  // the bytes against afterwards. The daemon carries the host's digest without
+  // checking it; verifying is this end's job.
+  el('fetch-digest').textContent = message.digest
+    ? `sha256 ${text(message.digest).slice(0, 16)}…`
+    : 'no digest offered';
+  el('fetch-offer').hidden = false;
+  if (message.length > MAX_BROWSER_FILE_BYTES) {
+    el('fetch-accept').disabled = true;
+    fetchNote(`Too large for a browser to hold (${readableBytes(MAX_BROWSER_FILE_BYTES)} limit).`);
+    return;
+  }
+  el('fetch-accept').disabled = false;
+  fetchNote('');
+}
+
+function acceptFetch() {
+  if (!fetching || !fetching.offer) return;
+  el('fetch-offer').hidden = true;
+  fetchNote('fetching…');
+  pullFetch();
+}
+
+function pullFetch() {
+  if (!fetching || fetching.outstanding > 0) return;
+  fetching.outstanding = FETCH_WINDOW_CHUNKS;
+  send({
+    type: 'download.pull',
+    request: fetching.request,
+    chunks: FETCH_WINDOW_CHUNKS,
+  });
+}
+
+function fetchChunk(message) {
+  if (!fetching || message.request !== fetching.request) return;
+  const bytes = decodeBase64(message.bytes);
+  fetching.parts.push(bytes);
+  fetching.received += bytes.length;
+  fetching.outstanding = Math.max(0, fetching.outstanding - 1);
+  const length = Number(fetching.offer.length) || 0;
+  fetchNote(`fetching… ${readableBytes(fetching.received)} of ${readableBytes(length)}`);
+  if (fetching.received < length) pullFetch();
+}
+
+async function finishFetch(message) {
+  if (!fetching || message.request !== fetching.request) return;
+  const held = fetching;
+  const length = Number(held.offer.length) || 0;
+  if (held.received !== length) {
+    // The offer said how long the file was, which is what makes a transfer
+    // that stopped short distinguishable from one still arriving.
+    resetFetch(`That transfer stopped after ${readableBytes(held.received)} of ${readableBytes(length)}.`);
+    return;
+  }
+  const bytes = joinBytes(held.parts, held.received);
+  if (held.offer.digest) {
+    const digest = await sha256Hex(bytes);
+    if (digest !== held.offer.digest) {
+      // Discarded rather than offered with a warning. A file that does not
+      // match what the host attested is not a file this page should hand
+      // somebody a Save button for.
+      resetFetch('That file did not match the digest its host reported, so it was discarded.');
+      return;
+    }
+  }
+  if (fetching !== held) return;
+  held.parts = [];
+  presentFetch(held, bytes);
+}
+
+function presentFetch(held, bytes) {
+  const name = text(held.offer.name) || 'download';
+  held.url = URL.createObjectURL(new Blob([bytes]));
+  el('fetch-save').href = held.url;
+  el('fetch-save').setAttribute('download', name);
+  el('fetch-result').hidden = false;
+  fetchNote(`${name} · ${readableBytes(bytes.length)} · verified`);
+
+  // Previewed only where a preview is plainly safe. Text is decoded and shown
+  // as text; an image is shown as an image. A PDF is saved rather than
+  // rendered, because rendering one means handing a file off somebody's host
+  // to the browser's scripted viewer inside this page.
+  // Both are hidden first. A preview left over from the last file would sit
+  // under the name of this one.
+  el('fetch-text').hidden = true;
+  el('fetch-image').hidden = true;
+  const kind = previewKind(name);
+  if (kind === 'text') {
+    const preview = bytes.length > MAX_TEXT_PREVIEW_BYTES
+      ? bytes.subarray(0, MAX_TEXT_PREVIEW_BYTES)
+      : bytes;
+    el('fetch-text').textContent = new TextDecoder('utf-8').decode(preview)
+      + (preview.length < bytes.length ? '\n…' : '');
+    el('fetch-text').hidden = false;
+  } else if (kind === 'image') {
+    el('fetch-image').src = held.url;
+    el('fetch-image').hidden = false;
+  }
+}
+
+const MAX_TEXT_PREVIEW_BYTES = 256 * 1024;
+const TEXT_SUFFIXES = [
+  '.txt', '.log', '.md', '.json', '.toml', '.yaml', '.yml', '.csv', '.rs', '.js',
+  '.ts', '.py', '.go', '.c', '.h', '.cpp', '.sh', '.diff', '.patch', '.html', '.css',
+];
+const IMAGE_SUFFIXES = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.avif', '.bmp'];
+
+// Decided from the name, because a download carries no declared type. A name
+// that matches nothing is saved and not previewed, which is the safe default.
+function previewKind(name) {
+  const lower = name.toLowerCase();
+  if (TEXT_SUFFIXES.some(suffix => lower.endsWith(suffix))) return 'text';
+  if (IMAGE_SUFFIXES.some(suffix => lower.endsWith(suffix))) return 'image';
+  return 'none';
+}
+
+function decodeBase64(value) {
+  const binary = atob(text(value));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+function joinBytes(parts, length) {
+  const joined = new Uint8Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    joined.set(part, offset);
+    offset += part.length;
+  }
+  return joined;
+}
+
+function readableBytes(value) {
+  const bytes = Number(value) || 0;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function cancelFetch(note) {
+  if (!fetching) return;
+  send({ type: 'download.cancel', request: fetching.request });
+  resetFetch(note);
+}
+
 async function uploadBrowserFile(file, pane) {
   const buffer = await file.arrayBuffer();
   if (buffer.byteLength !== file.size) throw new Error(`${file.name}: the file changed while reading`);
@@ -1190,6 +1435,7 @@ async function uploadSelectedFiles(selected) {
 }
 
 function stopWatching(why) {
+  cancelFetch('');
   if (watching) send({ type: 'pane.unsubscribe', pane: watching });
   watching = null;
   lease = 'observe';
@@ -1695,6 +1941,10 @@ function apply(message) {
         cell = null;
         subscribeScreen(watching);
       }
+      // A reconnect is a new client to the daemon, which is not holding the
+      // request a fetch in flight was numbered by. Cancelling it there would
+      // name somebody else's request, so this end simply forgets it.
+      if (fetching) resetFetch('That transfer ended when the connection did.');
       quickReplies = Array.isArray(message.quick_replies) ? message.quick_replies : [];
       renderQuickReplies();
       // A reconnect is a new client to the daemon, which is not holding this
@@ -1705,6 +1955,15 @@ function apply(message) {
       }
       renderAlerts();
       schedulePluginPoll();
+      break;
+    case 'download.offer':
+      offerFetch(message);
+      break;
+    case 'download.chunk':
+      fetchChunk(message);
+      break;
+    case 'download.finished':
+      void finishFetch(message);
       break;
     case 'notification':
       showAlert(message);
@@ -1914,6 +2173,13 @@ for (const button of document.querySelectorAll('.keys button')) {
     el('line').focus();
   };
 }
+el('fetch-form').onsubmit = event => {
+  event.preventDefault();
+  startFetch();
+};
+el('fetch-accept').onclick = () => acceptFetch();
+el('fetch-refuse').onclick = () => cancelFetch('');
+el('fetch-discard').onclick = () => resetFetch('');
 el('alerts').onclick = () => { void toggleAlerts(); };
 el('stop').onclick = () => stopWatching('');
 

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -175,6 +175,24 @@ pub enum Effect {
         agent: AgentId,
         mark: AgentMarkRequest,
     },
+    /// Look inside one of a target's configured roots. The broker routes it
+    /// and checks nothing: which roots exist is configuration the daemon
+    /// holds, and deciding here would be a second copy of that answer.
+    ListRemoteDirectory {
+        client: ClientId,
+        request: u64,
+        target: TargetSession,
+        root: String,
+        path: String,
+    },
+    SearchRemoteFiles {
+        client: ClientId,
+        request: u64,
+        target: TargetSession,
+        root: String,
+        query: String,
+        glob: bool,
+    },
     MarkAttentionSeen {
         pane: PaneId,
     },
@@ -497,6 +515,32 @@ impl Broker {
                 // delivered late enough to have been asked for afterwards is
                 // an interruption about something already over.
             }
+            ClientMessage::ListRemoteDirectory {
+                request,
+                target,
+                root,
+                path,
+            } => effects.push(Effect::ListRemoteDirectory {
+                client,
+                request,
+                target,
+                root,
+                path,
+            }),
+            ClientMessage::SearchRemoteFiles {
+                request,
+                target,
+                root,
+                query,
+                glob,
+            } => effects.push(Effect::SearchRemoteFiles {
+                client,
+                request,
+                target,
+                root,
+                query,
+                glob,
+            }),
             ClientMessage::UnsubscribeNotifications => {
                 if let Some(session) = self.clients.get_mut(&client) {
                     session.notifications_subscribed = false;
@@ -1566,6 +1610,7 @@ mod tests {
             event_error: None,
             connection_generation: 1,
             selected_herdr_bin: Some("herdr".to_owned()),
+            roots: Vec::new(),
             snapshot: Some(Arc::new(snapshot)),
             last_error: None,
             last_success: None,

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -48,6 +48,7 @@ use crate::operation::Operation;
 use crate::pairing::{self, PendingPairing};
 use crate::plugin;
 use crate::protocol::{ClientMessage, MAX_MESSAGE_BYTES, ServerMessage, decode, encode};
+use crate::remote_files;
 use crate::state::{FederationState, FederationStore, SupervisorOptions, target_key};
 use crate::terminal::{
     TerminalAccess, TerminalEvent, parse_terminal_event, spawn_terminal, terminal_input_command,
@@ -1820,6 +1821,28 @@ impl Daemon {
                     destination,
                     name,
                 } => self.begin_between(client, request, source, path, destination, name),
+                Effect::ListRemoteDirectory {
+                    client,
+                    request,
+                    target,
+                    root,
+                    path,
+                } => self.browse(client, request, target, root, None, path),
+                Effect::SearchRemoteFiles {
+                    client,
+                    request,
+                    target,
+                    root,
+                    query,
+                    glob,
+                } => self.browse(
+                    client,
+                    request,
+                    target,
+                    root,
+                    Some((query, glob)),
+                    String::new(),
+                ),
                 Effect::MarkAgent {
                     client,
                     request,
@@ -2941,6 +2964,49 @@ impl Daemon {
     /// federation and the attention index, both of which already survive a
     /// restart on their own terms. Rebuilding it is cheap and keeps one
     /// authority for each fact.
+    /// Look inside one of a target's configured roots, off the event loop.
+    ///
+    /// Spawned rather than awaited, and per request: a slow or wedged host
+    /// must not stop the daemon serving every other target, which is the same
+    /// isolation every other command path here already has.
+    fn browse(
+        &mut self,
+        client: ClientId,
+        request: u64,
+        key: TargetSession,
+        root: String,
+        search: Option<(String, bool)>,
+        path: String,
+    ) {
+        let Some(target) = self.targets.get(&key).cloned() else {
+            self.refuse(client, request, "no such target".to_owned());
+            return;
+        };
+        let Some(outbox) = self.outboxes.get(&client).cloned() else {
+            return;
+        };
+        let transport = self.transport.clone();
+        tokio::spawn(async move {
+            let listing = match search {
+                Some((query, glob)) => {
+                    remote_files::search(&target, &transport, &root, &query, glob).await
+                }
+                None => remote_files::list(&target, &transport, &root, &path).await,
+            };
+            let _ = outbox.send(match listing {
+                Ok(listing) => ServerMessage::RemoteFiles {
+                    request,
+                    target: key,
+                    listing,
+                },
+                Err(error) => ServerMessage::Error {
+                    request: Some(request),
+                    message: error.to_string(),
+                },
+            });
+        });
+    }
+
     /// Hand one coalesced alert to every subscribed device, if one is due.
     fn device_alerts(&mut self) -> Vec<Effect> {
         let Some(delivery) = self.device_notifications.take_ready(Instant::now()) else {
@@ -3192,6 +3258,7 @@ mod tests {
                 session: None,
                 socket: None,
                 herdr_bins: vec!["/nonexistent/herdr".to_owned()],
+                roots: Vec::new(),
             }],
             ..empty_config()
         }
@@ -3209,6 +3276,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
+            roots: Vec::new(),
         });
         config
     }
@@ -3400,6 +3468,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
+            roots: Vec::new(),
         }
     }
 
@@ -3744,6 +3813,7 @@ mod tests {
                 session: None,
                 socket: None,
                 herdr_bins: vec!["/nonexistent/herdr".to_owned()],
+                roots: Vec::new(),
             }],
             devices: Vec::new(),
             quick_replies: None,
@@ -4644,6 +4714,7 @@ mod tests {
                 session: None,
                 socket: None,
                 herdr_bins: vec!["/nonexistent/herdr".to_owned()],
+                roots: Vec::new(),
             },
             &Default::default(),
             crate::clipboard::OPAQUE,
@@ -4661,6 +4732,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
+            roots: Vec::new(),
         };
         let error = super::accept_copy(
             &destination,

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -704,6 +704,14 @@ mod tests {
         assert!(APP.contains("id=\"quick-replies\""));
         assert!(!APP.contains("data-reply=\""));
         assert!(APP.contains("message.quick_replies"));
+        // The download surface takes a typed path. Nothing in the page derives
+        // one from the terminal, which is what a search for a screen-reading
+        // helper here would catch.
+        assert!(APP.contains("type: 'download.begin'"));
+        assert!(APP.contains("type: 'download.pull'"));
+        assert!(APP.contains("type: 'download.cancel'"));
+        assert!(APP.contains("id=\"fetch-path\""));
+        assert!(APP.contains("crypto.subtle.digest('SHA-256'"));
         assert!(APP.contains("class=\"keys control-strip\""));
         assert!(APP.contains("id=\"plugin-tools\""));
         assert!(APP.contains("type: 'plugin.actions.list'"));

--- a/src/file_save.rs
+++ b/src/file_save.rs
@@ -1,0 +1,343 @@
+//! Writing a file fetched off a target onto this machine.
+//!
+//! The transfer protocol already describes the wire: an offer saying what the
+//! file is, chunks pulled a window at a time, and a finish frame. What is here
+//! is the receiving end's bookkeeping — where the bytes land, how many are
+//! expected, and whether what arrived is what the host attested to.
+//!
+//! It is a separate module from the frontend that drives it because it is the
+//! part worth testing on its own. A download that silently writes a truncated
+//! file, or one that leaves a half-written file behind when it fails, is a bug
+//! nobody notices until they open the file, and neither failure is visible from
+//! a screenshot of a terminal.
+//!
+//! Two rules shape it:
+//!
+//! * **Nothing is written where somebody would look for a finished file until
+//!   it is finished.** Bytes go to a temporary file beside the destination and
+//!   are renamed into place only after the length and the digest both check
+//!   out, so an interrupted transfer leaves nothing rather than something that
+//!   looks complete.
+//! * **The host's digest is checked here**, because this is the end that can.
+//!   The daemon carries the attestation without verifying it, exactly as it
+//!   carries a client's in the other direction.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use sha2::{Digest, Sha256};
+
+/// How many chunks the daemon may send before being asked again.
+///
+/// Flow control exists in this direction because the daemon is the sender and
+/// its queue to a client is unbounded. On a desktop the window can be wider
+/// than a phone's without meaning much, and it still bounds the queue.
+pub const SAVE_WINDOW_CHUNKS: u32 = 8;
+
+#[derive(Debug)]
+pub struct FileSave {
+    request: u64,
+    /// Where the finished file goes. Derived from the host's own name for it
+    /// and never from a path a target sent: what a client does with a name is
+    /// its own business, and joining a remote path onto a local directory is
+    /// how a download escapes the directory it was meant for.
+    destination: PathBuf,
+    length: u64,
+    digest: String,
+    received: u64,
+    hasher: Sha256,
+    file: tempfile::NamedTempFile,
+    outstanding: u32,
+}
+
+/// What the caller should do next.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SaveProgress {
+    /// Ask for more, and how many.
+    Pull(u32),
+    /// Bytes are still arriving and the window is not empty yet.
+    Waiting,
+    /// Finished and verified, at this path.
+    Saved(PathBuf),
+}
+
+impl FileSave {
+    /// Begin a save into `directory`, for a file the host called `name`.
+    ///
+    /// The name is reduced to its last component before it is used. The
+    /// protocol already promises a name rather than a path, and this is the
+    /// place where trusting that promise would cost somebody a file written
+    /// outside the directory they chose.
+    pub fn begin(
+        request: u64,
+        directory: &Path,
+        name: &str,
+        length: u64,
+        digest: String,
+    ) -> Result<Self> {
+        let name = Path::new(name)
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .filter(|name| !name.is_empty() && name != "." && name != "..")
+            .context("that file has no name to save it under")?;
+        let destination = directory.join(&name);
+        if destination.exists() {
+            // Refused rather than renamed around. A download that quietly
+            // became `report (2).txt` is one somebody opens the old copy of.
+            bail!("{} already exists", destination.display());
+        }
+        std::fs::create_dir_all(directory)
+            .with_context(|| format!("failed to create {}", directory.display()))?;
+        let file = tempfile::Builder::new()
+            .prefix(".super-herdr-download-")
+            .tempfile_in(directory)
+            .with_context(|| {
+                format!("failed to open a temporary file in {}", directory.display())
+            })?;
+        Ok(Self {
+            request,
+            destination,
+            length,
+            digest,
+            received: 0,
+            hasher: Sha256::new(),
+            file,
+            outstanding: 0,
+        })
+    }
+
+    pub fn request(&self) -> u64 {
+        self.request
+    }
+
+    pub fn destination(&self) -> &Path {
+        &self.destination
+    }
+
+    pub fn received(&self) -> u64 {
+        self.received
+    }
+
+    pub fn length(&self) -> u64 {
+        self.length
+    }
+
+    /// Open the window. Called once after the offer is accepted.
+    pub fn start(&mut self) -> SaveProgress {
+        self.outstanding = SAVE_WINDOW_CHUNKS;
+        SaveProgress::Pull(SAVE_WINDOW_CHUNKS)
+    }
+
+    /// Take one chunk. Refuses more than the offer declared rather than
+    /// growing a file past the length its digest was computed over.
+    pub fn chunk(&mut self, bytes: &[u8]) -> Result<SaveProgress> {
+        let remaining = self.length.saturating_sub(self.received);
+        if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > remaining {
+            bail!("that host sent more than it offered");
+        }
+        self.file
+            .write_all(bytes)
+            .context("failed to write the downloaded file")?;
+        self.hasher.update(bytes);
+        self.received += u64::try_from(bytes.len()).unwrap_or_default();
+        self.outstanding = self.outstanding.saturating_sub(1);
+        if self.received >= self.length || self.outstanding > 0 {
+            return Ok(SaveProgress::Waiting);
+        }
+        self.outstanding = SAVE_WINDOW_CHUNKS;
+        Ok(SaveProgress::Pull(SAVE_WINDOW_CHUNKS))
+    }
+
+    /// Check what arrived and put it where it belongs.
+    ///
+    /// Consumes the save either way: a failure here has already discarded the
+    /// temporary file, so there is nothing to resume and nothing left behind.
+    pub fn finish(self) -> Result<PathBuf> {
+        if self.received != self.length {
+            bail!(
+                "that transfer stopped after {} of {} bytes",
+                self.received,
+                self.length
+            );
+        }
+        let digest = format!("{:x}", self.hasher.finalize());
+        if !self.digest.is_empty() && digest != self.digest {
+            bail!("that file did not match the digest its host reported");
+        }
+        self.file
+            .as_file()
+            .sync_all()
+            .context("failed to flush the downloaded file")?;
+        self.file
+            .persist_noclobber(&self.destination)
+            .map_err(|error| error.error)
+            .with_context(|| format!("failed to save {}", self.destination.display()))?;
+        Ok(self.destination)
+    }
+}
+
+/// Where a saved file goes when nobody said.
+///
+/// The desktop convention, and the current directory only as a last resort. A
+/// download that lands somewhere a person has to be told about is one they have
+/// to be told about every time.
+pub fn default_directory() -> PathBuf {
+    if let Some(directory) = std::env::var_os("XDG_DOWNLOAD_DIR") {
+        return PathBuf::from(directory);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let downloads = PathBuf::from(&home).join("Downloads");
+        if downloads.is_dir() {
+            return downloads;
+        }
+        return PathBuf::from(home);
+    }
+    PathBuf::from(".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FileSave, SAVE_WINDOW_CHUNKS, SaveProgress};
+    use sha2::{Digest, Sha256};
+
+    fn digest_of(bytes: &[u8]) -> String {
+        format!("{:x}", Sha256::new().chain_update(bytes).finalize())
+    }
+
+    #[test]
+    fn a_verified_file_is_renamed_into_place_only_when_it_is_whole() {
+        let directory = tempfile::tempdir().unwrap();
+        let body = b"line one\nline two\n";
+        let mut save = FileSave::begin(
+            1,
+            directory.path(),
+            "report.txt",
+            body.len() as u64,
+            digest_of(body),
+        )
+        .unwrap();
+
+        assert_eq!(save.start(), SaveProgress::Pull(SAVE_WINDOW_CHUNKS));
+        assert_eq!(save.chunk(body).unwrap(), SaveProgress::Waiting);
+        assert!(
+            !directory.path().join("report.txt").exists(),
+            "nothing sits where a finished file goes until it is finished"
+        );
+
+        let saved = save.finish().unwrap();
+
+        assert_eq!(saved, directory.path().join("report.txt"));
+        assert_eq!(std::fs::read(&saved).unwrap(), body);
+    }
+
+    #[test]
+    fn a_file_that_fails_its_digest_leaves_nothing_behind() {
+        let directory = tempfile::tempdir().unwrap();
+        let body = b"line one\n";
+        let mut save = FileSave::begin(
+            1,
+            directory.path(),
+            "report.txt",
+            body.len() as u64,
+            "f".repeat(64),
+        )
+        .unwrap();
+        save.start();
+        save.chunk(body).unwrap();
+
+        let error = save.finish().unwrap_err().to_string();
+
+        assert!(error.contains("digest"), "{error}");
+        assert!(!directory.path().join("report.txt").exists());
+        assert_eq!(
+            std::fs::read_dir(directory.path()).unwrap().count(),
+            0,
+            "a failed save leaves no temporary file either"
+        );
+    }
+
+    #[test]
+    fn a_transfer_that_stops_short_is_reported_rather_than_saved() {
+        let directory = tempfile::tempdir().unwrap();
+        let body = b"line one\nline two\n";
+        let mut save =
+            FileSave::begin(1, directory.path(), "report.txt", 64, digest_of(body)).unwrap();
+        save.start();
+        save.chunk(body).unwrap();
+
+        let error = save.finish().unwrap_err().to_string();
+
+        assert!(error.contains("stopped after"), "{error}");
+        assert!(!directory.path().join("report.txt").exists());
+    }
+
+    #[test]
+    fn a_host_sending_more_than_it_offered_is_refused() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut save =
+            FileSave::begin(1, directory.path(), "report.txt", 4, String::new()).unwrap();
+        save.start();
+
+        assert!(
+            save.chunk(b"far too much").is_err(),
+            "a file grown past the length its digest covers is not the file that was offered"
+        );
+    }
+
+    #[test]
+    fn a_name_is_reduced_to_its_last_component() {
+        let directory = tempfile::tempdir().unwrap();
+
+        let save = FileSave::begin(1, directory.path(), "../../etc/passwd", 1, String::new());
+
+        assert_eq!(
+            save.unwrap().destination(),
+            directory.path().join("passwd"),
+            "the protocol promises a name; trusting that promise is what this refuses to do"
+        );
+    }
+
+    #[test]
+    fn a_name_that_is_only_a_path_is_refused() {
+        let directory = tempfile::tempdir().unwrap();
+
+        assert!(FileSave::begin(1, directory.path(), "..", 1, String::new()).is_err());
+        assert!(FileSave::begin(1, directory.path(), "/", 1, String::new()).is_err());
+    }
+
+    #[test]
+    fn an_existing_file_is_not_quietly_written_around() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("report.txt"), b"old").unwrap();
+
+        let error = FileSave::begin(1, directory.path(), "report.txt", 1, String::new())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("already exists"), "{error}");
+        assert_eq!(
+            std::fs::read(directory.path().join("report.txt")).unwrap(),
+            b"old",
+            "a download that quietly became report (2).txt is one somebody opens the old copy of"
+        );
+    }
+
+    #[test]
+    fn the_window_reopens_only_when_it_has_emptied() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut save =
+            FileSave::begin(1, directory.path(), "report.txt", 8, String::new()).unwrap();
+        save.start();
+
+        for _ in 0..SAVE_WINDOW_CHUNKS - 1 {
+            assert_eq!(save.chunk(b"").unwrap(), SaveProgress::Waiting);
+        }
+
+        assert_eq!(
+            save.chunk(b"").unwrap(),
+            SaveProgress::Pull(SAVE_WINDOW_CHUNKS),
+            "the daemon is asked for more only once it has sent what it was allowed"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod pairing;
 pub mod plugin;
 pub mod probe;
 pub mod protocol;
+pub mod remote_files;
 pub mod resource_action;
 pub mod screen;
 pub mod state;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod clipboard;
 pub mod config;
 pub mod daemon;
+pub mod file_save;
 pub mod model;
 pub mod notifications;
 pub mod operation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,6 +507,10 @@ fn run_target_command(
                 } else {
                     herdr_bins
                 },
+                // Not offered on the command line. A browsing bound is a
+                // considered decision about a host, written where it can be
+                // read back, rather than a flag typed once while adding one.
+                roots: Vec::new(),
             };
             let path = Config::add_target_file(config_path, target)?;
             stdout_line(format_args!("added target {name:?} to {}", path.display()))?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -44,6 +44,7 @@ use crate::config::QuickReply;
 use crate::model::{AgentId, PaneId, TargetSession};
 use crate::operation::Operation;
 use crate::plugin::{PluginAction, PluginRun, PluginRunId};
+use crate::remote_files::RemoteListing;
 use crate::screen::{Diff as ScreenDiff, Snapshot};
 use crate::state::{FederationState, TargetRuntimeState};
 use crate::terminal::{TerminalAccess, TerminalScrollDirection};
@@ -347,6 +348,32 @@ pub enum ClientMessage {
     /// daemon sending anything to this connection.
     #[serde(rename = "notifications.unsubscribe")]
     UnsubscribeNotifications,
+    /// List one directory inside one of a target's configured roots.
+    ///
+    /// The root is named rather than described: it must be one of the paths
+    /// the configuration declares, compared exactly, so a client cannot widen
+    /// its own bounds by asking about a parent.
+    #[serde(rename = "files.list")]
+    ListRemoteDirectory {
+        request: u64,
+        target: TargetSession,
+        root: String,
+        /// Where inside the root. Empty is the root itself.
+        path: String,
+    },
+    /// Find files by name under one of a target's configured roots.
+    ///
+    /// `glob` is what makes the query a pattern; without it the query matches
+    /// as literal text, so somebody searching for `[` finds a file called `[`.
+    #[serde(rename = "files.search")]
+    SearchRemoteFiles {
+        request: u64,
+        target: TargetSession,
+        root: String,
+        query: String,
+        #[serde(default)]
+        glob: bool,
+    },
 }
 
 /// Sent by the daemon.
@@ -449,6 +476,18 @@ pub enum ServerMessage {
     /// this projection exists to prevent.
     #[serde(rename = "agents.cards")]
     AgentCards { projection: AgentCardProjection },
+    /// What one directory holds, or what a search found.
+    ///
+    /// Names only, with a kind. A size is what the transfer offer already
+    /// reports at the moment it matters — before any byte moves — and
+    /// collecting one per entry here would mean reading every file in a
+    /// directory to answer a question the next step answers for free.
+    #[serde(rename = "files.listing")]
+    RemoteFiles {
+        request: u64,
+        target: TargetSession,
+        listing: RemoteListing,
+    },
     /// One coalesced attention alert for a paired device.
     ///
     /// Bounded metadata only, and by construction rather than by filtering
@@ -669,6 +708,7 @@ mod tests {
     use crate::plugin::{
         PluginAction, PluginActionContext, PluginActionId, PluginRun, PluginRunId, PluginRunStatus,
     };
+    use crate::remote_files::{RemoteEntry, RemoteEntryKind, RemoteListing};
     use crate::resource_action::SplitDirection;
     use crate::state::{
         FederationState, NormalizedSnapshot, PaneState, TargetConnectionState, TargetRuntimeState,
@@ -804,6 +844,19 @@ mod tests {
         round_trip_client(ClientMessage::SubscribeAgentCards);
         round_trip_client(ClientMessage::SubscribeNotifications);
         round_trip_client(ClientMessage::UnsubscribeNotifications);
+        round_trip_client(ClientMessage::ListRemoteDirectory {
+            request: 14,
+            target: TargetSession::new("first", "default"),
+            root: "/srv/build".to_owned(),
+            path: "reports".to_owned(),
+        });
+        round_trip_client(ClientMessage::SearchRemoteFiles {
+            request: 15,
+            target: TargetSession::new("first", "default"),
+            root: "/srv/build".to_owned(),
+            query: "report".to_owned(),
+            glob: false,
+        });
         round_trip_client(ClientMessage::MarkAgent {
             request: 11,
             agent: AgentId::new("first", "default", "w1:p1"),
@@ -868,6 +921,19 @@ mod tests {
             agent: AgentId::new("first", "default", "w1:p1"),
             title: "Agent needs attention".to_owned(),
             body: "reviewer · compiler".to_owned(),
+        });
+        round_trip_server(ServerMessage::RemoteFiles {
+            request: 14,
+            target: TargetSession::new("first", "default"),
+            listing: RemoteListing {
+                root: "/srv/build".to_owned(),
+                path: "reports".to_owned(),
+                entries: vec![RemoteEntry {
+                    kind: RemoteEntryKind::File,
+                    name: "report.txt".to_owned(),
+                }],
+                truncated: false,
+            },
         });
         round_trip_server(ServerMessage::PaneClosed { pane: pane() });
         round_trip_server(ServerMessage::PaneLease {
@@ -1037,6 +1103,7 @@ mod tests {
             event_error: None,
             connection_generation: 5,
             selected_herdr_bin: Some("herdr".to_owned()),
+            roots: Vec::new(),
             snapshot: Some(Arc::new(snapshot)),
             last_error: Some("connection reset".to_owned()),
             last_success: None,

--- a/src/remote_files.rs
+++ b/src/remote_files.rs
@@ -1,0 +1,473 @@
+//! Browsing and searching a target's files, inside bounds somebody configured.
+//!
+//! This exists so a person on a phone can find a file without typing its whole
+//! path from memory. It is deliberately not a file manager: it lists one
+//! directory, searches for file names under one root, and does nothing else.
+//! Reading a file is the transfer protocol's job and stays there.
+//!
+//! Three properties hold, and each is enforced where it cannot be argued with:
+//!
+//! * **Nothing is interpolated into a shell.** Every parameter travels on the
+//!   remote script's stdin and is read into a variable, the same way the file
+//!   read already works. A path with a quote, a semicolon or a newline in it is
+//!   a path, not a command.
+//! * **Nothing leaves the root.** The script changes into the directory and
+//!   compares `pwd -P` — the *physical* path, with symlinks resolved — against
+//!   the root's own physical path. A symlink pointing out of the tree resolves
+//!   to somewhere that fails that comparison, so it is refused rather than
+//!   followed. Search does not follow symlinks at all.
+//! * **Everything is bounded.** How many roots a target may declare, how deep a
+//!   search goes, how many entries come back, how long a query may be, and how
+//!   many bytes the remote may produce. A directory with a million files
+//!   returns a page and says it was truncated.
+//!
+//! Entries carry a name and a kind, and no size. Size is what the transfer
+//! offer already reports, and it reports it at the moment it matters — before
+//! any byte moves. Collecting it here would mean a `wc -c` per entry, which on
+//! some hosts reads every file in the directory to answer a question the next
+//! step answers for free.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail, ensure};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::config::{Target, TransportConfig};
+use crate::transport::build_ssh_command;
+
+/// How many entries one listing may carry.
+const MAX_ENTRIES: usize = 500;
+/// How deep a search descends below its root.
+const MAX_SEARCH_DEPTH: u32 = 6;
+/// How many bytes the remote side may produce for one answer.
+const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+const MAX_QUERY_CHARACTERS: usize = 128;
+const MAX_RELATIVE_CHARACTERS: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteEntryKind {
+    Directory,
+    File,
+    /// A socket, device, or anything else that is neither. Listed so a person
+    /// can see it is there, and never offered as something to fetch.
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteEntry {
+    pub kind: RemoteEntryKind,
+    /// A single name when listing a directory, or a path relative to the root
+    /// when searching. Never absolute: what a client is shown stays inside the
+    /// root it asked about.
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteListing {
+    pub root: String,
+    /// Where inside the root this describes. Empty is the root itself.
+    pub path: String,
+    pub entries: Vec<RemoteEntry>,
+    /// Whether there was more than this answer could carry. Said plainly,
+    /// because a list silently missing the file somebody is looking for is
+    /// worse than one that admits it stopped.
+    pub truncated: bool,
+}
+
+/// Read one directory inside a root.
+const LIST_SCRIPT: &str = r#"set -eu
+IFS= read -r root
+IFS= read -r relative
+cd "$root" 2>/dev/null || exit 3
+root_real=$(pwd -P)
+if [ -n "$relative" ]; then
+  cd "./$relative" 2>/dev/null || exit 4
+fi
+here=$(pwd -P)
+case "$here" in
+  "$root_real") ;;
+  "$root_real"/*) ;;
+  *) exit 5 ;;
+esac
+count=0
+for entry in * .[!.]* ..?*; do
+  if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
+    continue
+  fi
+  if [ -d "$entry" ]; then
+    kind=d
+  elif [ -f "$entry" ]; then
+    kind=f
+  else
+    kind=o
+  fi
+  printf '%s\0%s\0' "$kind" "$entry"
+  count=$((count + 1))
+  if [ "$count" -ge 500 ]; then
+    exit 0
+  fi
+done
+"#;
+
+/// Find file names under a root, without following symlinks out of it.
+const SEARCH_SCRIPT: &str = r#"set -eu
+IFS= read -r root
+IFS= read -r pattern
+IFS= read -r depth
+cd "$root" 2>/dev/null || exit 3
+find . -maxdepth "$depth" -name "$pattern" -type f -print0 2>/dev/null
+"#;
+
+/// List one directory, given as a path relative to one of the target's roots.
+pub async fn list(
+    target: &Target,
+    transport: &TransportConfig,
+    root: &str,
+    relative: &str,
+) -> Result<RemoteListing> {
+    let root = permitted_root(target, root)?;
+    let relative = checked_relative(relative)?;
+    let output = run(
+        target,
+        transport,
+        LIST_SCRIPT,
+        &[&root, &relative],
+        "list a directory",
+    )
+    .await?;
+    let (entries, truncated) = parse_entries(&output);
+    Ok(RemoteListing {
+        root,
+        path: relative,
+        entries,
+        truncated,
+    })
+}
+
+/// Find files under a root by name.
+///
+/// `glob` is what makes the query a pattern. Without it the query matches as
+/// literal text anywhere in a name, and the characters a glob would treat
+/// specially are escaped before they reach the host — so somebody searching
+/// for `[` finds a file called `[` rather than an error or a wildcard.
+pub async fn search(
+    target: &Target,
+    transport: &TransportConfig,
+    root: &str,
+    query: &str,
+    glob: bool,
+) -> Result<RemoteListing> {
+    let root = permitted_root(target, root)?;
+    ensure!(
+        !query.is_empty()
+            && query.chars().count() <= MAX_QUERY_CHARACTERS
+            && !query.chars().any(char::is_control),
+        "a search must be 1 to {MAX_QUERY_CHARACTERS} characters of ordinary text"
+    );
+    let pattern = if glob {
+        query.to_owned()
+    } else {
+        format!("*{}*", escape_glob(query))
+    };
+    let output = run(
+        target,
+        transport,
+        SEARCH_SCRIPT,
+        &[&root, &pattern, &MAX_SEARCH_DEPTH.to_string()],
+        "search for files",
+    )
+    .await?;
+    let (mut entries, truncated) = parse_paths(&output);
+    entries.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(RemoteListing {
+        root,
+        path: String::new(),
+        entries,
+        truncated,
+    })
+}
+
+/// The roots a target declares, as a client should see them.
+pub fn roots(target: &Target) -> Vec<String> {
+    target.roots.clone()
+}
+
+/// Check a root against what the target declares.
+///
+/// A client names a root rather than describing one: the answer has to be one
+/// of the paths whoever owns the configuration wrote down, compared exactly.
+/// Accepting a prefix or a parent would let a client widen its own bounds.
+fn permitted_root(target: &Target, root: &str) -> Result<String> {
+    target
+        .roots
+        .iter()
+        .find(|declared| declared.as_str() == root)
+        .cloned()
+        .with_context(|| "that path is not one of this target's configured roots".to_owned())
+}
+
+/// A relative path this is willing to descend into.
+///
+/// Refusing `..` here is belt to the script's braces: the script compares
+/// physical paths and would catch an escape anyway, but a request that is
+/// obviously trying to leave should not reach a host at all.
+fn checked_relative(relative: &str) -> Result<String> {
+    let relative = relative.trim_start_matches('/');
+    ensure!(
+        relative.chars().count() <= MAX_RELATIVE_CHARACTERS
+            && !relative.chars().any(char::is_control),
+        "that path is too long or contains control characters"
+    );
+    ensure!(
+        !relative.split('/').any(|part| part == ".."),
+        "a path inside a root may not climb out of it"
+    );
+    Ok(relative.to_owned())
+}
+
+/// Make a query match as text rather than as a pattern.
+fn escape_glob(query: &str) -> String {
+    let mut escaped = String::with_capacity(query.len());
+    for character in query.chars() {
+        if matches!(character, '*' | '?' | '[' | ']' | '\\') {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
+fn parse_entries(output: &[u8]) -> (Vec<RemoteEntry>, bool) {
+    let mut fields = split_nul(output);
+    let mut entries = Vec::new();
+    while let (Some(kind), Some(name)) = (fields.next(), fields.next()) {
+        let Ok(name) = String::from_utf8(name.to_vec()) else {
+            continue;
+        };
+        entries.push(RemoteEntry {
+            kind: match kind {
+                b"d" => RemoteEntryKind::Directory,
+                b"f" => RemoteEntryKind::File,
+                _ => RemoteEntryKind::Other,
+            },
+            name,
+        });
+    }
+    let truncated = entries.len() >= MAX_ENTRIES;
+    entries.truncate(MAX_ENTRIES);
+    (entries, truncated)
+}
+
+fn parse_paths(output: &[u8]) -> (Vec<RemoteEntry>, bool) {
+    let mut entries = Vec::new();
+    for path in split_nul(output) {
+        let Ok(path) = String::from_utf8(path.to_vec()) else {
+            continue;
+        };
+        let name = path.strip_prefix("./").unwrap_or(&path).to_owned();
+        if name.is_empty() {
+            continue;
+        }
+        entries.push(RemoteEntry {
+            kind: RemoteEntryKind::File,
+            name,
+        });
+    }
+    let truncated = entries.len() >= MAX_ENTRIES;
+    entries.truncate(MAX_ENTRIES);
+    (entries, truncated)
+}
+
+/// Split NUL-terminated output, discarding anything after the last terminator.
+///
+/// The remote side is capped by bytes, so its last record may have been cut in
+/// half. A half a file name is not a file name, and dropping it is why the
+/// framing is NUL rather than newlines in the first place.
+fn split_nul(output: &[u8]) -> impl Iterator<Item = &[u8]> {
+    let complete = output
+        .iter()
+        .rposition(|byte| *byte == 0)
+        .map_or(0, |index| index + 1);
+    output[..complete]
+        .split(|byte| *byte == 0)
+        .filter(|field| !field.is_empty())
+}
+
+async fn run(
+    target: &Target,
+    transport: &TransportConfig,
+    script: &str,
+    arguments: &[&str],
+    what: &str,
+) -> Result<Vec<u8>> {
+    let mut command = match target.ssh.as_deref() {
+        Some(destination) => build_ssh_command(destination, transport, script.to_owned()),
+        None => {
+            let mut command = Command::new("/bin/sh");
+            command.arg("-c").arg(script);
+            command
+        }
+    };
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .with_context(|| format!("failed to start the command to {what}"))?;
+    let mut input = child
+        .stdin
+        .take()
+        .context("the remote command did not expose stdin")?;
+    // One line per parameter, in the order the script reads them. Every one of
+    // them is data: the script reads into a variable and never evaluates.
+    let mut written = String::new();
+    for argument in arguments {
+        written.push_str(argument);
+        written.push('\n');
+    }
+    let _ = input.write_all(written.as_bytes()).await;
+    let _ = input.shutdown().await;
+    drop(input);
+
+    let output = timeout(
+        Duration::from_secs(transport.command_timeout_seconds),
+        child.wait_with_output(),
+    )
+    .await
+    .with_context(|| format!("timed out trying to {what}"))?
+    .with_context(|| format!("failed to {what}"))?;
+    if !output.status.success() {
+        bail!("could not {what} on that target");
+    }
+    let mut bytes = output.stdout;
+    bytes.truncate(MAX_OUTPUT_BYTES);
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_ENTRIES, RemoteEntryKind, checked_relative, escape_glob, parse_entries, parse_paths,
+        permitted_root,
+    };
+    use crate::config::Target;
+
+    fn target(roots: &[&str]) -> Target {
+        Target {
+            name: "host-a".to_owned(),
+            ssh: Some("host".to_owned()),
+            discover_sessions: false,
+            session: None,
+            socket: None,
+            herdr_bins: Vec::new(),
+            roots: roots.iter().map(|root| (*root).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn a_root_must_be_one_the_target_declared() {
+        let declared = target(&["/srv/build", "/home/example/work"]);
+        let none = target(&[]);
+
+        assert_eq!(
+            permitted_root(&declared, "/srv/build").unwrap(),
+            "/srv/build"
+        );
+        assert!(
+            permitted_root(&declared, "/srv").is_err(),
+            "a parent of a root is not a root"
+        );
+        assert!(
+            permitted_root(&declared, "/srv/build/inner").is_err(),
+            "a client naming a deeper path must still name the root it came from"
+        );
+        assert!(permitted_root(&declared, "/etc").is_err());
+        assert!(
+            permitted_root(&none, "/srv").is_err(),
+            "a target that declared no roots offers none"
+        );
+    }
+
+    #[test]
+    fn a_path_inside_a_root_may_not_climb_out_of_it() {
+        assert_eq!(checked_relative("sub/dir").unwrap(), "sub/dir");
+        assert_eq!(
+            checked_relative("/sub/dir").unwrap(),
+            "sub/dir",
+            "a leading separator is a client's habit, not a request for the filesystem root"
+        );
+        assert!(checked_relative("../etc").is_err());
+        assert!(checked_relative("sub/../../etc").is_err());
+        assert!(
+            checked_relative("sub/..name").is_ok(),
+            "a name that merely starts with dots is not a climb"
+        );
+    }
+
+    #[test]
+    fn a_plain_search_matches_text_and_not_a_pattern() {
+        assert_eq!(escape_glob("report[1].txt"), r"report\[1\].txt");
+        assert_eq!(escape_glob("*.rs"), r"\*.rs");
+        assert_eq!(escape_glob("plain"), "plain");
+    }
+
+    #[test]
+    fn entries_carry_their_kind_and_survive_awkward_names() {
+        let output = b"d\0sub dir\0f\0report.txt\0f\0line\nbreak.txt\0o\0socket\0";
+
+        let (entries, truncated) = parse_entries(output);
+
+        assert!(!truncated);
+        assert_eq!(entries.len(), 4);
+        assert_eq!(entries[0].kind, RemoteEntryKind::Directory);
+        assert_eq!(entries[0].name, "sub dir");
+        assert_eq!(
+            entries[2].name, "line\nbreak.txt",
+            "NUL framing is what lets a name contain a newline"
+        );
+        assert_eq!(entries[3].kind, RemoteEntryKind::Other);
+    }
+
+    #[test]
+    fn a_record_cut_in_half_by_the_byte_cap_is_dropped() {
+        let output = b"f\0whole.txt\0f\0half-a-na";
+
+        let (entries, _) = parse_entries(output);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "whole.txt");
+    }
+
+    #[test]
+    fn a_listing_says_when_it_stopped_short() {
+        let mut output = Vec::new();
+        for index in 0..MAX_ENTRIES + 1 {
+            output.extend_from_slice(format!("f\0file{index}\0").as_bytes());
+        }
+
+        let (entries, truncated) = parse_entries(&output);
+
+        assert_eq!(entries.len(), MAX_ENTRIES);
+        assert!(
+            truncated,
+            "a list silently missing the file somebody wants is worse than one that admits it"
+        );
+    }
+
+    #[test]
+    fn search_results_are_relative_to_the_root_they_came_from() {
+        let output = b"./sub/report.txt\0./top.txt\0";
+
+        let (entries, _) = parse_paths(output);
+
+        assert_eq!(entries[0].name, "sub/report.txt");
+        assert_eq!(entries[1].name, "top.txt");
+        assert!(entries.iter().all(|entry| !entry.name.starts_with('/')));
+    }
+}

--- a/src/resource_action.rs
+++ b/src/resource_action.rs
@@ -99,6 +99,23 @@ pub enum ResourceAction {
         action: PluginAction,
         context: PluginInvocationTarget,
     },
+    /// Fetch a file off a target and write it onto this machine.
+    SaveFileFromPane {
+        pane: PaneId,
+        label: String,
+    },
+    /// Move a file from one target to another without it touching this device.
+    ///
+    /// Only the daemon holds live connections to both hosts, so this is the
+    /// one direction a desktop-bound design could not express at all.
+    TransferFileBetween {
+        source: PaneId,
+        destination: PaneId,
+        label: String,
+        destination_label: String,
+    },
+    /// Abandon the transfer this client is receiving.
+    CancelFileTransfer,
     /// Pin, mute, or snooze one agent in Super-Herdr's own inbox.
     ///
     /// Listed among the Herdr actions because that is where a person looks for
@@ -120,6 +137,10 @@ impl ResourceAction {
                 | Self::OpenAgentNavigator
                 | Self::OpenAttentionCenter
                 | Self::MarkAgent { .. }
+                // Reading a file changes nothing on the host, and cancelling a
+                // transfer this client is receiving changes nothing anywhere.
+                | Self::SaveFileFromPane { .. }
+                | Self::CancelFileTransfer
         )
     }
 
@@ -145,6 +166,9 @@ impl ResourceAction {
             Self::RenameTab { tab, .. } | Self::CloseTab { tab, .. } => Some(tab.target_session()),
             Self::InvokePluginAction { action, .. } => Some(action.id.target.clone()),
             Self::MarkAgent { agent, .. } => Some(agent.target_session()),
+            Self::SaveFileFromPane { pane, .. } => Some(pane.target_session()),
+            Self::TransferFileBetween { source, .. } => Some(source.target_session()),
+            Self::CancelFileTransfer => None,
             Self::OpenTargetManager | Self::OpenAgentNavigator | Self::OpenAttentionCenter => None,
         }
     }
@@ -177,6 +201,13 @@ impl ResourceAction {
             Self::InvokePluginAction { action, .. } => {
                 format!("Plugin: {}", action.title)
             }
+            Self::SaveFileFromPane { label, .. } => format!("Save a file from {label:?}"),
+            Self::TransferFileBetween {
+                label,
+                destination_label,
+                ..
+            } => format!("Send a file from {label:?} to {destination_label:?}"),
+            Self::CancelFileTransfer => "Cancel the file transfer".to_owned(),
             Self::MarkAgent { mark, label, .. } => match mark {
                 AgentMarkRequest::Pin { pinned: true } => format!("Pin agent {label:?}"),
                 AgentMarkRequest::Pin { pinned: false } => format!("Unpin agent {label:?}"),
@@ -282,6 +313,38 @@ mod tests {
             "Snooze agent \"reviewer\" for 60 minutes"
         );
         assert!(action.search_text().contains("build/toolchains"));
+    }
+
+    #[test]
+    fn reading_a_file_is_not_a_herdr_mutation_but_moving_one_is() {
+        let save = ResourceAction::SaveFileFromPane {
+            pane: PaneId::new("build", "toolchains", "w2:p1"),
+            label: "shell".to_owned(),
+        };
+        let send = ResourceAction::TransferFileBetween {
+            source: PaneId::new("build", "toolchains", "w2:p1"),
+            destination: PaneId::new("development", "work", "w1:p1"),
+            label: "shell".to_owned(),
+            destination_label: "development/work".to_owned(),
+        };
+
+        assert!(!save.mutates_herdr(), "reading changes nothing on the host");
+        assert!(send.mutates_herdr(), "writing a file to a host changes it");
+        assert!(!save.is_destructive() && !send.is_destructive());
+        assert_eq!(
+            save.target_session(),
+            Some(TargetSession::new("build", "toolchains"))
+        );
+        assert_eq!(
+            send.target_session(),
+            Some(TargetSession::new("build", "toolchains")),
+            "a transfer is scoped to where it reads from"
+        );
+        assert_eq!(
+            send.palette_label(),
+            "Send a file from \"shell\" to \"development/work\""
+        );
+        assert_eq!(ResourceAction::CancelFileTransfer.target_session(), None);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -284,6 +284,11 @@ pub struct TargetRuntimeState {
     pub event_error: Option<String>,
     pub connection_generation: u64,
     pub selected_herdr_bin: Option<String>,
+    /// Directories this target's file picker may look inside, from
+    /// configuration. Carried in the federation because it is what a client
+    /// needs to offer the picker at all, and it is not a secret: it is the
+    /// list somebody wrote down as the places worth browsing.
+    pub roots: Vec<String>,
     pub snapshot: Option<Arc<NormalizedSnapshot>>,
     pub last_error: Option<String>,
     pub last_success: Option<SystemTime>,
@@ -300,6 +305,7 @@ impl TargetRuntimeState {
             event_error: None,
             connection_generation: 0,
             selected_herdr_bin: None,
+            roots: target.roots.clone(),
             snapshot: None,
             last_error: None,
             last_success: None,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -152,6 +152,7 @@ fn targets_for_discovered_sessions(
             session: Some(session.name),
             socket: Some(session.socket_path),
             herdr_bins: target.herdr_bins.clone(),
+            roots: target.roots.clone(),
         })
         .collect()
 }
@@ -947,6 +948,7 @@ mod tests {
             session: Some("work".to_owned()),
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
 
         assert_eq!(
@@ -989,6 +991,7 @@ mod tests {
             session: Some("fallback".to_owned()),
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
 
         assert!(targets_for_discovered_sessions(&target, Vec::new()).is_empty());

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -401,6 +401,9 @@ struct TargetForm {
     discover_sessions: bool,
     socket: Option<String>,
     herdr_bins: Vec<String>,
+    /// Carried, never edited: a browsing bound belongs in configuration, and a
+    /// form that dropped it would quietly empty a picker on the next save.
+    roots: Vec<String>,
     field: TargetFormField,
     error: Option<String>,
     test_state: TargetTestState,
@@ -419,6 +422,7 @@ impl TargetForm {
             discover_sessions: true,
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
             field: TargetFormField::Name,
             error: None,
             test_state: TargetTestState::Untested,
@@ -437,6 +441,7 @@ impl TargetForm {
             discover_sessions: target.discover_sessions,
             socket: target.socket.clone(),
             herdr_bins: target.herdr_bins.clone(),
+            roots: target.roots.clone(),
             field: TargetFormField::Name,
             error: None,
             test_state: TargetTestState::Untested,
@@ -454,6 +459,11 @@ impl TargetForm {
             session: (!self.session.is_empty()).then(|| self.session.clone()),
             socket: self.socket.clone(),
             herdr_bins: self.herdr_bins.clone(),
+            // The target form does not edit roots. They are a browsing bound
+            // somebody writes in configuration, not a field to fill in while
+            // adding a machine, and a form that dropped them would quietly
+            // empty a picker on the next save.
+            roots: self.roots.clone(),
         }
     }
 
@@ -5362,6 +5372,9 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
         // sitting at. It does not subscribe to the device sink and is never
         // sent one.
         ServerMessage::Notification { .. } => {}
+        // The picker is a small-screen affordance. The TUI has a shell in
+        // every pane and a person who would rather use it.
+        ServerMessage::RemoteFiles { .. } => {}
         ServerMessage::AgentCards { projection } => {
             app.agent_marks = projection
                 .cards()
@@ -7802,6 +7815,7 @@ mod tests {
             // What the file says: nothing. The host reports it at runtime.
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
         let key = TargetSession::new("workstation", "example-session");
 
@@ -8609,6 +8623,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
         Config::add_target_file(Some(&path), existing.clone()).unwrap();
         let mut app = App {
@@ -8647,6 +8662,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
         let mut duplicate = TargetForm::add();
         duplicate.name = "existing".to_owned();
@@ -8762,6 +8778,7 @@ mod tests {
             session: None,
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
+            roots: Vec::new(),
         };
         let frame_area = ratatui::layout::Rect::new(0, 0, 120, 40);
         let mut app = App {
@@ -10080,6 +10097,7 @@ mod tests {
             event_error: None,
             connection_generation: 1,
             selected_herdr_bin: Some("herdr".to_owned()),
+            roots: Vec::new(),
             snapshot: snapshot.map(Arc::new),
             last_error: None,
             last_success: None,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -31,6 +31,7 @@ use crate::client::{Client, ClientCommands};
 use crate::clipboard;
 use crate::config::{Config, Target, TransportConfig};
 use crate::daemon::server::{DaemonOptions, spawn_in_process};
+use crate::file_save::{self, FileSave, SaveProgress};
 use crate::model::{AgentId, PaneId, TabId, TargetSession, WorkspaceId};
 use crate::notifications::{self, NotificationDelivery, NotificationQueue};
 use crate::operation::Operation;
@@ -802,6 +803,15 @@ struct PendingPluginCatalog {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TextPromptAction {
+    /// The path on a target to fetch onto this machine.
+    SaveFile {
+        pane: PaneId,
+    },
+    /// The path on one target to move to another.
+    TransferFile {
+        source: PaneId,
+        destination: PaneId,
+    },
     /// Send a file named by path rather than by clipboard, which is what a file
     /// dragged onto a terminal amounts to.
     SendFile {
@@ -856,6 +866,11 @@ struct App {
     /// actually available rather than both halves of it; the daemon remains
     /// the authority, and this is a mirror of its answer.
     agent_marks: BTreeMap<AgentId, AgentMarkState>,
+    /// The file being written onto this machine, and the request it answers.
+    /// The request is held separately because it is known from the moment the
+    /// download is asked for, and the save itself only from the offer.
+    file_save: Option<FileSave>,
+    file_save_request: Option<u64>,
     pending_plugin_catalogs: BTreeMap<u64, PendingPluginCatalog>,
     pending_uploads: BTreeMap<u64, PendingUpload>,
     last_frame_area: Option<Rect>,
@@ -916,6 +931,8 @@ impl Default for App {
             pending_operations: BTreeMap::new(),
             plugin_catalogs: BTreeMap::new(),
             agent_marks: BTreeMap::new(),
+            file_save: None,
+            file_save_request: None,
             pending_plugin_catalogs: BTreeMap::new(),
             pending_uploads: BTreeMap::new(),
             last_frame_area: None,
@@ -2614,12 +2631,18 @@ fn command_palette_actions(
     selected: Option<&PaneId>,
     plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
     agent_marks: &BTreeMap<AgentId, AgentMarkState>,
+    transferring: bool,
 ) -> Vec<ResourceAction> {
     let mut actions = vec![
         ResourceAction::OpenTargetManager,
         ResourceAction::OpenAgentNavigator,
         ResourceAction::OpenAttentionCenter,
     ];
+    // Offered only while there is one to cancel. An entry that answers "there
+    // is nothing to do" is one more line to read past every other time.
+    if transferring {
+        actions.push(ResourceAction::CancelFileTransfer);
+    }
 
     let selected_is_actionable = selected.is_some_and(|pane| {
         state
@@ -2682,6 +2705,11 @@ fn command_palette_actions(
                 label: pane_label.clone(),
             },
         ]);
+        actions.push(ResourceAction::SaveFileFromPane {
+            pane: pane.id.clone(),
+            label: pane_label.clone(),
+        });
+        actions.extend(transfer_destinations(state, &pane.id));
         actions.extend(agent_mark_actions(
             snapshot,
             &pane.id,
@@ -2948,6 +2976,60 @@ fn workspace_recreate_actions(
 /// the choice is worth.
 const TUI_SNOOZE_MINUTES: u32 = 60;
 
+/// Where a file on this pane's host could be sent.
+///
+/// One destination per other live target session, not one per pane: the choice
+/// that matters is which machine, and a menu listing every pane on every host
+/// is the hierarchy this is meant to save somebody from walking. The
+/// destination pane is the one the daemon will stage through, so it has to be
+/// a real one.
+fn transfer_destinations(state: &FederationState, source: &PaneId) -> Vec<ResourceAction> {
+    let source_session = source.target_session();
+    let label = |snapshot: &NormalizedSnapshot, pane: &PaneId| {
+        snapshot
+            .panes
+            .get(pane)
+            .map(|held| display_label(&held.id.resource, held.label.as_deref()))
+            .unwrap_or_else(|| pane.resource.clone())
+    };
+    let mut destinations = Vec::new();
+    for runtime in state.targets.values() {
+        if runtime.key == source_session || runtime.connection != TargetConnectionState::Live {
+            continue;
+        }
+        let Some(snapshot) = runtime.snapshot.as_deref() else {
+            continue;
+        };
+        let Some(destination) = snapshot.panes.keys().next().cloned() else {
+            continue;
+        };
+        destinations.push(ResourceAction::TransferFileBetween {
+            source: source.clone(),
+            label: label(snapshot, source),
+            destination_label: runtime.key.to_string(),
+            destination,
+        });
+    }
+    destinations
+}
+
+/// Abandon a save this client is receiving.
+///
+/// The daemon is told, because it is reading a file on somebody's host to feed
+/// it and should stop. Whatever arrived is dropped with the temporary file it
+/// was going into.
+fn cancel_file_save(app: &mut App) {
+    let Some(request) = app.file_save_request.take() else {
+        app.message = Some("no file transfer to cancel".to_owned());
+        return;
+    };
+    if let Some(client) = app.client.as_ref() {
+        client.cancel_download(request);
+    }
+    app.file_save = None;
+    app.message = Some("file transfer cancelled".to_owned());
+}
+
 /// The marks a person can put on the agent in one pane.
 ///
 /// Offered only where there is an agent to mark: a pane running a shell has
@@ -3090,6 +3172,15 @@ fn context_menu_for_target(
                     label: label.clone(),
                 },
             ];
+            actions.push(ResourceAction::SaveFileFromPane {
+                pane: pane.clone(),
+                label: label.clone(),
+            });
+            actions.extend(
+                transfer_destinations(state, pane)
+                    .into_iter()
+                    .take(MAX_CONTEXT_MENU_MOVE_DESTINATIONS),
+            );
             actions.extend(agent_mark_actions(snapshot, pane, &label, agent_marks));
             (
                 format!("pane {label} · {}", pane.target_session()),
@@ -3176,11 +3267,15 @@ fn filtered_palette_actions(
     query: &str,
     plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
     agent_marks: &BTreeMap<AgentId, AgentMarkState>,
+    transferring: bool,
 ) -> Vec<ResourceAction> {
-    let mut actions = command_palette_actions(state, selected, plugin_catalogs, agent_marks)
-        .into_iter()
-        .filter_map(|action| fuzzy_score(&action.search_text(), query).map(|score| (score, action)))
-        .collect::<Vec<_>>();
+    let mut actions =
+        command_palette_actions(state, selected, plugin_catalogs, agent_marks, transferring)
+            .into_iter()
+            .filter_map(|action| {
+                fuzzy_score(&action.search_text(), query).map(|score| (score, action))
+            })
+            .collect::<Vec<_>>();
     actions.sort_by(|(left_score, left), (right_score, right)| {
         left_score
             .cmp(right_score)
@@ -3200,6 +3295,7 @@ fn handle_command_palette_input(key: u8, state: &FederationState, app: &mut App)
         &palette.query,
         &app.plugin_catalogs,
         &app.agent_marks,
+        app.file_save_request.is_some(),
     );
     match key {
         0x1b => return Ok(false),
@@ -3239,6 +3335,7 @@ fn handle_command_palette_input(key: u8, state: &FederationState, app: &mut App)
         &palette.query,
         &app.plugin_catalogs,
         &app.agent_marks,
+        app.file_save_request.is_some(),
     )
     .len();
     palette.selected = palette.selected.min(count.saturating_sub(1));
@@ -3428,6 +3525,35 @@ fn execute_resource_action(action: ResourceAction, state: &FederationState, app:
                 true,
             );
         }
+        ResourceAction::SaveFileFromPane { pane, label } => {
+            app.text_prompt = Some(TextPrompt {
+                title: format!("save a file from {label}"),
+                label: format!("path on {}", pane.target_session()),
+                value: String::new(),
+                action: TextPromptAction::SaveFile { pane },
+                error: None,
+                partial: Vec::new(),
+            });
+        }
+        ResourceAction::TransferFileBetween {
+            source,
+            destination,
+            destination_label,
+            ..
+        } => {
+            app.text_prompt = Some(TextPrompt {
+                title: format!("send a file to {destination_label}"),
+                label: format!("path on {}", source.target_session()),
+                value: String::new(),
+                action: TextPromptAction::TransferFile {
+                    source,
+                    destination,
+                },
+                error: None,
+                partial: Vec::new(),
+            });
+        }
+        ResourceAction::CancelFileTransfer => cancel_file_save(app),
         ResourceAction::MarkAgent { agent, mark, .. } => {
             // No confirmation and no Herdr operation: a mark changes what this
             // inbox shows and nothing on the host, and the daemon answers by
@@ -3630,14 +3756,62 @@ fn handle_text_prompt_input(key: u8, state: &FederationState, app: &mut App) -> 
                 app.text_prompt = Some(prompt);
                 return Ok(false);
             }
+            if let TextPromptAction::SaveFile { pane } = &prompt.action {
+                match (value.is_empty(), app.client.clone()) {
+                    (true, _) => prompt.error = Some("A path is required".to_owned()),
+                    (_, None) => prompt.error = Some("file routing is unavailable".to_owned()),
+                    (_, Some(client)) => {
+                        // One at a time, and said so rather than silently
+                        // replacing a transfer somebody is waiting on.
+                        if app.file_save.is_some() {
+                            prompt.error = Some("a file is already being saved".to_owned());
+                        } else {
+                            app.file_save_request =
+                                Some(client.begin_download(pane.clone(), value));
+                            app.message = Some("asking for the file…".to_owned());
+                            return Ok(false);
+                        }
+                    }
+                }
+                app.text_prompt = Some(prompt);
+                return Ok(false);
+            }
+            if let TextPromptAction::TransferFile {
+                source,
+                destination,
+            } = &prompt.action
+            {
+                match (value.is_empty(), app.client.clone()) {
+                    (true, _) => prompt.error = Some("A path is required".to_owned()),
+                    (_, None) => prompt.error = Some("file routing is unavailable".to_owned()),
+                    (_, Some(client)) => {
+                        client.transfer_between(
+                            source.clone(),
+                            value.clone(),
+                            destination.clone(),
+                            None,
+                        );
+                        app.message = Some(format!(
+                            "sending {value:?} to {}…",
+                            destination.target_session()
+                        ));
+                        return Ok(false);
+                    }
+                }
+                app.text_prompt = Some(prompt);
+                return Ok(false);
+            }
             if value.is_empty() {
                 prompt.error = Some("A non-empty label is required".to_owned());
             } else {
                 // The prompt is where an intent becomes an operation: the label
                 // the person typed is now part of what the daemon is asked to do.
                 let (operation, description, follow_server_focus) = match prompt.action {
-                    // Handled above: a file is sent rather than operated on.
-                    TextPromptAction::SendFile { .. } => return Ok(false),
+                    // Handled above: these move a file rather than operate on
+                    // a Herdr resource.
+                    TextPromptAction::SendFile { .. }
+                    | TextPromptAction::SaveFile { .. }
+                    | TextPromptAction::TransferFile { .. } => return Ok(false),
                     TextPromptAction::CreateWorkspace { target } => (
                         Operation::CreateWorkspace {
                             target: target.clone(),
@@ -5223,9 +5397,83 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
         // The frontend does not ask for files off a host: it has a shell on
         // one, and somewhere to put what it reads is a question about this
         // machine's filesystem that no key in the TUI currently asks.
-        ServerMessage::DownloadOffer { .. }
-        | ServerMessage::DownloadChunk { .. }
-        | ServerMessage::DownloadFinished { .. } => {}
+        ServerMessage::DownloadOffer {
+            request,
+            name,
+            length,
+            digest,
+        } => {
+            if app.file_save_request != Some(request) {
+                return;
+            }
+            let directory = file_save::default_directory();
+            match FileSave::begin(request, &directory, &name, length, digest) {
+                Ok(mut save) => {
+                    if let (SaveProgress::Pull(chunks), Some(client)) =
+                        (save.start(), app.client.as_ref())
+                    {
+                        client.pull_download(request, chunks);
+                    }
+                    app.message = Some(format!(
+                        "saving {} ({} bytes) to {}…",
+                        name,
+                        length,
+                        save.destination().display()
+                    ));
+                    app.file_save = Some(save);
+                }
+                Err(error) => {
+                    // Refused before anything is asked for, so the daemon
+                    // stops reading the file on somebody's host as well.
+                    if let Some(client) = app.client.as_ref() {
+                        client.cancel_download(request);
+                    }
+                    app.file_save_request = None;
+                    app.message = Some(format!("cannot save that file: {error}"));
+                }
+            }
+        }
+        ServerMessage::DownloadChunk { request, bytes } => {
+            let Some(save) = app
+                .file_save
+                .as_mut()
+                .filter(|save| save.request() == request)
+            else {
+                return;
+            };
+            match save.chunk(&bytes) {
+                Ok(SaveProgress::Pull(chunks)) => {
+                    if let Some(client) = app.client.as_ref() {
+                        client.pull_download(request, chunks);
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    if let Some(client) = app.client.as_ref() {
+                        client.cancel_download(request);
+                    }
+                    app.file_save = None;
+                    app.file_save_request = None;
+                    app.message = Some(format!("that transfer was refused: {error}"));
+                }
+            }
+        }
+        ServerMessage::DownloadFinished { request } => {
+            let Some(save) = app
+                .file_save
+                .take()
+                .filter(|save| save.request() == request)
+            else {
+                return;
+            };
+            app.file_save_request = None;
+            app.message = Some(match save.finish() {
+                Ok(path) => format!("saved {}", path.display()),
+                // The temporary file went with the failure, so there is
+                // nothing on disk pretending to be the file that was asked for.
+                Err(error) => format!("that file was not saved: {error}"),
+            });
+        }
         ServerMessage::UploadComplete {
             request,
             path,
@@ -5481,6 +5729,7 @@ fn render(frame: &mut Frame, state: &FederationState, app: &App) {
             palette,
             &app.plugin_catalogs,
             &app.agent_marks,
+            app.file_save_request.is_some(),
         );
     } else if let Some(prompt) = app.text_prompt.as_ref() {
         render_text_prompt(frame, prompt);
@@ -5587,6 +5836,7 @@ fn render_command_palette(
     palette: &CommandPalette,
     plugin_catalogs: &BTreeMap<TargetSession, PluginCatalog>,
     agent_marks: &BTreeMap<AgentId, AgentMarkState>,
+    transferring: bool,
 ) {
     let area = centered_popup(frame.area(), 82, 22);
     frame.render_widget(Clear, area);
@@ -5603,6 +5853,7 @@ fn render_command_palette(
         &palette.query,
         plugin_catalogs,
         agent_marks,
+        transferring,
     );
     let mut lines = vec![
         Line::from(vec![
@@ -8053,6 +8304,7 @@ mod tests {
             "jump second",
             &app.plugin_catalogs,
             &app.agent_marks,
+            false,
         );
         assert_eq!(actions.len(), 1);
         let ResourceAction::JumpToPane { pane, .. } = &actions[0] else {
@@ -8102,7 +8354,8 @@ mod tests {
             target.clone(),
             runtime(target, TargetConnectionState::Live, Some(snapshot)),
         );
-        let actions = command_palette_actions(&state, Some(&pane), &catalogs, &BTreeMap::new());
+        let actions =
+            command_palette_actions(&state, Some(&pane), &catalogs, &BTreeMap::new(), false);
         assert!(actions.iter().any(|action| {
             matches!(
                 action,
@@ -8185,6 +8438,120 @@ mod tests {
                 .filter(|action| matches!(action, ResourceAction::MarkAgent { .. }))
                 .all(|action| !action.mutates_herdr()),
             "a mark is Super-Herdr's own inbox state and must not reach the host"
+        );
+    }
+
+    #[test]
+    fn a_pane_can_be_saved_from_and_sent_from_to_every_other_host() {
+        let mut state = FederationState::default();
+        for host in ["host-a", "host-b", "host-c"] {
+            let key = TargetSession::new(host, "work");
+            let snapshot = NormalizedSnapshot::from_value(
+                &key,
+                &json!({
+                    "workspaces": [{"workspace_id": "w1"}],
+                    "tabs": [{"tab_id": "w1:t1", "workspace_id": "w1"}],
+                    "panes": [{
+                        "pane_id": "w1:p1", "workspace_id": "w1",
+                        "tab_id": "w1:t1", "label": "shell"
+                    }]
+                }),
+            );
+            state.targets.insert(
+                key.clone(),
+                runtime(key, TargetConnectionState::Live, Some(snapshot)),
+            );
+        }
+
+        let menu = context_menu_for_target(
+            &state,
+            ContextTarget::Pane(PaneId::new("host-a", "work", "w1:p1")),
+            ratatui::layout::Position::new(1, 1),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(
+            menu.actions.iter().any(|action| matches!(
+                action,
+                ResourceAction::SaveFileFromPane { pane, .. }
+                    if pane == &PaneId::new("host-a", "work", "w1:p1")
+            )),
+            "a pane can be read from"
+        );
+        let destinations = menu
+            .actions
+            .iter()
+            .filter_map(|action| match action {
+                ResourceAction::TransferFileBetween { destination, .. } => {
+                    Some(destination.target.as_str())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            destinations,
+            ["host-b", "host-c"],
+            "one destination per other host, and never back to the source"
+        );
+    }
+
+    #[test]
+    fn a_disconnected_host_is_not_offered_as_a_destination() {
+        let mut state = FederationState::default();
+        for (host, connection) in [
+            ("host-a", TargetConnectionState::Live),
+            ("host-b", TargetConnectionState::Backoff { attempt: 1 }),
+        ] {
+            let key = TargetSession::new(host, "work");
+            let snapshot = NormalizedSnapshot::from_value(
+                &key,
+                &json!({
+                    "workspaces": [{"workspace_id": "w1"}],
+                    "tabs": [{"tab_id": "w1:t1", "workspace_id": "w1"}],
+                    "panes": [{"pane_id": "w1:p1", "workspace_id": "w1", "tab_id": "w1:t1"}]
+                }),
+            );
+            state
+                .targets
+                .insert(key.clone(), runtime(key, connection, Some(snapshot)));
+        }
+
+        let menu = context_menu_for_target(
+            &state,
+            ContextTarget::Pane(PaneId::new("host-a", "work", "w1:p1")),
+            ratatui::layout::Position::new(1, 1),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(
+            !menu
+                .actions
+                .iter()
+                .any(|action| matches!(action, ResourceAction::TransferFileBetween { .. })),
+            "a host that cannot be reached cannot be sent to"
+        );
+    }
+
+    #[test]
+    fn cancelling_a_transfer_is_offered_only_while_there_is_one() {
+        let state = FederationState::default();
+
+        let idle = command_palette_actions(&state, None, &BTreeMap::new(), &BTreeMap::new(), false);
+        let busy = command_palette_actions(&state, None, &BTreeMap::new(), &BTreeMap::new(), true);
+
+        assert!(
+            !idle
+                .iter()
+                .any(|action| matches!(action, ResourceAction::CancelFileTransfer)),
+            "an entry that answers 'there is nothing to do' is one more line to read past"
+        );
+        assert!(
+            busy.iter()
+                .any(|action| matches!(action, ResourceAction::CancelFileTransfer))
         );
     }
 
@@ -8526,6 +8893,7 @@ mod tests {
             Some(&PaneId::new("host-b", "work", "w1:p1")),
             &BTreeMap::new(),
             &BTreeMap::new(),
+            false,
         );
         let palette_moves = palette
             .iter()

--- a/tools/page-harness.mjs
+++ b/tools/page-harness.mjs
@@ -20,6 +20,7 @@ const node = id => {
       className: '', style: {}, dataset: {}, children: [], disabled: false,
       append(...children) { this.children.push(...children); },
       remove() {},
+      removeAttribute(name) { delete this[name]; },
       addEventListener(type, listener) { this[`on${type}`] = listener; },
       setAttribute(name, value) { this[name] = value; },
       focus() { this.focused = true; },
@@ -124,8 +125,21 @@ class StubEventSource {
   close() {}
 }
 globalThis.EventSource = StubEventSource;
+// Object URLs are a browser thing; the page revokes what it creates, so the
+// stub counts both to catch a blob left behind.
+let objectUrls = 0;
+globalThis.URL = class extends URL {
+  static createObjectURL() {
+    objectUrls++;
+    return `blob:stub/${objectUrls}`;
+  }
 
-const module = new Function(`${script}\nreturn { apply, observe, takeControl, uploadSelectedFiles, shellQuote, el, KEYS, endpoint, renderPanes, codeBoxes, enteredCode };`);
+  static revokeObjectURL() {
+    objectUrls--;
+  }
+};
+
+const module = new Function(`${script}\nreturn { apply, observe, takeControl, uploadSelectedFiles, shellQuote, el, KEYS, endpoint, renderPanes, codeBoxes, enteredCode, stopWatching };`);
 const page = module();
 
 const deliver = message => page.apply(message);
@@ -674,3 +688,152 @@ deliver({
 check('an alert after turning them off raises nothing', alerts.length === 0);
 StubNotification.granting = true;
 await page.el('alerts').onclick();
+
+// Fetching a file off a target. Two steps: the daemon says what the file is,
+// and nothing crosses the link until a person accepts it.
+const digestOf = async bytes => Buffer.from(
+  await crypto.subtle.digest('SHA-256', bytes),
+).toString('hex');
+// The request number is remembered rather than re-read, because the tests
+// clear `sent` between steps the way a real client forgets nothing.
+let fetchRequest = 0;
+const askFor = path => {
+  page.el('fetch-path').value = path;
+  page.el('fetch-form').onsubmit({ preventDefault() {} });
+  fetchRequest = sent.find(one => one.body.type === 'download.begin').body.request;
+};
+const offer = (name, length, digest) => deliver({
+  type: 'download.offer', request: fetchRequest, name, length, digest,
+});
+const arrive = bytes => deliver({
+  type: 'download.chunk', request: fetchRequest, bytes: bytes.toString('base64'),
+});
+const finish = () => deliver({ type: 'download.finished', request: fetchRequest });
+
+page.observe(pane, 'first/main/w1:p1');
+sent.length = 0;
+askFor('/srv/build/report.txt');
+const begun = sent.find(one => one.body.type === 'download.begin');
+check('asking for a file names the pane and the typed path',
+  begun.body.pane.resource === 'w1:p1' && begun.body.path === '/srv/build/report.txt');
+check('asking for a file pulls nothing yet',
+  sent.every(one => one.body.type !== 'download.pull'));
+
+const body = Buffer.from('line one\nline two\n');
+const digest = await digestOf(body);
+offer('report.txt', body.length, digest);
+check('the offer is shown before any bytes move', page.el('fetch-offer').hidden === false);
+check('the offer names the file', page.el('fetch-name').textContent === 'report.txt');
+check('the offer gives the size', page.el('fetch-size').textContent === '18 B');
+check('the offer names the source', page.el('fetch-where').textContent === 'first/main · /srv/build/report.txt');
+check('the offer shows the host digest', page.el('fetch-digest').textContent.startsWith('sha256 '));
+check('an unaccepted offer has pulled nothing',
+  sent.every(one => one.body.type !== 'download.pull'));
+
+sent.length = 0;
+page.el('fetch-accept').onclick();
+check('accepting pulls a bounded window',
+  sent.some(one => one.body.type === 'download.pull' && one.body.chunks === 4));
+arrive(body);
+finish();
+// The digest is verified asynchronously, so wait for the verdict rather than
+// for a flag the stub starts out holding.
+await waitFor(() => page.el('fetch-note').textContent.includes('verified'));
+check('a verified file is offered for saving', page.el('fetch-save')['download'] === 'report.txt');
+check('a verified file says so', page.el('fetch-note').textContent.includes('verified'));
+check('a text file is previewed as text',
+  page.el('fetch-text').hidden === false
+    && page.el('fetch-text').textContent === 'line one\nline two\n');
+check('a text preview is not an image', page.el('fetch-image').hidden === true);
+page.el('fetch-discard').onclick();
+check('discarding releases the object URL', objectUrls === 0);
+
+// An image is shown as an image, decided from the name because a download
+// carries no declared type. A name matching nothing is saved and not previewed.
+sent.length = 0;
+askFor('/srv/build/shot.png');
+const image = Buffer.from('89504e470d0a1a0a', 'hex');
+offer('shot.png', image.length, await digestOf(image));
+page.el('fetch-accept').onclick();
+arrive(image);
+finish();
+await waitFor(() => page.el('fetch-note').textContent.includes('verified'));
+check('an image is previewed as an image', page.el('fetch-image').hidden === false);
+check('an image preview is not text', page.el('fetch-text').hidden === true);
+page.el('fetch-discard').onclick();
+
+sent.length = 0;
+askFor('/srv/build/archive.tar.zst');
+offer('archive.tar.zst', body.length, digest);
+page.el('fetch-accept').onclick();
+arrive(body);
+finish();
+await waitFor(() => page.el('fetch-note').textContent.includes('verified'));
+check('an unrecognised type is saved and not previewed',
+  page.el('fetch-text').hidden === true && page.el('fetch-image').hidden === true);
+check('an unrecognised type is still offered for saving',
+  page.el('fetch-save')['download'] === 'archive.tar.zst');
+page.el('fetch-discard').onclick();
+
+// A file that does not match what its host attested is discarded, not offered
+// with a warning.
+sent.length = 0;
+askFor('/srv/build/report.txt');
+offer('report.txt', body.length, 'f'.repeat(64));
+page.el('fetch-accept').onclick();
+arrive(body);
+finish();
+await waitFor(() => page.el('fetch-note').textContent.includes('digest'));
+check('a file failing its digest is discarded', page.el('fetch-result').hidden === true);
+check('a file failing its digest says why',
+  page.el('fetch-note').textContent.includes('did not match'));
+check('a discarded file leaves no object URL', objectUrls === 0);
+
+// A transfer that stops short is distinguishable from one still arriving,
+// which is what the declared length is for.
+sent.length = 0;
+askFor('/srv/build/report.txt');
+offer('report.txt', body.length, digest);
+page.el('fetch-accept').onclick();
+arrive(body.subarray(0, 4));
+finish();
+await waitFor(() => page.el('fetch-note').textContent.includes('stopped'));
+check('a short transfer is reported, not saved', page.el('fetch-result').hidden === true);
+
+// Too large to hold is refused before a byte moves.
+sent.length = 0;
+askFor('/srv/build/core.dump');
+offer('core.dump', 64 * 1024 * 1024, digest);
+check('an oversized file cannot be accepted', page.el('fetch-accept').disabled === true);
+check('an oversized file says why', page.el('fetch-note').textContent.includes('Too large'));
+check('an oversized file pulls nothing',
+  sent.every(one => one.body.type !== 'download.pull'));
+page.el('fetch-refuse').onclick();
+check('refusing an offer cancels it',
+  sent.some(one => one.body.type === 'download.cancel'));
+
+// A fetch belongs to the pane it was asked for.
+sent.length = 0;
+askFor('/srv/build/report.txt');
+offer('report.txt', body.length, digest);
+sent.length = 0;
+page.observe({ target: 'first', session: 'main', resource: 'w1:p2' }, 'other');
+check('watching another pane cancels a fetch',
+  sent.some(one => one.body.type === 'download.cancel'));
+check('an abandoned fetch clears its offer', page.el('fetch-offer').hidden === true);
+
+// A reconnect leaves the daemon holding no such request, so this end forgets
+// it rather than cancelling a number that now means something else.
+page.observe(pane, 'first/main/w1:p1');
+sent.length = 0;
+askFor('/srv/build/report.txt');
+offer('report.txt', body.length, digest);
+sent.length = 0;
+deliver({
+  type: 'server.hello', protocol: 3, server_version: '0.7.20',
+  features: ['terminal', 'agent_cards'], quick_replies: [],
+});
+check('a reconnect does not cancel a request the daemon has forgotten',
+  sent.every(one => one.body.type !== 'download.cancel'));
+check('a reconnect reports the ended transfer',
+  page.el('fetch-note').textContent.includes('connection'));

--- a/tools/page-harness.mjs
+++ b/tools/page-harness.mjs
@@ -837,3 +837,128 @@ check('a reconnect does not cancel a request the daemon has forgotten',
   sent.every(one => one.body.type !== 'download.cancel'));
 check('a reconnect reports the ended transfer',
   page.el('fetch-note').textContent.includes('connection'));
+
+// The picker looks only where the configuration says it may, and produces a
+// path for the fetch rather than fetching anything itself.
+const entries = () => page.el('picker-entries').children;
+const rootChips = () => page.el('picker-roots').children;
+const listing = (request, held) => deliver({
+  type: 'files.listing',
+  request,
+  target: { target: 'first', session: 'main' },
+  listing: held,
+});
+const lastRequest = type => sent.filter(one => one.body.type === type).at(-1).body.request;
+
+// A target that declares no roots offers no picker.
+deliver({
+  type: 'state.full',
+  state: {
+    targets: [{
+      key: { target: 'first', session: 'main' }, connection: 'live', roots: [],
+      snapshot: { workspaces: [], panes: [{ id: pane }], agents: [] },
+    }],
+  },
+});
+page.observe(pane, 'first/main/w1:p1');
+check('no configured roots offers no picker', page.el('picker').hidden === true);
+
+deliver({
+  type: 'state.full',
+  state: {
+    targets: [{
+      key: { target: 'first', session: 'main' }, connection: 'live',
+      roots: ['/srv/build', '/home/example/work'],
+      snapshot: { workspaces: [], panes: [{ id: pane }], agents: [] },
+    }],
+  },
+});
+page.observe(pane, 'first/main/w1:p1');
+check('configured roots offer a picker', page.el('picker').hidden === false);
+check('every configured root is offered', rootChips().length === 2);
+check('a root chip names its root', rootChips()[0].dataset.root === '/srv/build');
+
+sent.length = 0;
+rootChips()[0].onclick();
+const listed = sent.find(one => one.body.type === 'files.list');
+check('choosing a root asks for its own listing',
+  listed.body.root === '/srv/build' && listed.body.path === '');
+check('a listing names the qualified target',
+  listed.body.target.target === 'first' && listed.body.target.session === 'main');
+
+listing(listed.body.request, {
+  root: '/srv/build',
+  path: '',
+  entries: [
+    { kind: 'directory', name: 'reports' },
+    { kind: 'file', name: 'build.log' },
+    { kind: 'other', name: 'runner.sock' },
+  ],
+  truncated: false,
+});
+check('a listing shows every entry', entries().length === 3);
+check('a directory is marked as one', entries()[0].dataset.kind === 'directory');
+check('a directory is shown with a separator', entries()[0].children[0].textContent === 'reports/');
+check('a socket is listed and not offered', entries()[2].children[0].disabled === true);
+
+// Descending stays inside the root, and the way back up is built from the path
+// the daemon described rather than from wherever the page has been.
+sent.length = 0;
+entries()[0].children[0].onclick();
+check('descending asks for the subdirectory',
+  sent.find(one => one.body.type === 'files.list').body.path === 'reports');
+listing(lastRequest('files.list'), {
+  root: '/srv/build', path: 'reports',
+  entries: [{ kind: 'file', name: 'weekly.txt' }],
+  truncated: false,
+});
+check('a subdirectory offers a way back up', entries()[0].children[0].textContent === '../');
+check('the path is shown', page.el('picker-where').textContent === '/srv/build/reports');
+
+// Choosing a file fills the fetch path and fetches nothing.
+sent.length = 0;
+entries()[1].children[0].onclick();
+check('choosing a file fills the path',
+  page.el('fetch-path').value === '/srv/build/reports/weekly.txt');
+check('choosing a file fetches nothing',
+  sent.every(one => one.body.type !== 'download.begin'));
+
+sent.length = 0;
+entries()[0].children[0].onclick();
+check('going back up asks for the root again',
+  sent.find(one => one.body.type === 'files.list').body.path === '');
+
+// Search is scoped to the root, and a pattern is opt-in.
+sent.length = 0;
+page.el('picker-query').value = 'weekly';
+page.el('picker-search-form').onsubmit({ preventDefault() {} });
+const searched = sent.find(one => one.body.type === 'files.search');
+check('a search names its root and query',
+  searched.body.root === '/srv/build' && searched.body.query === 'weekly');
+check('a search is literal text by default', searched.body.glob === false);
+page.el('picker-glob').onclick();
+check('the pattern toggle reports itself', page.el('picker-glob')['aria-pressed'] === 'true');
+sent.length = 0;
+page.el('picker-query').value = '*.log';
+page.el('picker-search-form').onsubmit({ preventDefault() {} });
+check('a pattern search says so',
+  sent.find(one => one.body.type === 'files.search').body.glob === true);
+
+listing(lastRequest('files.search'), {
+  root: '/srv/build', path: '',
+  entries: [{ kind: 'file', name: 'reports/weekly.log' }],
+  truncated: true,
+});
+check('a search result keeps its path under the root',
+  entries()[0].children[0].textContent === 'reports/weekly.log');
+check('a search offers no way up', entries().length === 1);
+check('a truncated answer says so',
+  page.el('picker-note').textContent.includes('more than this list can show'));
+sent.length = 0;
+entries()[0].children[0].onclick();
+check('choosing a search result fills the whole path',
+  page.el('fetch-path').value === '/srv/build/reports/weekly.log');
+
+// The picker belongs to the pane being watched.
+page.observe({ target: 'first', session: 'main', resource: 'w1:p2' }, 'other');
+check('watching another pane clears the picker', entries().length === 0);


### PR DESCRIPTION
Stacked on #21.

Three transfer directions that had wire support and no caller anywhere.

## The gap

The transfer protocol has carried downloads since it was written — offer, pulled window, finish frame, flow control, digests. **No client ever asked.** The browser and the TUI both silently ignored every download message, and `TransferBetween` — the direction only the daemon can express, since only it holds live connections to both hosts — had never been reachable from any UI.

## Browser fetch (commit 1)

Two steps, deliberately: `download.begin` returns what the file *is* — name, length, and the digest the host computed — and the daemon sends nothing until pulled. So a person sees the size, the qualified source and the digest before a byte crosses the link, and a path naming a core dump is refused up front rather than discovered halfway through.

Verification is the receiving end's job because it is the only end that can. **A file that does not match is discarded, not offered with a warning** — a Save button beside a warning is a Save button people press.

## The picker (commit 2)

Finding the file is a separate, narrower surface. A target declares which directories may be browsed; one that declares none offers no picker, because a browser starting at `/` is one nobody asked for.

Worth a careful look:

- **Nothing is interpolated into a shell.** Every parameter travels on the remote script's stdin, the way the existing file read already works.
- **Containment is checked on the host** by comparing `pwd -P` — the physical path, symlinks resolved — against the root's own. A local string check would have missed a symlink out of the tree.
- **Output is NUL-framed**, so a name may contain a newline, and a record cut in half by the byte cap is dropped rather than half-read.
- **Roots bound browsing, not reading**, and the config comment says so. A paired device already holds pane control and can read anything its user can, so a root is a place worth looking rather than a permission boundary.

## Desktop save and host-to-host (commit 3)

`src/file_save.rs` holds the receiving end's bookkeeping, because a download that silently writes a truncated file is a bug nobody notices until they open the file — and one that is invisible in a screenshot of a TUI. Four failure modes it closes: nothing lands where a finished file goes until length *and* digest check out; the host's name is reduced to its last component (`../../etc/passwd` becomes `passwd`); an existing file is refused rather than renamed around; a host sending more than it offered is refused.

## One judgment call

The backlog asked for PDF preview. Text and images ship; **PDF does not**, because rendering one hands a file off somebody's host to the browser's scripted viewer inside this page, and the served page has no CSP. It is saved instead, and the backlog records that reasoning rather than sitting unchecked.

## Checks

384 tests · 191 page-harness assertions · fmt, clippy (host + macOS target), check-docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdRHimPZdtFsZgAnmpCRUE
