### PR TITLE
super-herdr doctor and cross-host plugin inventory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1112,6 +1112,40 @@ write into. Until such an envelope exists, transfers are initiated from the
 client, and Super-Herdr does not invent a side channel by scraping the pane's
 own output for markers.
 
+## Plugins across hosts
+
+Herdr installs plugins per host, so once somebody runs agents on three
+machines, "which of them has the review plugin, and is it the same one?" stops
+being answerable by looking. The usual answer — install it everywhere again and
+hope — is how versions drift apart quietly.
+
+Two things make this harder than diffing lists, and both are decisions rather
+than details. A `plugin_id` is server-local: two hosts can name unrelated
+plugins the same thing, and one plugin can be installed under different ids, so
+matching on it would report drift between things that were never the same
+plugin and silence between two copies of one. Identity here is therefore the
+*source* the plugin was installed from, and the id stays qualified by its
+target. And a plugin with no source has no identity to compare at all — a
+linked local plugin exists only where it was linked, so it is named as local to
+that host and never matched, because a name is not evidence that two
+directories hold the same code. A source is an identity only when it is
+complete; a partial one is discarded rather than half-matched.
+
+A version difference and a commit difference are reported separately, and never
+both for the same plugin: a version that did not change while the code did is
+the drift nobody would otherwise look for, while a version difference already
+explains a commit one. A host that could not be asked is a line in the report
+rather than the end of it, and is never counted as missing anything — an
+unreachable machine is not evidence, and treating it as one sends somebody to
+install a plugin that is already there.
+
+Nothing here installs anything. A lockfile records what one named host has,
+pinned to resolved commits rather than tags, because a tag can be moved and a
+branch certainly will. A plan prints the `herdr plugin install` commands that
+would close the gap and runs none of them: Herdr has an installer, and a second
+one would be a second thing to keep correct. Applying belongs to a command that
+asks per target, which does not exist yet.
+
 ## Diagnosing a layer
 
 Super-Herdr sits on several things it does not own: a configuration file, a

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1112,6 +1112,36 @@ write into. Until such an envelope exists, transfers are initiated from the
 client, and Super-Herdr does not invent a side channel by scraping the pane's
 own output for markers.
 
+## Diagnosing a layer
+
+Super-Herdr sits on several things it does not own: a configuration file, a
+Herdr on every host, SSH between them, a daemon socket, a browser route, and a
+desktop's clipboard and notification tools. When one of them is wrong the
+symptom is usually the same — something did not appear — and the layer it came
+from is the expensive part to work out. `super-herdr doctor` answers that in one
+pass, and never guesses on the strength of a symptom it did not check.
+
+It reports and never repairs. Every failed check carries the command somebody
+would run, and none of them run here: a diagnostic that changes the system is
+one people are afraid to run on a machine that is nearly working, which is
+exactly when it is most useful. If a `--fix` mode is ever added it will need a
+separate confirmation per mutation, and it must never stop or restart a Herdr
+session — that is somebody's running work.
+
+The output is meant to be pasted somewhere public. Host names, SSH
+destinations, socket paths, browser URLs and home directories are reduced to
+their shape; target names are kept, because they are the labels somebody chose
+and without them a report says a problem exists without saying where. Terminal
+contents, clipboard payloads, device tokens and pairing material do not appear
+at all, and no check reads any of them. `--json` emits the same metadata for a
+support bundle.
+
+Every network check is bounded and independent, so one unreachable host delays
+its own line and nothing else. Two checks exist because their failure is
+otherwise invisible until somebody tries: a Herdr older than protocol 20 is a
+warning rather than a failure, because everything except plugin actions works
+against it, and a host with no digest tool cannot verify a transfer at all.
+
 ## Security
 
 - OpenSSH configuration and host-key verification remain authoritative.

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -223,18 +223,21 @@ one controlled pane.
 
 ### 5. Unified diagnostics
 
-- [ ] Add a read-only `super-herdr doctor` command.
-- [ ] Check configuration permissions, Herdr executable/protocol compatibility,
-      SSH aliases, each target independently, the daemon socket, bridge route,
-      pairing prerequisites, clipboard tools, notification capability, and
-      transfer dependencies.
-- [ ] Bound and time out every network check.
-- [ ] Redact host details, credentials, authorization headers, private routes,
+- [x] Add a read-only `super-herdr doctor` command.
+- [x] Check configuration permissions, Herdr executable/protocol compatibility,
+      each target independently, the daemon socket, bridge route, pairing
+      prerequisites, clipboard tools, notification capability, and transfer
+      dependencies. SSH alias resolution is not checked separately: a target
+      that resolves is one the probe reached, and one that does not fails the
+      probe with ssh's own message, which is more useful than a second opinion.
+- [x] Bound and time out every network check.
+- [x] Redact host details, credentials, authorization headers, private routes,
       terminal contents, and pairing material from output.
-- [ ] Report corrective commands instead of changing the system automatically.
+- [x] Report corrective commands instead of changing the system automatically.
 - [ ] If a later `--fix` mode is added, require a separate confirmation for
-      every mutation and never stop or restart a Herdr session.
-- [ ] Add machine-readable output for support bundles containing metadata only.
+      every mutation and never stop or restart a Herdr session. No `--fix` mode
+      exists; this stays open as the constraint on adding one.
+- [x] Add machine-readable output for support bundles containing metadata only.
 
 Exit condition: a user can identify which layer is broken without exposing
 private material or affecting a healthy target.

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -244,17 +244,23 @@ private material or affecting a healthy target.
 
 ### 6. Cross-host plugin inventory and explicit sync
 
-- [ ] Read installed plugin inventory through documented Herdr CLI/socket
+- [x] Read installed plugin inventory through documented Herdr CLI/socket
       interfaces for each qualified target and session.
-- [ ] Show missing plugins and version drift without treating same-named
+- [x] Show missing plugins and version drift without treating same-named
       server-local plugin IDs as globally identical.
-- [ ] Add marketplace search and plugin-detail links.
-- [ ] Export a desired plugin set with pinned references and a lockfile.
-- [ ] Produce an installation/update plan before making changes.
-- [ ] Apply only to explicitly selected targets after confirmation.
-- [ ] Isolate errors per target and never roll back by stopping or restarting a
+- [x] Isolate errors per target and never roll back by stopping or restarting a
       Herdr session.
-- [ ] Do not import Herdr internals or duplicate its plugin installer.
+- [x] Do not import Herdr internals or duplicate its plugin installer.
+- [x] Export a desired plugin set with pinned references and a lockfile.
+- [x] Produce an installation/update plan before making changes.
+- [ ] Add plugin-detail links, and marketplace search. Detail links ship,
+      derived from the source Herdr reports. Search does not: Herdr documents
+      no marketplace or catalogue interface — `herdr plugin install` takes an
+      `owner/repo`, and there is nothing to query. Blocked upstream, like the
+      structured choices in step 2.
+- [ ] Apply only to explicitly selected targets after confirmation. The plan
+      exists and is printed; running it changes somebody's hosts and wants its
+      own branch and its own review.
 
 Exit condition: the operator can see and deliberately reconcile plugin drift
 across machines while one failing target leaves every other target usable.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ A card whose host has disconnected, or whose agent has ended, is shown and not
 offered — Super-Herdr resolves the live pane again before it routes anything,
 so a reconnect can never redirect your next keystroke.
 
+Run `super-herdr doctor` when something does not appear and you cannot tell
+which layer is at fault. It checks the configuration, every target
+independently, the daemon socket, the browser route, pairing, clipboard tools,
+notifications and transfer dependencies; reports the command to run for
+anything broken without running it; and redacts host names, destinations,
+paths and URLs so the output can be pasted into an issue. `--json` gives the
+same metadata for a support bundle.
+
 ## What is included
 
 - Concurrent discovery and supervision across local and SSH targets
@@ -177,6 +185,8 @@ so a reconnect can never redirect your next keystroke.
   opt-in pattern search that never leaves those roots
 - Desktop save from a target and host-to-host transfer that never touches this
   machine, both from the same right-click menus
+- `super-herdr doctor`: one read-only pass over every layer, with redacted
+  output and the command to run for anything broken
 - Configurable browser quick replies, terminal keys, a soft-keyboard dock, and
   a file picker
 - Digest-verified local-to-host, host-to-local, and host-to-host file transfer

--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ A card whose host has disconnected, or whose agent has ended, is shown and not
 offered — Super-Herdr resolves the live pane again before it routes anything,
 so a reconnect can never redirect your next keystroke.
 
+`super-herdr plugins list` shows what is installed on every host and what
+differs — missing plugins, version drift, and the same version built from
+different commits. Plugins are matched by where they were installed from
+rather than by the id a host gave them, so two hosts that happen to use the
+same name are not mistaken for one plugin. `plugins lock --from HOST` writes
+that host's set pinned to resolved commits, and `plugins plan --lock FILE`
+prints the `herdr plugin install` commands that would close the gap without
+running any of them.
+
 Run `super-herdr doctor` when something does not appear and you cannot tell
 which layer is at fault. It checks the configuration, every target
 independently, the daemon socket, the browser route, pairing, clipboard tools,
@@ -187,6 +196,8 @@ same metadata for a support bundle.
   machine, both from the same right-click menus
 - `super-herdr doctor`: one read-only pass over every layer, with redacted
   output and the command to run for anything broken
+- Cross-host plugin inventory, drift, a pinned lockfile, and a printed
+  install plan that runs nothing
 - Configurable browser quick replies, terminal keys, a soft-keyboard dock, and
   a file picker
 - Digest-verified local-to-host, host-to-local, and host-to-host file transfer

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,689 @@
+//! `super-herdr doctor`: which layer is broken, without exposing the machine.
+//!
+//! Super-Herdr sits on several things it does not own — a configuration file, a
+//! Herdr on every host, SSH between them, a daemon socket, a browser route, a
+//! desktop's clipboard and notification tools. When one of them is wrong the
+//! symptom is usually the same: something did not appear. This says which
+//! layer, in one pass, and never guesses on the strength of a symptom it did
+//! not check.
+//!
+//! Two rules shape what it prints:
+//!
+//! * **It reports, and never repairs.** Every failed check carries the command
+//!   somebody would run, and none of them run here. A diagnostic that changes
+//!   the system is one people are afraid to run on a machine that is nearly
+//!   working, which is exactly when it is most useful.
+//! * **The output is meant to be pasted somewhere public.** Host names, SSH
+//!   destinations, socket paths, browser URLs and home directories are
+//!   redacted to their shape. Target names are kept, because they are the
+//!   labels somebody chose and without them a report says a problem exists
+//!   without saying where.
+//!
+//! Terminal contents, clipboard payloads, device tokens and pairing material do
+//! not appear here at all, and no check reads any of them.
+
+use std::path::Path;
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::config::Config;
+use crate::probe::{self, ProbeReport};
+
+/// How long any one network check may take before it is reported as slow
+/// rather than waited on. A doctor that hangs is a doctor nobody runs twice.
+const NETWORK_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    Ok,
+    /// Works, but something will bite later.
+    Warn,
+    Fail,
+    /// Not checked, and why is in the detail. Distinct from `Ok` because
+    /// "nothing to check" and "checked and fine" are different sentences.
+    Skipped,
+}
+
+impl Status {
+    fn mark(self) -> &'static str {
+        match self {
+            Self::Ok => "ok  ",
+            Self::Warn => "warn",
+            Self::Fail => "FAIL",
+            Self::Skipped => "--  ",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Check {
+    pub area: String,
+    pub name: String,
+    pub status: Status,
+    pub detail: String,
+    /// What somebody would run to fix it. Never run here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remedy: Option<String>,
+}
+
+impl Check {
+    fn new(area: &str, name: &str, status: Status, detail: impl Into<String>) -> Self {
+        Self {
+            area: area.to_owned(),
+            name: name.to_owned(),
+            status,
+            detail: detail.into(),
+            remedy: None,
+        }
+    }
+
+    /// A line from a diagnostic that already knows how to describe itself.
+    ///
+    /// The clipboard and notification checks predate this command and produce
+    /// prose. Wrapping rather than reformatting keeps one description of each
+    /// subsystem instead of two that drift.
+    pub fn note(area: &str, line: String) -> Self {
+        let (name, detail) = line
+            .split_once(':')
+            .map(|(name, detail)| (name.trim().to_owned(), detail.trim().to_owned()))
+            .unwrap_or_else(|| (area.to_owned(), line.clone()));
+        // A subsystem that says it is unavailable or off is reported that way
+        // rather than as a passing check. Marking every imported line `ok`
+        // would make the report agree with itself and not with the machine.
+        let status = if detail.starts_with("unavailable") || detail == "disabled" {
+            Status::Skipped
+        } else {
+            Status::Ok
+        };
+        Self {
+            area: area.to_owned(),
+            name,
+            status,
+            detail,
+            remedy: None,
+        }
+    }
+
+    fn with_remedy(mut self, remedy: impl Into<String>) -> Self {
+        self.remedy = Some(remedy.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    pub checks: Vec<Check>,
+}
+
+impl Report {
+    pub fn failed(&self) -> bool {
+        self.checks.iter().any(|check| check.status == Status::Fail)
+    }
+
+    /// One line per check, plus the remedies underneath the ones that need
+    /// them. Written to be read in a terminal and pasted into an issue.
+    ///
+    /// Grouped by area in the order each area first appears, rather than in
+    /// the order checks were produced: the local checks and the probes both
+    /// describe targets, and a report that names that heading twice reads as
+    /// two different subjects.
+    pub fn render(&self) -> String {
+        let mut areas: Vec<&str> = Vec::new();
+        for check in &self.checks {
+            if !areas.contains(&check.area.as_str()) {
+                areas.push(&check.area);
+            }
+        }
+        let mut rendered = String::new();
+        for area in areas {
+            if !rendered.is_empty() {
+                rendered.push('\n');
+            }
+            rendered.push_str(&format!("{area}\n"));
+            for check in self.checks.iter().filter(|check| check.area == area) {
+                rendered.push_str(&format!(
+                    "  {} {}: {}\n",
+                    check.status.mark(),
+                    check.name,
+                    check.detail
+                ));
+                if let Some(remedy) = &check.remedy {
+                    rendered.push_str(&format!("       try: {remedy}\n"));
+                }
+            }
+        }
+        rendered
+    }
+}
+
+/// Describe a path without saying where it is.
+///
+/// A path is evidence of shape — that it is set, roughly how long, and what
+/// kind of thing it names — and the rest of it is somebody's username and
+/// directory layout. Kept as a helper rather than inlined so that adding a
+/// check cannot accidentally print one.
+pub fn redact_path(path: &Path) -> String {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "?".to_owned());
+    format!("…/{name}")
+}
+
+/// Describe a destination without naming a host.
+pub fn redact_destination(destination: &str) -> String {
+    let shape = if destination.contains('@') {
+        "user@host"
+    } else {
+        "host"
+    };
+    format!("<{shape}, {} chars>", destination.chars().count())
+}
+
+/// Describe a URL by its scheme only.
+pub fn redact_url(url: &str) -> String {
+    match url.split_once("://") {
+        Some((scheme, _)) => format!("<{scheme} url>"),
+        None => "<url>".to_owned(),
+    }
+}
+
+/// Run every check that does not need the network.
+///
+/// Split from the target probe so a test can assert what this says without a
+/// host to say it about, and so the slow part is visibly the slow part.
+pub fn local_checks(config: &Config, config_path: &Path, socket: Option<&Path>) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    checks.push(Check::new(
+        "configuration",
+        "file",
+        Status::Ok,
+        format!("read {}", redact_path(config_path)),
+    ));
+    checks.push(match config_permissions(config_path) {
+        Some(mode) if mode & 0o077 != 0 => Check::new(
+            "configuration",
+            "permissions",
+            Status::Warn,
+            format!("mode {mode:04o} is readable by other users"),
+        )
+        .with_remedy(format!("chmod 600 {}", redact_path(config_path))),
+        Some(mode) => Check::new(
+            "configuration",
+            "permissions",
+            Status::Ok,
+            format!("mode {mode:04o}"),
+        ),
+        None => Check::new(
+            "configuration",
+            "permissions",
+            Status::Skipped,
+            "not applicable on this platform",
+        ),
+    });
+    checks.push(match config.validate() {
+        Ok(()) => Check::new(
+            "configuration",
+            "contents",
+            Status::Ok,
+            format!("{} target(s) configured", config.targets.len()),
+        ),
+        Err(error) => Check::new("configuration", "contents", Status::Fail, error.to_string())
+            .with_remedy("super-herdr check".to_owned()),
+    });
+
+    for target in &config.targets {
+        let where_ = match target.ssh.as_deref() {
+            Some(destination) => format!("over SSH to {}", redact_destination(destination)),
+            None => "on this machine".to_owned(),
+        };
+        checks.push(Check::new(
+            "targets",
+            &target.name,
+            Status::Ok,
+            format!(
+                "{where_}; {} herdr candidate(s); {}",
+                target.herdr_bins.len(),
+                if target.discover_sessions {
+                    "sessions discovered"
+                } else {
+                    "one session"
+                }
+            ),
+        ));
+        if !target.roots.is_empty() {
+            checks.push(Check::new(
+                "targets",
+                &format!("{} file roots", target.name),
+                Status::Ok,
+                format!("{} configured", target.roots.len()),
+            ));
+        }
+    }
+
+    checks.push(match socket {
+        Some(path) if path.exists() => Check::new(
+            "daemon",
+            "socket",
+            Status::Ok,
+            format!("present at {}", redact_path(path)),
+        ),
+        Some(path) => Check::new(
+            "daemon",
+            "socket",
+            Status::Skipped,
+            format!(
+                "no socket at {}; the daemon is not running",
+                redact_path(path)
+            ),
+        )
+        .with_remedy("super-herdr daemon".to_owned()),
+        None => Check::new(
+            "daemon",
+            "socket",
+            Status::Skipped,
+            "no runtime directory to hold one",
+        ),
+    });
+
+    checks.push(browser_route(config));
+    checks.push(match config.devices.len() {
+        0 => Check::new(
+            "pairing",
+            "devices",
+            Status::Skipped,
+            "no device paired yet",
+        )
+        .with_remedy("pair from the TUI with Ctrl+] then P".to_owned()),
+        count => Check::new("pairing", "devices", Status::Ok, format!("{count} paired")),
+    });
+
+    checks
+}
+
+fn browser_route(config: &Config) -> Check {
+    if config.web.port == Some(0) {
+        return Check::new(
+            "browser",
+            "route",
+            Status::Skipped,
+            "web.port = 0 serves no browser client",
+        );
+    }
+    match (config.web.url.as_deref(), config.web.address) {
+        (Some(url), _) => Check::new(
+            "browser",
+            "route",
+            Status::Ok,
+            format!("operator-managed proxy at {}", redact_url(url)),
+        ),
+        (None, Some(_)) => Check::new(
+            "browser",
+            "route",
+            Status::Ok,
+            "direct listener on a configured address",
+        ),
+        (None, None) if config.web.bridge => Check::new(
+            "browser",
+            "route",
+            Status::Ok,
+            "hosted bridge; TLS terminates there, so it is a trusted relay",
+        ),
+        (None, None) => Check::new(
+            "browser",
+            "route",
+            Status::Warn,
+            "no bridge and no address; a phone on another network cannot reach this daemon",
+        )
+        .with_remedy("set web.bridge = true, or web.address for a private route".to_owned()),
+    }
+}
+
+/// Turn one target probe into a check, keeping hosts out of the text.
+pub fn target_check(report: &ProbeReport) -> Check {
+    if !report.ok {
+        let detail = report
+            .error
+            .as_deref()
+            .unwrap_or("no snapshot")
+            .lines()
+            .next()
+            .unwrap_or("no snapshot")
+            .to_owned();
+        return Check::new("targets", &report.target, Status::Fail, detail).with_remedy(format!(
+            "super-herdr probe --timeout 30 # {}",
+            report.target
+        ));
+    }
+    let version = report.herdr_version.as_deref().unwrap_or("unknown");
+    let protocol = report
+        .protocol
+        .map(|protocol| protocol.to_string())
+        .unwrap_or_else(|| "unknown".to_owned());
+    let status = if report.protocol.is_some_and(|protocol| protocol < 20) {
+        Status::Warn
+    } else {
+        Status::Ok
+    };
+    let detail = format!(
+        "herdr {version}, protocol {protocol}, {} pane(s), {} agent(s), {} ms",
+        report.panes, report.agents, report.elapsed_ms
+    );
+    let check = Check::new("targets", &report.target, status, detail);
+    if status == Status::Warn {
+        return check.with_remedy(
+            "upgrade Herdr on that host to 0.8.2 or newer for plugin actions".to_owned(),
+        );
+    }
+    check
+}
+
+/// The tools a target needs for file transfers to work.
+///
+/// Worth its own check because the failure is invisible until somebody tries:
+/// the transfer scripts hash on the host, and a host with no digest tool at all
+/// fails every transfer with an error about a script rather than about a
+/// missing program.
+pub fn transfer_tools_check(target: &str, tools: &[&str]) -> Check {
+    match tools.first() {
+        Some(tool) => Check::new(
+            "transfers",
+            target,
+            Status::Ok,
+            format!("digests with {tool}"),
+        ),
+        None => Check::new(
+            "transfers",
+            target,
+            Status::Fail,
+            "no sha256sum, shasum or openssl; file transfers cannot be verified",
+        )
+        .with_remedy("install coreutils or openssl on that host".to_owned()),
+    }
+}
+
+/// Ask a host which digest tool it has.
+///
+/// The parameterless script is fixed text and reads nothing from the wire, so
+/// there is nothing here to quote. A host that answers with none is one whose
+/// transfers cannot be verified, which is worth knowing before somebody tries.
+const DIGEST_TOOLS_SCRIPT: &str = r#"set -eu
+for tool in sha256sum shasum openssl; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    printf '%s
+' "$tool"
+  fi
+done
+"#;
+
+pub async fn digest_tools(
+    target: &crate::config::Target,
+    transport: &crate::config::TransportConfig,
+) -> Vec<String> {
+    use std::process::Stdio;
+
+    use tokio::process::Command;
+
+    let mut command = match target.ssh.as_deref() {
+        Some(destination) => crate::transport::build_ssh_command(
+            destination,
+            transport,
+            DIGEST_TOOLS_SCRIPT.to_owned(),
+        ),
+        None => {
+            let mut command = Command::new("/bin/sh");
+            command.arg("-c").arg(DIGEST_TOOLS_SCRIPT);
+            command
+        }
+    };
+    let Ok(child) = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+    else {
+        return Vec::new();
+    };
+    let Ok(Ok(output)) = tokio::time::timeout(NETWORK_TIMEOUT, child.wait_with_output()).await
+    else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Probe every target, each on its own bounded clock.
+pub async fn probe_targets(config: &Config, timeout: Option<Duration>) -> Vec<Check> {
+    let timeout = timeout.unwrap_or(NETWORK_TIMEOUT);
+    match probe::probe_all(config, timeout).await {
+        Ok(reports) => reports.iter().map(target_check).collect(),
+        Err(error) => vec![
+            Check::new("targets", "probe", Status::Fail, error.to_string())
+                .with_remedy("super-herdr check".to_owned()),
+        ],
+    }
+}
+
+#[cfg(target_family = "unix")]
+fn config_permissions(path: &Path) -> Option<u32> {
+    use std::os::unix::fs::PermissionsExt;
+    Some(std::fs::metadata(path).ok()?.permissions().mode() & 0o7777)
+}
+
+#[cfg(not(target_family = "unix"))]
+fn config_permissions(_path: &Path) -> Option<u32> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{
+        Check, Report, Status, local_checks, redact_destination, redact_path, redact_url,
+        target_check, transfer_tools_check,
+    };
+    use crate::config::Config;
+    use crate::probe::ProbeReport;
+
+    fn config(text: &str) -> Config {
+        Config::parse(text).unwrap()
+    }
+
+    fn probe(ok: bool, protocol: Option<u64>) -> ProbeReport {
+        ProbeReport {
+            target: "development".to_owned(),
+            endpoint: "example-host".to_owned(),
+            session: "work".to_owned(),
+            ok,
+            elapsed_ms: 12,
+            herdr_bin: Some("/home/example/.local/bin/herdr".to_owned()),
+            herdr_version: Some("0.8.0".to_owned()),
+            protocol,
+            workspaces: 1,
+            tabs: 1,
+            panes: 2,
+            agents: 1,
+            workspace_ids: Vec::new(),
+            error: (!ok).then(|| "ssh: connect to host example.com: refused".to_owned()),
+            snapshot: None,
+        }
+    }
+
+    #[test]
+    fn a_report_says_where_a_machine_is_without_saying_which_machine() {
+        assert_eq!(
+            redact_path(Path::new("/home/someone/.config/x.toml")),
+            "…/x.toml"
+        );
+        assert_eq!(
+            redact_destination("deploy@build.internal.example"),
+            "<user@host, 29 chars>"
+        );
+        assert_eq!(redact_destination("buildhost"), "<host, 9 chars>");
+        assert_eq!(redact_url("https://relay.example/r/abc"), "<https url>");
+    }
+
+    #[test]
+    fn a_configuration_other_users_can_read_is_a_warning_with_a_command() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("config.toml");
+        std::fs::write(&path, "").unwrap();
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        let checks = local_checks(
+            &config("[[targets]]\nname = \"one\"\nssh = \"host\"\n"),
+            &path,
+            None,
+        );
+
+        let permissions = checks
+            .iter()
+            .find(|check| check.name == "permissions")
+            .unwrap();
+        #[cfg(target_family = "unix")]
+        {
+            assert_eq!(permissions.status, Status::Warn);
+            assert!(
+                permissions
+                    .remedy
+                    .as_deref()
+                    .unwrap()
+                    .starts_with("chmod 600")
+            );
+            assert!(
+                !permissions.remedy.as_deref().unwrap().contains("someone"),
+                "even a remedy is something somebody pastes into an issue"
+            );
+        }
+        #[cfg(not(target_family = "unix"))]
+        assert_eq!(permissions.status, Status::Skipped);
+    }
+
+    #[test]
+    fn a_target_is_described_without_naming_its_host() {
+        let checks = local_checks(
+            &config("[[targets]]\nname = \"build\"\nssh = \"deploy@build.internal\"\n"),
+            Path::new("/home/someone/.config/super-herdr/config.toml"),
+            None,
+        );
+
+        let target = checks.iter().find(|check| check.name == "build").unwrap();
+        assert!(target.detail.contains("<user@host"));
+        assert!(
+            !target.detail.contains("build.internal"),
+            "a target's own label is kept; the host it names is not"
+        );
+    }
+
+    #[test]
+    fn an_unreachable_target_reports_one_line_and_a_command() {
+        let check = target_check(&probe(false, None));
+
+        assert_eq!(check.status, Status::Fail);
+        assert_eq!(check.detail, "ssh: connect to host example.com: refused");
+        assert!(check.remedy.is_some(), "a failure says what to run next");
+    }
+
+    #[test]
+    fn a_target_too_old_for_plugin_actions_is_a_warning_rather_than_a_failure() {
+        assert_eq!(target_check(&probe(true, Some(19))).status, Status::Warn);
+        assert_eq!(target_check(&probe(true, Some(20))).status, Status::Ok);
+    }
+
+    #[test]
+    fn a_host_with_no_digest_tool_cannot_verify_a_transfer() {
+        assert_eq!(
+            transfer_tools_check("build", &["sha256sum"]).status,
+            Status::Ok
+        );
+        let missing = transfer_tools_check("build", &[]);
+        assert_eq!(missing.status, Status::Fail);
+        assert!(missing.remedy.is_some());
+    }
+
+    #[test]
+    fn a_daemon_with_no_route_out_is_a_warning_a_phone_would_hit() {
+        let checks = local_checks(
+            &config("[web]\nbridge = false\n\n[[targets]]\nname = \"one\"\nssh = \"host\"\n"),
+            Path::new("/tmp/config.toml"),
+            None,
+        );
+
+        let route = checks.iter().find(|check| check.area == "browser").unwrap();
+        assert_eq!(route.status, Status::Warn);
+        assert!(route.detail.contains("another network"));
+    }
+
+    #[test]
+    fn one_area_is_one_heading_however_the_checks_arrived() {
+        let report = Report {
+            checks: vec![
+                Check::new("targets", "build", Status::Ok, "configured"),
+                Check::new("daemon", "socket", Status::Ok, "present"),
+                Check::new("targets", "build reachability", Status::Ok, "12 ms"),
+            ],
+        };
+
+        let rendered = report.render();
+
+        assert_eq!(
+            rendered.matches("targets\n").count(),
+            1,
+            "a heading printed twice reads as two different subjects"
+        );
+        let targets = rendered.find("targets\n").unwrap();
+        assert!(rendered[targets..].contains("build reachability"));
+    }
+
+    #[test]
+    fn an_imported_line_is_reported_as_the_subsystem_describes_itself() {
+        assert_eq!(
+            Check::note(
+                "clipboard",
+                "paste action: unavailable to a nested process".to_owned()
+            )
+            .status,
+            Status::Skipped,
+            "reporting every imported line as ok would agree with the report and not the machine"
+        );
+        assert_eq!(
+            Check::note("notifications", "notifications: disabled".to_owned()).status,
+            Status::Skipped
+        );
+        assert_eq!(
+            Check::note("clipboard", "copy: OSC 52 terminal request".to_owned()).status,
+            Status::Ok
+        );
+    }
+
+    #[test]
+    fn a_report_renders_grouped_lines_and_reports_whether_anything_failed() {
+        let report = Report {
+            checks: vec![
+                Check::new("configuration", "file", Status::Ok, "read …/config.toml"),
+                Check::new("targets", "build", Status::Fail, "unreachable")
+                    .with_remedy("super-herdr probe"),
+            ],
+        };
+
+        let rendered = report.render();
+
+        assert!(rendered.contains("configuration\n  ok   file:"));
+        assert!(rendered.contains("FAIL build: unreachable"));
+        assert!(rendered.contains("try: super-herdr probe"));
+        assert!(report.failed());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod clipboard;
 pub mod config;
 pub mod daemon;
+pub mod doctor;
 pub mod file_save;
 pub mod model;
 pub mod notifications;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod notifications;
 pub mod operation;
 pub mod pairing;
 pub mod plugin;
+pub mod plugin_fleet;
 pub mod probe;
 pub mod protocol;
 pub mod remote_files;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,11 @@ enum Commands {
         #[arg(long, value_name = "SECONDS")]
         timeout: Option<u64>,
     },
+    /// Inspect plugins across every configured host.
+    Plugins {
+        #[command(subcommand)]
+        command: PluginCommands,
+    },
     /// Report which layer is broken, without changing anything.
     Doctor {
         /// Emit one machine-readable report of metadata only.
@@ -109,6 +114,31 @@ enum Commands {
     Target {
         #[command(subcommand)]
         command: TargetCommands,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum PluginCommands {
+    /// List what is installed where, and what differs.
+    List {
+        /// Emit one machine-readable inventory.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Write down one host's plugins as the set to reproduce elsewhere.
+    Lock {
+        /// The target whose plugins are the desired set.
+        #[arg(long, value_name = "NAME")]
+        from: String,
+    },
+    /// Show what it would take to bring hosts to a lockfile. Runs nothing.
+    Plan {
+        /// A lockfile written by `super-herdr plugins lock`.
+        #[arg(long, value_name = "PATH")]
+        lock: PathBuf,
+        /// Restrict the plan to these targets; every target by default.
+        #[arg(long = "target", value_name = "NAME")]
+        targets: Vec<String>,
     },
 }
 
@@ -231,6 +261,112 @@ enum TargetCommands {
     List,
 }
 
+/// Ask every configured host what it has installed, each on its own clock.
+///
+/// One host failing is one line in the report rather than the end of it: a
+/// fleet report where an unreachable machine hides the other five is one
+/// nobody can act on.
+async fn plugin_inventory(
+    config: &Config,
+    timeout: Duration,
+) -> super_herdr::plugin_fleet::Inventory {
+    let mut inventory = super_herdr::plugin_fleet::Inventory::default();
+    for target in &config.targets {
+        let key = super_herdr::state::target_key(target);
+        match super_herdr::plugin::installed(target, &config.transport, timeout).await {
+            Ok(plugins) => {
+                inventory.installed.insert(key, plugins);
+            }
+            Err(error) => {
+                inventory.errors.insert(key, error.to_string());
+            }
+        }
+    }
+    inventory
+}
+
+fn render_inventory(inventory: &super_herdr::plugin_fleet::Inventory) -> String {
+    use super_herdr::plugin_fleet::Drift;
+
+    let mut rendered = String::new();
+    for (target, plugins) in &inventory.installed {
+        rendered.push_str(&format!("{target}\n"));
+        if plugins.is_empty() {
+            rendered.push_str("  no plugins installed\n");
+        }
+        for plugin in plugins {
+            rendered.push_str(&format!(
+                "  {} {}{}{}\n",
+                plugin.name,
+                plugin.version,
+                plugin
+                    .source
+                    .as_ref()
+                    .map(|source| format!("  {source}"))
+                    .unwrap_or_else(|| "  (linked locally)".to_owned()),
+                if plugin.enabled { "" } else { "  [disabled]" }
+            ));
+        }
+    }
+    for (target, error) in &inventory.errors {
+        rendered.push_str(&format!("{target}\n  could not be asked: {error}\n"));
+    }
+
+    let drift = inventory.drift();
+    if drift.is_empty() && inventory.errors.is_empty() {
+        rendered.push_str("\nEvery host that answered agrees.\n");
+        return rendered;
+    }
+    if !drift.is_empty() {
+        rendered.push_str("\ndifferences\n");
+    }
+    for one in &drift {
+        rendered.push_str(&match one {
+            Drift::Missing {
+                source,
+                absent_from,
+                ..
+            } => format!(
+                "  {source} is not installed on {}\n",
+                absent_from
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Drift::Version { source, versions } => format!(
+                "  {source} differs: {}\n",
+                versions
+                    .iter()
+                    .map(|(version, targets)| format!("{version} on {}", targets.len()))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            ),
+            Drift::Commit { source, commits } => format!(
+                "  {source} is one version built from {} different commits\n",
+                commits.len()
+            ),
+            Drift::Disabled {
+                source,
+                disabled_on,
+            } => format!(
+                "  {source} is switched off on {}\n",
+                disabled_on
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Drift::LocalOnly {
+                target,
+                name,
+                plugin_id,
+            } => format!("  {name} ({plugin_id}) is linked locally on {target} only\n"),
+        });
+    }
+    rendered
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     match run().await {
@@ -314,6 +450,81 @@ async fn run() -> Result<ExitCode> {
                 ))?;
             }
             Ok(ExitCode::SUCCESS)
+        }
+        Commands::Plugins { command } => {
+            let expanded = expand_discovered_sessions(config).await;
+            let timeout = Duration::from_secs(expanded.transport.command_timeout_seconds);
+            let inventory = plugin_inventory(&expanded, timeout).await;
+            match command {
+                PluginCommands::List { json } => {
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "inventory": inventory,
+                                "drift": inventory.drift(),
+                            }))?
+                        );
+                    } else {
+                        print!("{}", render_inventory(&inventory));
+                    }
+                    // One unreachable host is a failure worth an exit code,
+                    // and the hosts that answered are still reported above it.
+                    Ok(if inventory.errors.is_empty() {
+                        ExitCode::SUCCESS
+                    } else {
+                        ExitCode::FAILURE
+                    })
+                }
+                PluginCommands::Lock { from } => {
+                    let key = expanded
+                        .targets
+                        .iter()
+                        .map(super_herdr::state::target_key)
+                        .find(|key| key.target == from)
+                        .with_context(|| format!("no configured target named {from:?}"))?;
+                    let lockfile = inventory
+                        .lockfile(&key)
+                        .with_context(|| format!("{from} reported no plugins"))?;
+                    println!("{}", serde_json::to_string_pretty(&lockfile)?);
+                    Ok(ExitCode::SUCCESS)
+                }
+                PluginCommands::Plan { lock, targets } => {
+                    let text = std::fs::read_to_string(&lock)
+                        .with_context(|| format!("failed to read {}", lock.display()))?;
+                    let lockfile: super_herdr::plugin_fleet::Lockfile =
+                        serde_json::from_str(&text).context("that lockfile is not valid")?;
+                    let wanted = expanded
+                        .targets
+                        .iter()
+                        .map(super_herdr::state::target_key)
+                        .filter(|key| targets.is_empty() || targets.contains(&key.target))
+                        .collect::<Vec<_>>();
+                    let steps = inventory.plan(&lockfile, &wanted);
+                    if steps.is_empty() {
+                        println!("Every named host already holds this set.");
+                    }
+                    for step in &steps {
+                        println!(
+                            "{} {} on {}{}",
+                            match step.action {
+                                super_herdr::plugin_fleet::PlanAction::Install => "install",
+                                super_herdr::plugin_fleet::PlanAction::Update => "update",
+                            },
+                            step.source,
+                            step.target,
+                            step.from
+                                .as_deref()
+                                .map(|from| format!(" (from {from})"))
+                                .unwrap_or_default()
+                        );
+                        println!("    {}", step.command);
+                    }
+                    // Printed and not run. Applying belongs to a command that
+                    // asks first, per target, and does not exist yet.
+                    Ok(ExitCode::SUCCESS)
+                }
+            }
         }
         Commands::Doctor { json, timeout } => {
             let socket = DaemonOptions::discover().ok().map(|options| options.socket);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use clap::{Parser, Subcommand};
 use super_herdr::clipboard;
 use super_herdr::config::{Config, Target};
 use super_herdr::daemon::{DaemonOptions, serve};
+use super_herdr::doctor;
 use super_herdr::notifications;
 use super_herdr::probe::{FederationReport, probe_all};
 use super_herdr::transport::expand_discovered_sessions;
@@ -57,6 +58,15 @@ enum Commands {
         #[arg(long, requires = "json")]
         snapshots: bool,
         /// Override the configured command timeout.
+        #[arg(long, value_name = "SECONDS")]
+        timeout: Option<u64>,
+    },
+    /// Report which layer is broken, without changing anything.
+    Doctor {
+        /// Emit one machine-readable report of metadata only.
+        #[arg(long)]
+        json: bool,
+        /// Override the per-check network timeout.
         #[arg(long, value_name = "SECONDS")]
         timeout: Option<u64>,
     },
@@ -304,6 +314,40 @@ async fn run() -> Result<ExitCode> {
                 ))?;
             }
             Ok(ExitCode::SUCCESS)
+        }
+        Commands::Doctor { json, timeout } => {
+            let socket = DaemonOptions::discover().ok().map(|options| options.socket);
+            let mut checks = doctor::local_checks(&config, &path, socket.as_deref());
+            let expanded = expand_discovered_sessions(config).await;
+            let timeout = timeout.map(Duration::from_secs);
+            checks.extend(doctor::probe_targets(&expanded, timeout).await);
+            for target in &expanded.targets {
+                let tools = doctor::digest_tools(target, &expanded.transport).await;
+                checks.push(doctor::transfer_tools_check(
+                    &target.name,
+                    &tools.iter().map(String::as_str).collect::<Vec<_>>(),
+                ));
+            }
+            for line in clipboard::diagnostic_lines(None).await {
+                checks.push(doctor::Check::note("clipboard", line));
+            }
+            for line in notifications::diagnostic_lines(&expanded.notifications).await {
+                checks.push(doctor::Check::note("notifications", line));
+            }
+
+            let report = doctor::Report { checks };
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                print!("{}", report.render());
+            }
+            // A failing check is an exit code, so this can sit in a script
+            // without anybody parsing the text.
+            Ok(if report.failed() {
+                ExitCode::FAILURE
+            } else {
+                ExitCode::SUCCESS
+            })
         }
         Commands::Probe {
             json,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -17,6 +17,8 @@ use crate::model::{PaneId, TabId, TargetSession, WorkspaceId};
 use crate::transport::{ApiSession, SnapshotError};
 
 const MAX_PLUGIN_ACTIONS: usize = 512;
+
+use crate::plugin_fleet::{InstalledPlugin, MAX_PLUGINS_PER_TARGET, PluginSource};
 const MAX_PLUGIN_RUNS: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -155,6 +157,134 @@ pub async fn list(
     })
     .await
     .map_err(|_| SnapshotError::timed_out(request_timeout))?
+}
+
+/// What is installed on one host, through Herdr's documented `plugin.list`.
+///
+/// Separate from the action registry because it answers a different question:
+/// the registry says what a pane can be asked to do right now, and this says
+/// what somebody installed and where it came from. The command arrays that the
+/// action path strips are not present here at all.
+pub async fn installed(
+    target: &Target,
+    transport: &TransportConfig,
+    request_timeout: Duration,
+) -> Result<Vec<InstalledPlugin>, SnapshotError> {
+    timeout(request_timeout, async {
+        let mut session = ApiSession::open(target, transport, request_timeout).await?;
+        let value = session.request("plugin.list", json!({})).await?;
+        parse_installed(value)
+    })
+    .await
+    .map_err(|_| SnapshotError::timed_out(request_timeout))?
+}
+
+fn parse_installed(value: Value) -> Result<Vec<InstalledPlugin>, SnapshotError> {
+    let listed: PluginList = serde_json::from_value(value)
+        .map_err(|_| SnapshotError::unavailable("Herdr returned an invalid plugin list"))?;
+    if listed.kind != "plugin_list" {
+        return Err(SnapshotError::unavailable(
+            "Herdr returned an unexpected plugin list response",
+        ));
+    }
+    if listed.plugins.len() > MAX_PLUGINS_PER_TARGET {
+        return Err(SnapshotError::unavailable(format!(
+            "Herdr reported more than {MAX_PLUGINS_PER_TARGET} plugins"
+        )));
+    }
+    Ok(listed
+        .plugins
+        .into_iter()
+        .map(|plugin| InstalledPlugin {
+            plugin_id: bounded(&plugin.plugin_id),
+            name: bounded(&plugin.name),
+            version: bounded(&plugin.version),
+            enabled: plugin.enabled,
+            requested_ref: plugin.requested_ref_of(),
+            resolved_commit: plugin.resolved_commit_of(),
+            // A source is an identity only when it is complete. A partial one
+            // would let two different plugins agree on whatever half of it
+            // arrived, which is the collision this whole module exists to
+            // avoid — so anything missing a field is no source at all.
+            source: plugin.source.as_ref().and_then(|source| {
+                Some(PluginSource {
+                    kind: bounded(source.kind.as_deref()?),
+                    owner: bounded(source.owner.as_deref()?),
+                    repo: bounded(source.repo.as_deref()?),
+                    subdir: source.subdir.as_deref().map(bounded),
+                })
+            }),
+            warnings: plugin
+                .warnings
+                .iter()
+                .take(8)
+                .map(|warning| bounded(warning))
+                .collect(),
+        })
+        .collect())
+}
+
+fn bounded(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .take(256)
+        .collect()
+}
+
+#[derive(Deserialize)]
+struct PluginList {
+    #[serde(rename = "type")]
+    kind: String,
+    plugins: Vec<ListedPlugin>,
+}
+
+#[derive(Deserialize)]
+struct ListedPlugin {
+    plugin_id: String,
+    name: String,
+    version: String,
+    enabled: bool,
+    #[serde(default)]
+    source: Option<ListedSource>,
+    #[serde(default)]
+    warnings: Vec<String>,
+}
+
+impl ListedPlugin {
+    fn requested_ref_of(&self) -> Option<String> {
+        self.source.as_ref()?.requested_ref.as_deref().map(bounded)
+    }
+
+    fn resolved_commit_of(&self) -> Option<String> {
+        self.source
+            .as_ref()?
+            .resolved_commit
+            .as_deref()
+            .map(bounded)
+    }
+}
+
+#[derive(Deserialize)]
+struct ListedSource {
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    owner: Option<String>,
+    #[serde(default)]
+    repo: Option<String>,
+    #[serde(default)]
+    subdir: Option<String>,
+    #[serde(default)]
+    requested_ref: Option<String>,
+    #[serde(default)]
+    resolved_commit: Option<String>,
 }
 
 fn parse_list(target: &TargetSession, value: Value) -> Result<Vec<PluginAction>, SnapshotError> {
@@ -547,6 +677,74 @@ fn insert_optional(context: &mut Map<String, Value>, field: &str, value: Option<
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_source_missing_a_field_is_no_source_at_all() {
+        let value = serde_json::json!({
+            "type": "plugin_list",
+            "plugins": [
+                {
+                    "plugin_id": "complete", "name": "complete", "version": "1.0",
+                    "enabled": true,
+                    "source": {
+                        "kind": "github", "owner": "alice", "repo": "review",
+                        "requested_ref": "v1", "resolved_commit": "abc"
+                    }
+                },
+                {
+                    "plugin_id": "partial", "name": "partial", "version": "1.0",
+                    "enabled": true,
+                    "source": {"kind": "github", "owner": "alice"}
+                },
+                {"plugin_id": "linked", "name": "linked", "version": "0.1", "enabled": false}
+            ]
+        });
+
+        let plugins = super::parse_installed(value).unwrap();
+
+        assert_eq!(
+            plugins[0].source.as_ref().unwrap().to_string(),
+            "alice/review"
+        );
+        assert_eq!(plugins[0].resolved_commit.as_deref(), Some("abc"));
+        assert!(
+            plugins[1].source.is_none(),
+            "half an identity would let two different plugins agree on the half that arrived"
+        );
+        assert!(plugins[2].source.is_none());
+        assert!(!plugins[2].enabled);
+    }
+
+    #[test]
+    fn a_host_reporting_absurdly_many_plugins_is_refused() {
+        let plugins = (0..super::MAX_PLUGINS_PER_TARGET + 1)
+            .map(|index| {
+                serde_json::json!({
+                    "plugin_id": format!("p{index}"), "name": "p", "version": "1",
+                    "enabled": true
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            super::parse_installed(serde_json::json!({
+                "type": "plugin_list",
+                "plugins": plugins
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn an_unexpected_response_is_not_read_as_a_plugin_list() {
+        assert!(
+            super::parse_installed(serde_json::json!({
+                "type": "plugin_action_list",
+                "plugins": []
+            }))
+            .is_err()
+        );
+    }
+
     use serde_json::json;
 
     use super::{

--- a/src/plugin_fleet.rs
+++ b/src/plugin_fleet.rs
@@ -1,0 +1,633 @@
+//! What is installed where, across every host, and what differs.
+//!
+//! Herdr installs plugins per host. Once somebody runs agents on three
+//! machines, "which of them has the review plugin, and is it the same one?"
+//! stops being answerable by looking, and the usual answer — install it
+//! everywhere again and hope — is how versions drift apart quietly.
+//!
+//! Two things make this harder than diffing lists, and both are decisions
+//! rather than details:
+//!
+//! * **A plugin id is server-local.** Herdr's `plugin_id` identifies a plugin
+//!   *on one host*. Two hosts can name unrelated plugins the same thing, and
+//!   the same plugin can be installed under different ids. Matching on it would
+//!   report drift between things that were never the same plugin, and silence
+//!   between two copies of one. So identity here is the *source* — where it was
+//!   installed from — and the id stays qualified by the target it came from.
+//! * **A plugin with no source has no identity to compare.** A linked local
+//!   plugin exists only on the host it was linked on. It is reported as local
+//!   to that host and never matched against anything, because a name is not
+//!   evidence that two directories hold the same code.
+//!
+//! Nothing here installs anything. It produces a lockfile of what somebody has
+//! decided they want and a plan of the commands that would get there — Herdr's
+//! own `herdr plugin install` commands, because Herdr has an installer and
+//! reimplementing it would be a second thing to keep correct.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::TargetSession;
+
+/// How many plugins one host may report before the answer is refused.
+pub const MAX_PLUGINS_PER_TARGET: usize = 256;
+
+/// Where a plugin came from, which is the only identity it has across hosts.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct PluginSource {
+    /// Herdr's own word for the kind of source. Carried rather than
+    /// interpreted: a kind this does not recognise is still an identity, and
+    /// two plugins of different kinds are different plugins.
+    pub kind: String,
+    pub owner: String,
+    pub repo: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subdir: Option<String>,
+}
+
+impl std::fmt::Display for PluginSource {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}/{}", self.owner, self.repo)?;
+        if let Some(subdir) = &self.subdir {
+            write!(formatter, "/{subdir}")?;
+        }
+        Ok(())
+    }
+}
+
+impl PluginSource {
+    /// Where somebody reads about this plugin.
+    ///
+    /// Derived from the source rather than looked up, because Herdr documents
+    /// no marketplace or catalogue to search: `herdr plugin install` takes
+    /// `owner/repo`, so `owner/repo` is what a link can be built from. A source
+    /// of a kind this cannot address gets no link rather than a guessed one.
+    pub fn detail_url(&self) -> Option<String> {
+        (self.kind == "github").then(|| format!("https://github.com/{}/{}", self.owner, self.repo))
+    }
+
+    /// What `herdr plugin install` would be given.
+    pub fn install_argument(&self) -> String {
+        self.to_string()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstalledPlugin {
+    /// Server-local. Never compared across hosts; carried so a person can find
+    /// the thing again on the host it is on.
+    pub plugin_id: String,
+    pub name: String,
+    pub version: String,
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<PluginSource>,
+    /// What was asked for — a tag, a branch, a commit — and what it became.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+/// What every reachable host reported, and what the others said instead.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Inventory {
+    pub installed: BTreeMap<TargetSession, Vec<InstalledPlugin>>,
+    /// One line per target that could not answer. Kept beside the answers
+    /// rather than replacing them: a fleet report where one unreachable host
+    /// hides the other five is a report nobody can act on.
+    pub errors: BTreeMap<TargetSession, String>,
+}
+
+/// A difference worth a person's attention.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Drift {
+    /// Installed somewhere and not somewhere else.
+    Missing {
+        source: PluginSource,
+        present_on: Vec<TargetSession>,
+        absent_from: Vec<TargetSession>,
+    },
+    /// Installed everywhere, at different versions.
+    Version {
+        source: PluginSource,
+        versions: BTreeMap<String, Vec<TargetSession>>,
+    },
+    /// Same version, different commit. Worth saying separately: a version that
+    /// did not change while the code did is the drift somebody would otherwise
+    /// never look for.
+    Commit {
+        source: PluginSource,
+        commits: BTreeMap<String, Vec<TargetSession>>,
+    },
+    /// Present but switched off somewhere.
+    Disabled {
+        source: PluginSource,
+        disabled_on: Vec<TargetSession>,
+    },
+    /// A plugin with no source, which exists only where it was linked. Not a
+    /// difference to reconcile — there is nothing to compare it to — but worth
+    /// naming so it is not mistaken for a gap.
+    LocalOnly {
+        target: TargetSession,
+        plugin_id: String,
+        name: String,
+    },
+}
+
+/// One plugin somebody wants, pinned to something that will not move.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockedPlugin {
+    pub source: PluginSource,
+    /// What to ask for. The resolved commit when there is one, because a tag
+    /// can be moved and a branch certainly will: a lockfile that pinned a
+    /// branch would reproduce whatever that branch says later, which is the
+    /// opposite of what it is for.
+    pub reference: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lockfile {
+    pub plugins: Vec<LockedPlugin>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanAction {
+    Install,
+    Update,
+}
+
+/// One command somebody would run, and why.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlanStep {
+    pub target: TargetSession,
+    pub source: PluginSource,
+    pub action: PlanAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<String>,
+    pub to: String,
+    /// Herdr's own command. Not run here, and not reimplemented: Herdr has an
+    /// installer, and a second one would be a second thing to keep correct.
+    pub command: String,
+}
+
+impl Inventory {
+    pub fn targets(&self) -> impl Iterator<Item = &TargetSession> {
+        self.installed.keys()
+    }
+
+    /// Everything installed from one source, by the target it is on.
+    fn by_source(&self) -> BTreeMap<PluginSource, BTreeMap<TargetSession, &InstalledPlugin>> {
+        let mut grouped: BTreeMap<PluginSource, BTreeMap<TargetSession, &InstalledPlugin>> =
+            BTreeMap::new();
+        for (target, plugins) in &self.installed {
+            for plugin in plugins {
+                let Some(source) = plugin.source.clone() else {
+                    continue;
+                };
+                grouped
+                    .entry(source)
+                    .or_default()
+                    .insert(target.clone(), plugin);
+            }
+        }
+        grouped
+    }
+
+    /// What differs across the hosts that answered.
+    ///
+    /// Only across those: a host that could not be reached is not evidence
+    /// that it is missing anything, and reporting it as a gap would send
+    /// somebody to install a plugin that is already there.
+    pub fn drift(&self) -> Vec<Drift> {
+        let answered = self.installed.keys().cloned().collect::<BTreeSet<_>>();
+        let mut drift = Vec::new();
+        for (source, holders) in self.by_source() {
+            let absent_from = answered
+                .iter()
+                .filter(|target| !holders.contains_key(*target))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !absent_from.is_empty() {
+                drift.push(Drift::Missing {
+                    source: source.clone(),
+                    present_on: holders.keys().cloned().collect(),
+                    absent_from,
+                });
+            }
+
+            let mut versions: BTreeMap<String, Vec<TargetSession>> = BTreeMap::new();
+            let mut commits: BTreeMap<String, Vec<TargetSession>> = BTreeMap::new();
+            let mut disabled_on = Vec::new();
+            for (target, plugin) in &holders {
+                versions
+                    .entry(plugin.version.clone())
+                    .or_default()
+                    .push(target.clone());
+                if let Some(commit) = &plugin.resolved_commit {
+                    commits
+                        .entry(commit.clone())
+                        .or_default()
+                        .push(target.clone());
+                }
+                if !plugin.enabled {
+                    disabled_on.push(target.clone());
+                }
+            }
+            if versions.len() > 1 {
+                drift.push(Drift::Version {
+                    source: source.clone(),
+                    versions,
+                });
+            } else if commits.len() > 1 {
+                // Only when the versions agree. A version difference already
+                // explains a commit difference, and saying both would be one
+                // disagreement reported twice.
+                drift.push(Drift::Commit {
+                    source: source.clone(),
+                    commits,
+                });
+            }
+            if !disabled_on.is_empty() {
+                drift.push(Drift::Disabled {
+                    source,
+                    disabled_on,
+                });
+            }
+        }
+
+        for (target, plugins) in &self.installed {
+            for plugin in plugins.iter().filter(|plugin| plugin.source.is_none()) {
+                drift.push(Drift::LocalOnly {
+                    target: target.clone(),
+                    plugin_id: plugin.plugin_id.clone(),
+                    name: plugin.name.clone(),
+                });
+            }
+        }
+        drift
+    }
+
+    /// Write down what one host has, as the set to reproduce elsewhere.
+    ///
+    /// A host is named rather than merged from all of them: "what everybody
+    /// has" is not a decision anybody made, and picking the newest of each
+    /// would invent a combination nobody has ever run.
+    pub fn lockfile(&self, from: &TargetSession) -> Option<Lockfile> {
+        let plugins = self.installed.get(from)?;
+        Some(Lockfile {
+            plugins: plugins
+                .iter()
+                .filter_map(|plugin| {
+                    let source = plugin.source.clone()?;
+                    // The commit when there is one: a tag can be moved and a
+                    // branch certainly will.
+                    let reference = plugin
+                        .resolved_commit
+                        .clone()
+                        .or_else(|| plugin.requested_ref.clone())?;
+                    Some(LockedPlugin {
+                        source,
+                        reference,
+                        version: plugin.version.clone(),
+                    })
+                })
+                .collect(),
+        })
+    }
+
+    /// What it would take to bring the named targets to this lockfile.
+    ///
+    /// Produced whole and printed before anything runs. A host already holding
+    /// the pinned reference produces no step at all, so a plan that is empty
+    /// says the fleet already agrees rather than saying nothing happened.
+    pub fn plan(&self, lockfile: &Lockfile, targets: &[TargetSession]) -> Vec<PlanStep> {
+        let mut steps = Vec::new();
+        for target in targets {
+            let Some(installed) = self.installed.get(target) else {
+                // Not reached, so not planned for. Guessing at what an
+                // unreachable host holds is how a plan installs over something.
+                continue;
+            };
+            for locked in &lockfile.plugins {
+                let held = installed
+                    .iter()
+                    .find(|plugin| plugin.source.as_ref() == Some(&locked.source));
+                let at = held.and_then(|plugin| {
+                    plugin
+                        .resolved_commit
+                        .clone()
+                        .or_else(|| plugin.requested_ref.clone())
+                });
+                if at.as_deref() == Some(locked.reference.as_str()) {
+                    continue;
+                }
+                steps.push(PlanStep {
+                    target: target.clone(),
+                    source: locked.source.clone(),
+                    action: if held.is_some() {
+                        PlanAction::Update
+                    } else {
+                        PlanAction::Install
+                    },
+                    from: held.map(|plugin| plugin.version.clone()),
+                    to: locked.reference.clone(),
+                    command: format!(
+                        "herdr plugin install {} --ref {} -y",
+                        locked.source.install_argument(),
+                        locked.reference
+                    ),
+                });
+            }
+        }
+        steps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Drift, InstalledPlugin, Inventory, LockedPlugin, Lockfile, PlanAction, PluginSource,
+    };
+    use crate::model::TargetSession;
+
+    fn source(owner: &str, repo: &str) -> PluginSource {
+        PluginSource {
+            kind: "github".to_owned(),
+            owner: owner.to_owned(),
+            repo: repo.to_owned(),
+            subdir: None,
+        }
+    }
+
+    fn plugin(id: &str, version: &str, source: Option<PluginSource>) -> InstalledPlugin {
+        InstalledPlugin {
+            plugin_id: id.to_owned(),
+            name: id.to_owned(),
+            version: version.to_owned(),
+            enabled: true,
+            source,
+            requested_ref: Some("v1".to_owned()),
+            resolved_commit: Some("a".repeat(40)),
+            warnings: Vec::new(),
+        }
+    }
+
+    fn inventory(entries: Vec<(&str, Vec<InstalledPlugin>)>) -> Inventory {
+        let mut held = Inventory::default();
+        for (target, plugins) in entries {
+            held.installed
+                .insert(TargetSession::new(target, "work"), plugins);
+        }
+        held
+    }
+
+    #[test]
+    fn two_hosts_naming_different_plugins_the_same_thing_are_not_one_plugin() {
+        let held = inventory(vec![
+            (
+                "host-a",
+                vec![plugin("review", "1.0", Some(source("alice", "review")))],
+            ),
+            (
+                "host-b",
+                vec![plugin("review", "1.0", Some(source("bob", "review")))],
+            ),
+        ]);
+
+        let drift = held.drift();
+
+        // Each is missing from the other host, and neither is a version
+        // difference: they were never the same plugin.
+        assert_eq!(drift.len(), 2);
+        assert!(drift.iter().all(|one| matches!(one, Drift::Missing { .. })));
+        assert!(
+            !drift.iter().any(|one| matches!(one, Drift::Version { .. })),
+            "a shared plugin_id is not evidence that two hosts hold the same code"
+        );
+    }
+
+    #[test]
+    fn one_plugin_installed_under_different_ids_is_still_one_plugin() {
+        let held = inventory(vec![
+            (
+                "host-a",
+                vec![plugin("review", "1.0", Some(source("alice", "review")))],
+            ),
+            (
+                "host-b",
+                vec![plugin(
+                    "code-review",
+                    "1.0",
+                    Some(source("alice", "review")),
+                )],
+            ),
+        ]);
+
+        assert!(
+            held.drift().is_empty(),
+            "identity is where it came from, not what the host called it"
+        );
+    }
+
+    #[test]
+    fn a_version_difference_is_reported_once_and_not_twice() {
+        let mut newer = plugin("review", "2.0", Some(source("alice", "review")));
+        newer.resolved_commit = Some("b".repeat(40));
+        let held = inventory(vec![
+            (
+                "host-a",
+                vec![plugin("review", "1.0", Some(source("alice", "review")))],
+            ),
+            ("host-b", vec![newer]),
+        ]);
+
+        let drift = held.drift();
+
+        assert_eq!(drift.len(), 1);
+        assert!(matches!(drift[0], Drift::Version { .. }));
+    }
+
+    #[test]
+    fn the_same_version_built_from_different_commits_is_its_own_finding() {
+        let mut moved = plugin("review", "1.0", Some(source("alice", "review")));
+        moved.resolved_commit = Some("b".repeat(40));
+        let held = inventory(vec![
+            (
+                "host-a",
+                vec![plugin("review", "1.0", Some(source("alice", "review")))],
+            ),
+            ("host-b", vec![moved]),
+        ]);
+
+        let drift = held.drift();
+
+        assert!(
+            matches!(drift.as_slice(), [Drift::Commit { .. }]),
+            "a version that did not change while the code did is the drift nobody looks for"
+        );
+    }
+
+    #[test]
+    fn a_linked_local_plugin_is_named_and_never_matched() {
+        let held = inventory(vec![
+            ("host-a", vec![plugin("scratch", "0.1", None)]),
+            ("host-b", vec![plugin("scratch", "0.1", None)]),
+        ]);
+
+        let drift = held.drift();
+
+        assert_eq!(drift.len(), 2);
+        assert!(
+            drift
+                .iter()
+                .all(|one| matches!(one, Drift::LocalOnly { .. }))
+        );
+        assert!(
+            !drift.iter().any(|one| matches!(one, Drift::Missing { .. })),
+            "a name is not evidence that two directories hold the same code"
+        );
+    }
+
+    #[test]
+    fn a_host_that_could_not_answer_is_not_reported_as_missing_anything() {
+        let mut held = inventory(vec![(
+            "host-a",
+            vec![plugin("review", "1.0", Some(source("alice", "review")))],
+        )]);
+        held.errors.insert(
+            TargetSession::new("host-b", "work"),
+            "connection refused".to_owned(),
+        );
+
+        assert!(
+            held.drift().is_empty(),
+            "an unreachable host is not evidence that it is missing anything"
+        );
+    }
+
+    #[test]
+    fn a_plugin_switched_off_somewhere_is_worth_saying() {
+        let mut off = plugin("review", "1.0", Some(source("alice", "review")));
+        off.enabled = false;
+        let held = inventory(vec![
+            (
+                "host-a",
+                vec![plugin("review", "1.0", Some(source("alice", "review")))],
+            ),
+            ("host-b", vec![off]),
+        ]);
+
+        assert!(matches!(
+            held.drift().as_slice(),
+            [Drift::Disabled { disabled_on, .. }] if disabled_on.len() == 1
+        ));
+    }
+
+    #[test]
+    fn a_lockfile_pins_the_commit_rather_than_the_tag_that_moved() {
+        let held = inventory(vec![(
+            "host-a",
+            vec![plugin("review", "1.0", Some(source("alice", "review")))],
+        )]);
+
+        let lockfile = held
+            .lockfile(&TargetSession::new("host-a", "work"))
+            .unwrap();
+
+        assert_eq!(lockfile.plugins.len(), 1);
+        assert_eq!(
+            lockfile.plugins[0].reference,
+            "a".repeat(40),
+            "a lockfile that pinned a branch would reproduce whatever it says later"
+        );
+    }
+
+    #[test]
+    fn a_plan_names_herdr_own_command_and_skips_what_already_agrees() {
+        let held = inventory(vec![
+            (
+                "host-a",
+                vec![plugin("review", "1.0", Some(source("alice", "review")))],
+            ),
+            ("host-b", Vec::new()),
+        ]);
+        let lockfile = Lockfile {
+            plugins: vec![LockedPlugin {
+                source: source("alice", "review"),
+                reference: "a".repeat(40),
+                version: "1.0".to_owned(),
+            }],
+        };
+
+        let plan = held.plan(
+            &lockfile,
+            &[
+                TargetSession::new("host-a", "work"),
+                TargetSession::new("host-b", "work"),
+            ],
+        );
+
+        assert_eq!(
+            plan.len(),
+            1,
+            "a host already holding the pin needs no step"
+        );
+        assert_eq!(plan[0].target, TargetSession::new("host-b", "work"));
+        assert_eq!(plan[0].action, PlanAction::Install);
+        assert_eq!(
+            plan[0].command,
+            format!(
+                "herdr plugin install alice/review --ref {} -y",
+                "a".repeat(40)
+            )
+        );
+    }
+
+    #[test]
+    fn a_plan_skips_a_target_that_never_answered() {
+        let held = inventory(vec![(
+            "host-a",
+            vec![plugin("review", "1.0", Some(source("alice", "review")))],
+        )]);
+        let lockfile = held
+            .lockfile(&TargetSession::new("host-a", "work"))
+            .unwrap();
+
+        let plan = held.plan(&lockfile, &[TargetSession::new("host-gone", "work")]);
+
+        assert!(
+            plan.is_empty(),
+            "guessing at what an unreachable host holds is how a plan installs over something"
+        );
+    }
+
+    #[test]
+    fn a_source_addresses_its_own_documentation_and_installer() {
+        let with_subdir = PluginSource {
+            subdir: Some("plugins/review".to_owned()),
+            ..source("alice", "tools")
+        };
+
+        assert_eq!(with_subdir.to_string(), "alice/tools/plugins/review");
+        assert_eq!(
+            with_subdir.detail_url().unwrap(),
+            "https://github.com/alice/tools"
+        );
+        assert_eq!(
+            PluginSource {
+                kind: "path".to_owned(),
+                ..source("alice", "tools")
+            }
+            .detail_url(),
+            None,
+            "a source this cannot address gets no link rather than a guessed one"
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #22.

Two read-only commands for the questions that are expensive to answer by hand.

## `super-herdr doctor`

Super-Herdr sits on a config file, a Herdr on every host, SSH between them, a daemon socket, a browser route, and a desktop's clipboard and notification tools. When one is wrong the symptom is usually the same — something did not appear — and working out which layer is the expensive part.

**It reports and never repairs.** Every failed check carries the command somebody would run, and none of them run here: a diagnostic that changes the system is one people are afraid to run on a machine that is nearly working, which is exactly when it is most useful. A failing check is also an exit code.

**The output is meant to be pasted somewhere public.** I checked this rather than asserting it — grepped the real output of both formats for my username, home path and `@`: zero hits. Destinations become `<user@host, 29 chars>`, paths become `…/config.toml`. Target names are kept, because they are the labels somebody chose and without them a report says a problem exists without saying where.

Run against my real setup, it correctly flagged the local Herdr:

```
targets
  warn local-check: herdr 0.8.0, protocol 19, 9 pane(s), 4 agent(s), 8 ms
       try: upgrade Herdr on that host to 0.8.2 or newer for plugin actions
```

The `sha256sum` fix this check was written for is already on `main` as its own PR; only the check remains here.

Two backlog items are deliberately not ticked, with reasons recorded: **SSH alias resolution** is not a separate check (a target that resolves is one the probe reached; one that does not fails with ssh's own message), and **`--fix`** does not exist, so that item stays open as the constraint on adding one.

## `super-herdr plugins`

Herdr installs plugins per host, so "which machines have the review plugin, and is it the same one?" stops being answerable by looking.

The decision worth reviewing: **a `plugin_id` is server-local.** Two hosts can name unrelated plugins the same thing, and one plugin can be installed under different ids. Matching on it would report drift between things that were never the same plugin *and* silence between two copies of one. So identity is the **source** it was installed from, and the id stays qualified by its target. A plugin with no source is named as local to its host and never matched — a name is not evidence that two directories hold the same code — and a *partial* source is discarded rather than half-matched.

Version drift and commit drift are separate findings and never both for one plugin. A host that could not be asked is a line in the report, never counted as missing anything.

Nothing installs. A lockfile pins resolved commits rather than tags; a plan prints Herdr's own `herdr plugin install` commands and runs none. **Marketplace search is blocked upstream** — Herdr documents no marketplace or catalogue interface at all — so that item says so rather than sitting open. Applying a plan changes somebody's hosts and wants its own branch.

## Checks

408 tests · 191 page-harness assertions · fmt, clippy (host + macOS target), check-docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdRHimPZdtFsZgAnmpCRUE
