### PR TITLE
Local names and favourites, SSH config import, and network guidance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1112,6 +1112,38 @@ write into. Until such an envelope exists, transfers are initiated from the
 client, and Super-Herdr does not invent a side channel by scraping the pane's
 own output for markers.
 
+## Names that belong to this installation
+
+A person running agents on five machines ends up with `w1`, `w3` and `wD`
+meaning "the compiler one", "the flaky one" and "the customer's". Herdr can be
+told to rename a workspace, but that changes it for everybody using that host
+and is somebody else's decision. So Super-Herdr keeps its own: a label it
+shows, a set of destinations worth one action, and nine slots for the ones
+somebody jumps to constantly. Nothing here renames anything on a host; Herdr's
+own rename stays a separate, explicit action.
+
+An alias is never an identity. Everything is keyed by a qualified id and looked
+up by one, so two hosts can both have a "build" without anything colliding, and
+a card carrying a local name still carries the identity that routes.
+
+The hard part is that Herdr's ids are server-local and can come back: delete
+`w1` and the next workspace may be `w1` again. An alias keyed only by that id
+would move silently onto a different workspace, and the person would see a name
+they trust over something they have never looked at. So an alias also records
+what the resource was called when it was named, and when that no longer matches
+the alias is *suspended* — shown as needing confirmation rather than applied or
+deleted, because nothing here can tell a rename from a reuse and guessing
+either way is worse than asking. A person can confirm it; only a person can.
+
+Names for a target removed from the configuration are forgotten, because
+removing it was a decision. Nothing is forgotten because a host was merely
+unreachable, which is not a decision anybody made.
+
+Filters and the landing view are the exception: they live in the browser rather
+than the daemon, because they are one person's habit on one device — the phone
+that only ever wants "needs you" and the laptop that wants everything — and a
+device that refuses to remember them still has to render one.
+
 ## Plugins across hosts
 
 Herdr installs plugins per host, so once somebody runs agents on three

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -267,15 +267,18 @@ across machines while one failing target leaves every other target usable.
 
 ### 7. Aliases, favourites, and saved views
 
-- [ ] Add Super-Herdr-local display aliases for qualified agents, workspaces,
-      panes, sessions, and targets.
-- [ ] Never use an alias as routing identity.
-- [ ] Add pinned workspaces and favourite qualified destinations.
-- [ ] Add optional numbered jump slots without renaming Herdr resources.
-- [ ] Save inbox filters and the preferred landing view per client.
-- [ ] Surface an explicit Herdr rename action separately when the documented
-      interface supports it; never rename automatically.
-- [ ] Handle deleted, moved, and duplicate-looking resources without silently
+- [x] Add Super-Herdr-local display aliases for qualified agents, workspaces,
+      panes, sessions, and targets. Stored and settable for every kind; the
+      browser renders them on agent cards, and the TUI's hierarchy still shows
+      Herdr's own labels.
+- [x] Never use an alias as routing identity.
+- [x] Add pinned workspaces and favourite qualified destinations.
+- [x] Add optional numbered jump slots without renaming Herdr resources.
+- [x] Save inbox filters and the preferred landing view per client.
+- [x] Surface an explicit Herdr rename action separately when the documented
+      interface supports it; never rename automatically. Herdr's rename was
+      already its own context-menu action and stays one; nothing local calls it.
+- [x] Handle deleted, moved, and duplicate-looking resources without silently
       retargeting an alias.
 
 Exit condition: frequently used projects and agents are one action away while

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -286,19 +286,22 @@ all operations remain bound to qualified live identities.
 
 ### 8. Multi-host onboarding and network choices
 
-- [ ] Offer an OpenSSH-config alias importer with a preview and explicit target
+- [x] Offer an OpenSSH-config alias importer with a preview and explicit target
       selection.
-- [ ] Support adding and probing several targets in one wizard with independent
-      results and timeouts.
-- [ ] Add local tags and groups such as work, home, lab, and pods.
-- [ ] Explain hosted bridge, direct LAN, Tailscale, NetBird/WireGuard-style
+- [x] Support adding and probing several targets in one wizard with independent
+      results and timeouts. The wizard is the `target import` command rather
+      than a TUI screen; the TUI already has its own add-and-test form.
+- [x] Add local tags and groups such as work, home, lab, and pods.
+- [x] Explain hosted bridge, direct LAN, Tailscale, NetBird/WireGuard-style
       private routes, and an operator-managed proxy as peer choices.
-- [ ] Make the default hosted route clear: it needs no Tailscale but remains a
+- [x] Make the default hosted route clear: it needs no Tailscale but remains a
       trusted relay because TLS terminates there.
-- [ ] Investigate a native Windows control-plane build that can supervise SSH
+- [x] Investigate a native Windows control-plane build that can supervise SSH
       targets without claiming native Herdr support or depending on Herdr
-      internals.
-- [ ] Keep WSL2 as the documented Windows fallback until the native matrix is
+      internals. Written up in `ROADMAP.md`: plausible as a control plane,
+      blocked mainly on a local-socket abstraction, a shell abstraction, and
+      Windows clipboard and notification backends. Not scheduled.
+- [x] Keep WSL2 as the documented Windows fallback until the native matrix is
       complete.
 
 Exit condition: a new user with several existing SSH hosts can add them without

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ same metadata for a support bundle.
   install plan that runs nothing
 - Local names, favourites and jump slots that never rename a Herdr resource and
   are never trusted onto a reused id
+- OpenSSH config import with a preview, per-host probing, and local tags
 - Configurable browser quick replies, terminal keys, a soft-keyboard dock, and
   a file picker
 - Digest-verified local-to-host, host-to-local, and host-to-host file transfer
@@ -245,10 +246,32 @@ super-herdr clipboard check
 super-herdr notifications check
 ```
 
+If your machines are already in `~/.ssh/config`, `super-herdr target import`
+lists them and adds nothing. Name the ones you want with `--add`, and each is
+probed on its own before it is written — one host being unreachable says
+nothing about the others, and an alias that did not answer is reported rather
+than added. `--tag work` groups what a run adds.
+
 See [config.example.toml](config.example.toml) for manual TOML configuration.
-The browser route can use the hosted bridge, a private address, Tailscale Serve,
-or an operator-managed proxy. See the [architecture](ARCHITECTURE.md) for those
-trust boundaries and the [bridge guide](crates/bridge/README.md) for self-hosting.
+
+### Choosing how a phone reaches you
+
+These are peers, not a ladder. Pick the trust boundary you want:
+
+| Route | What it needs | Who can see the traffic |
+| --- | --- | --- |
+| **Hosted bridge** (default) | Nothing. Works from any network. | TLS terminates at the relay, so it is a trusted relay rather than end-to-end encryption. It carries bounded opaque traffic and holds no device tokens, but it is a third party in the path. |
+| **Direct address** | The phone and the daemon on one network. | Nobody in between. Refused on a public address: a device token authenticates but does not encrypt. |
+| **Tailscale, NetBird, or another WireGuard-style network** | That network on both devices. | Nobody in between; the tunnel is theirs, not Super-Herdr's. Point `web.address` at the interface it gives you. |
+| **Your own proxy** | A TLS terminator you run. | You, wherever you terminate. Set `web.url` to where the phone reaches it. |
+
+The default is the bridge because it works with no setup from a hotel network,
+and being clear about it matters more than defending it: it needs no Tailscale,
+and it is a relay you are trusting. If that is the wrong trade for your machines,
+the other three rows are one configuration key each.
+
+See the [architecture](ARCHITECTURE.md) for those trust boundaries and the
+[bridge guide](crates/bridge/README.md) for self-hosting.
 
 ## Security summary
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ A card whose host has disconnected, or whose agent has ended, is shown and not
 offered — Super-Herdr resolves the live pane again before it routes anything,
 so a reconnect can never redirect your next keystroke.
 
+Give an agent, workspace, pane, session or host a name of your own, mark the
+ones you keep coming back to as favourites, and put the busiest in numbered
+jump slots. These are Super-Herdr's own labels: nothing about them reaches a
+host or renames a Herdr resource. If the host later calls something else by
+that id, the name is suspended and shown as needing confirmation rather than
+applied to whatever turned up — Super-Herdr cannot tell a rename from a reused
+id, so it asks. Your inbox filters and landing view are remembered by the
+browser you use them in.
+
 `super-herdr plugins list` shows what is installed on every host and what
 differs — missing plugins, version drift, and the same version built from
 different commits. Plugins are matched by where they were installed from
@@ -198,6 +207,8 @@ same metadata for a support bundle.
   output and the command to run for anything broken
 - Cross-host plugin inventory, drift, a pinned lockfile, and a printed
   install plan that runs nothing
+- Local names, favourites and jump slots that never rename a Herdr resource and
+  are never trusted onto a reused id
 - Configurable browser quick replies, terminal keys, a soft-keyboard dock, and
   a file picker
 - Digest-verified local-to-host, host-to-local, and host-to-host file transfer

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,45 @@ Work is ordered by dependency and product risk.
 The community-informed product epics that follow these qualification gates are
 specified as checkable work in [PRODUCT_BACKLOG.md](PRODUCT_BACKLOG.md).
 
+## Investigation: a native Windows control plane
+
+Asked in `PRODUCT_BACKLOG.md` step 8, and answered here rather than started,
+because the answer changes what would be worth building.
+
+What was checked, in this tree:
+
+- **File permissions** are already portable. Every `std::os::unix` use is a
+  `PermissionsExt` call behind a `cfg(target_family = "unix")` gate with a
+  no-op sibling, across `config`, `attention`, `ui_state`, `aliases`,
+  `notifications` and `doctor`. Nothing here blocks a Windows build.
+- **Unix domain sockets are the real coupling.** `UnixStream` appears in
+  `transport`, `client` and `daemon::server` — twenty uses in total — on two
+  distinct paths: the daemon's own client socket, and the socket Herdr exposes
+  on a target. The first is ours and could be a named pipe or a loopback
+  listener. The second is not: it is how Herdr's documented API is reached, and
+  it lives on the *target*, where SSH already carries it. A Windows control
+  plane talking to Linux and macOS targets over SSH never needs AF_UNIX
+  locally for it.
+- **Local command execution** assumes `/bin/sh` in two places, both for
+  commands run on *this* machine rather than on a target. Both would need a
+  Windows equivalent or a documented refusal.
+- **The TUI** is `crossterm`, which supports Windows already.
+- **Clipboard and notifications** are the widest gap: both are built around
+  platform tools this tree knows how to find on Linux and macOS, and neither
+  has a Windows path.
+
+The conclusion is that a native Windows build is plausible as a *control plane
+for SSH targets* — supervising, browsing, transferring, and serving the browser
+client — and is not plausible as a host that runs Herdr itself, which
+Super-Herdr should not claim either way since it does not implement Herdr. The
+work is a local-socket abstraction, a shell abstraction, and Windows clipboard
+and notification backends. None of it requires importing anything from Herdr,
+which was the constraint the question was really asking about.
+
+It is not scheduled. WSL2 remains the documented Windows path until somebody
+has a Windows machine to qualify a native build on, because a platform nobody
+can test is a platform that is broken and does not know it.
+
 ## Completed foundation
 
 - Persistent multi-host federation with qualified target/session IDs.

--- a/config.example.toml
+++ b/config.example.toml
@@ -61,6 +61,10 @@ discover_sessions = true
 # reading — a paired device already holds pane control and can read anything
 # its user can, so a root is a place to look rather than a permission.
 #roots = ["/srv/build", "/home/example/work"]
+# Local groupings for filtering — work, home, lab, a pod name. A tag never
+# reaches a host and never takes part in identity: two hosts tagged "work" are
+# still two entirely separate targets.
+#tags = ["work", "lab"]
 # Optional overrides:
 #session = "default"
 #socket = "/absolute/path/to/herdr.sock"

--- a/examples/qualify-upload.rs
+++ b/examples/qualify-upload.rs
@@ -50,6 +50,7 @@ async fn main() -> Result<()> {
         socket: None,
         herdr_bins: vec!["herdr".to_owned()],
         roots: Vec::new(),
+        tags: Vec::new(),
     };
 
     let payload = png(64 * 1024);
@@ -214,6 +215,7 @@ async fn relay(
                     "herdr".to_owned(),
                 ],
                 roots: Vec::new(),
+                tags: Vec::new(),
             }],
             devices: Vec::new(),
             quick_replies: None,

--- a/examples/qualify-upload.rs
+++ b/examples/qualify-upload.rs
@@ -222,6 +222,7 @@ async fn relay(
         DaemonOptions {
             socket: directory.path().join("unused.sock"),
             agent_marks: None,
+            aliases: None,
             attention_state: Some(directory.path().join("attention.json")),
             refresh_interval: std::time::Duration::from_secs(3600),
             web_port: None,

--- a/src/agent_card.rs
+++ b/src/agent_card.rs
@@ -36,6 +36,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use serde::{Deserialize, Serialize};
 
 use crate::agent_marks::{AgentMarkState, AgentMarks};
+use crate::aliases::{AliasState, Aliases, ResourceRef};
 use crate::attention::{AgentPhase, AttentionIndex, agent_phase, bounded_metadata};
 use crate::model::{AgentId, PaneId};
 use crate::state::{
@@ -144,6 +145,18 @@ pub struct AgentCard {
     /// something that reached the host: see [`crate::agent_marks`].
     #[serde(default)]
     pub marks: AgentMarkState,
+    /// A local name for this agent, when there is one that still fits. Shown
+    /// instead of the title; `title` keeps the host's own word so a client can
+    /// show both and nothing has to ask the host what it used to say.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    /// A local name exists but the host now calls this something else. Neither
+    /// applied nor forgotten: a person is asked, because nothing here can tell
+    /// a rename from a reused id.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub alias_suspended: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub favourite: bool,
 }
 
 /// The whole inbox, in the order it should be rendered.
@@ -174,6 +187,20 @@ impl AgentCardProjection {
     pub fn is_empty(&self) -> bool {
         self.needs_you.is_empty() && self.working.is_empty() && self.recent.is_empty()
     }
+}
+
+/// What this installation, rather than a host, has to say about an agent.
+///
+/// Bundled because they travel together and mean one thing: everything here is
+/// Super-Herdr's own state, none of it reaches a host, and a caller holding
+/// one of them almost always holds all three.
+#[derive(Debug, Clone, Copy)]
+pub struct LocalView<'a> {
+    pub marks: &'a AgentMarks,
+    pub aliases: &'a Aliases,
+    /// The clock a snooze is measured against, supplied so a projection of the
+    /// same inputs is the same projection and a test can say so.
+    pub now_ms: u64,
 }
 
 /// A resolved, current route to an agent's pane.
@@ -267,8 +294,7 @@ impl AgentCardIndex {
         &mut self,
         state: &FederationState,
         attention: &AttentionIndex,
-        marks: &AgentMarks,
-        now_ms: u64,
+        local: LocalView<'_>,
     ) -> AgentCardProjection {
         let mut seen = BTreeMap::new();
         let mut ambiguous = BTreeSet::new();
@@ -279,7 +305,7 @@ impl AgentCardIndex {
             let live = target.connection == TargetConnectionState::Live;
             for agent in snapshot.agents.values() {
                 let id = agent_key(agent);
-                let card = self.build_card(agent, snapshot, attention, live, marks, now_ms);
+                let card = self.build_card(agent, snapshot, attention, live, local);
                 if seen.insert(id.clone(), card).is_some() {
                     // Two agents on one target answering to one identity. Both
                     // cards stay visible — a person should be able to see that
@@ -481,8 +507,7 @@ impl AgentCardIndex {
         snapshot: &NormalizedSnapshot,
         attention: &AttentionIndex,
         live: bool,
-        marks: &AgentMarks,
-        now_ms: u64,
+        local: LocalView<'_>,
     ) -> AgentCard {
         let pane = snapshot.panes.get(&agent.pane);
         let status = bounded_metadata(
@@ -498,13 +523,14 @@ impl AgentCardIndex {
             agent.interactive_ready.unwrap_or(false),
         ));
         let key = agent_key(agent);
-        let marked = marks.state(&key);
+        let marked = local.marks.state(&key);
+        let reference = ResourceRef::Agent(key.clone());
         // A muted or snoozed agent keeps its activity — it is still blocked,
         // and saying otherwise would be a lie a person could act on — but it
         // stops competing for the top of the inbox. Coming back is re-entering
         // the queue: it takes a fresh place in the section rather than
         // reclaiming the one it held before it was quieted.
-        let section = if marked.quiet_at(now_ms) {
+        let section = if marked.quiet_at(local.now_ms) {
             AgentCardSection::Recent
         } else {
             match activity {
@@ -535,18 +561,26 @@ impl AgentCardIndex {
                     .unwrap_or(tab.resource.as_str())
             })
             .unwrap_or("unassigned");
+        let title = bounded_metadata(
+            agent
+                .name
+                .as_deref()
+                .or_else(|| pane.and_then(|pane| pane.agent.as_deref()))
+                .or_else(|| pane.and_then(|pane| pane.label.as_deref()))
+                .unwrap_or(&agent.pane.resource),
+            MAX_LABEL_CHARACTERS,
+        );
+        // Compared against the title rather than the raw resource, because
+        // the title is what a person read when they named it.
+        let (alias, alias_suspended) = match local.aliases.resolve(&reference, &title) {
+            Some((label, AliasState::Current)) => (Some(label.to_owned()), false),
+            Some((_, AliasState::Suspended)) => (None, true),
+            None => (None, false),
+        };
         AgentCard {
             agent: key,
             pane: Some(agent.pane.clone()),
-            title: bounded_metadata(
-                agent
-                    .name
-                    .as_deref()
-                    .or_else(|| pane.and_then(|pane| pane.agent.as_deref()))
-                    .or_else(|| pane.and_then(|pane| pane.label.as_deref()))
-                    .unwrap_or(&agent.pane.resource),
-                MAX_LABEL_CHARACTERS,
-            ),
+            title: title.clone(),
             workspace: bounded_metadata(workspace, MAX_LABEL_CHARACTERS),
             tab: bounded_metadata(tab, MAX_LABEL_CHARACTERS),
             pane_label: bounded_metadata(
@@ -572,6 +606,9 @@ impl AgentCardIndex {
                 .find(|event| event.pane == agent.pane)
                 .map(|event| event.occurred_at_ms),
             marks: marked,
+            alias,
+            alias_suspended,
+            favourite: local.aliases.is_favourite(&reference),
         }
     }
 }
@@ -634,9 +671,11 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::{
-        AgentActivity, AgentCardIndex, AgentCardSection, CardRouteError, MAX_HISTORY_CARDS,
+        AgentActivity, AgentCardIndex, AgentCardSection, CardRouteError, LocalView,
+        MAX_HISTORY_CARDS,
     };
     use crate::agent_marks::{AgentMarkRequest, AgentMarks};
+    use crate::aliases::{Aliases, ResourceRef};
     use crate::attention::AttentionIndex;
     use crate::model::{AgentId, TargetSession};
     use crate::state::{
@@ -672,8 +711,7 @@ mod tests {
         let projection = index.project(
             &state,
             &AttentionIndex::default(),
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert_eq!(titles(&projection.needs_you), ["reviewer"]);
@@ -702,8 +740,7 @@ mod tests {
         let projection = index.project(
             &state,
             &AttentionIndex::default(),
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert!(projection.needs_you.is_empty());
@@ -738,8 +775,7 @@ mod tests {
         let projection = index.project(
             &state,
             &AttentionIndex::default(),
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert_eq!(projection.needs_you.len(), 2);
@@ -774,7 +810,11 @@ mod tests {
                 Some(agents_snapshot(&[("p9", "blocked")])),
             ),
         ]);
-        let before = index.project(&first, &attention, &AgentMarks::default(), NOW);
+        let before = index.project(
+            &first,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
         assert_eq!(
             order(&before.needs_you),
             [pane_key("host-a", "p1"), pane_key("host-b", "p9")]
@@ -791,7 +831,11 @@ mod tests {
                 Some(agents_snapshot(&[("p1", "blocked")])),
             ),
         );
-        let after = index.project(&second, &attention, &AgentMarks::default(), NOW);
+        let after = index.project(
+            &second,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         assert_eq!(
             order(&after.needs_you),
@@ -809,7 +853,11 @@ mod tests {
         );
 
         // A refresh that changes nothing at all publishes nothing at all.
-        let unchanged = index.project(&second, &attention, &AgentMarks::default(), NOW);
+        let unchanged = index.project(
+            &second,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
         assert_eq!(unchanged.revision, after.revision);
         assert_eq!(unchanged.needs_you, after.needs_you);
     }
@@ -823,7 +871,11 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked"), ("p2", "blocked")])),
         )]);
-        index.project(&blocked_pair, &attention, &AgentMarks::default(), NOW);
+        index.project(
+            &blocked_pair,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         // p1 is answered and starts working, then blocks again. It is now the
         // most recently blocked agent, so it queues behind p2 rather than
@@ -833,8 +885,16 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "working"), ("p2", "blocked")])),
         )]);
-        index.project(&answered, &attention, &AgentMarks::default(), NOW);
-        let projection = index.project(&blocked_pair, &attention, &AgentMarks::default(), NOW);
+        index.project(
+            &answered,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
+        let projection = index.project(
+            &blocked_pair,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         assert_eq!(
             order(&projection.needs_you),
@@ -851,14 +911,22 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked")])),
         )]);
-        index.project(&running, &attention, &AgentMarks::default(), NOW);
+        index.project(
+            &running,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         let ended = federation(vec![(
             "host-a",
             TargetConnectionState::Live,
             Some(agents_snapshot(&[])),
         )]);
-        let projection = index.project(&ended, &attention, &AgentMarks::default(), NOW);
+        let projection = index.project(
+            &ended,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         assert!(projection.needs_you.is_empty());
         assert_eq!(projection.recent.len(), 1);
@@ -881,14 +949,22 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked")])),
         )]);
-        index.project(&before, &attention, &AgentMarks::default(), NOW);
+        index.project(
+            &before,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         let after_move = federation(vec![(
             "host-a",
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p2", "blocked")])),
         )]);
-        let projection = index.project(&after_move, &attention, &AgentMarks::default(), NOW);
+        let projection = index.project(
+            &after_move,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         assert_eq!(order(&projection.needs_you), [pane_key("host-a", "p2")]);
         assert_eq!(projection.recent.len(), 1);
@@ -911,7 +987,11 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked")])),
         )]);
-        index.project(&live, &attention, &AgentMarks::default(), NOW);
+        index.project(
+            &live,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         // Disconnected, but the last snapshot is retained: the agent is
         // probably still there, and emptying the inbox on a flapping link
@@ -921,7 +1001,11 @@ mod tests {
             TargetConnectionState::Backoff { attempt: 1 },
             Some(agents_snapshot(&[("p1", "blocked")])),
         )]);
-        let projection = index.project(&dropped, &attention, &AgentMarks::default(), NOW);
+        let projection = index.project(
+            &dropped,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         assert_eq!(projection.needs_you.len(), 1);
         let card = &projection.needs_you[0];
@@ -948,15 +1032,13 @@ mod tests {
                 Some(agents_snapshot(&[("p1", "blocked")])),
             )]),
             &attention,
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         let projection = index.project(
             &federation(vec![("host-a", TargetConnectionState::Connecting, None)]),
             &attention,
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert_eq!(projection.needs_you.len(), 1);
@@ -975,15 +1057,13 @@ mod tests {
                 Some(agents_snapshot(&[("p1", "blocked")])),
             )]),
             &attention,
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         let projection = index.project(
             &FederationState::default(),
             &attention,
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert!(
@@ -1008,8 +1088,7 @@ mod tests {
         let projection = index.project(
             &state,
             &AttentionIndex::default(),
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert_eq!(projection.needs_you.len(), 1);
@@ -1067,8 +1146,7 @@ mod tests {
         let projection = index.project(
             &state,
             &AttentionIndex::default(),
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
         let card = projection.cards().next().unwrap();
 
@@ -1091,8 +1169,7 @@ mod tests {
                     Some(agents_snapshot(&[(name.as_str(), "blocked")])),
                 )]),
                 &attention,
-                &AgentMarks::default(),
-                NOW,
+                local(&AgentMarks::default(), &Aliases::default()),
             );
         }
         let projection = index.project(
@@ -1102,8 +1179,7 @@ mod tests {
                 Some(agents_snapshot(&[])),
             )]),
             &attention,
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert_eq!(projection.recent.len(), MAX_HISTORY_CARDS);
@@ -1130,8 +1206,11 @@ mod tests {
         )]);
         attention.observe(&blocked);
 
-        let projection =
-            AgentCardIndex::default().project(&blocked, &attention, &AgentMarks::default(), NOW);
+        let projection = AgentCardIndex::default().project(
+            &blocked,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         assert!(projection.needs_you[0].unread);
         assert!(projection.needs_you[0].last_change_ms.is_some());
@@ -1148,7 +1227,11 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked"), ("p2", "blocked")])),
         )]);
-        index.project(&state, &attention, &AgentMarks::default(), NOW);
+        index.project(
+            &state,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         let mut marks = AgentMarks::default();
         marks.apply(
@@ -1156,7 +1239,7 @@ mod tests {
             AgentMarkRequest::Pin { pinned: true },
             NOW,
         );
-        let projection = index.project(&state, &attention, &marks, NOW);
+        let projection = index.project(&state, &attention, local(&marks, &Aliases::default()));
 
         assert_eq!(
             order(&projection.needs_you),
@@ -1181,7 +1264,11 @@ mod tests {
             NOW,
         );
 
-        let projection = index.project(&state, &AttentionIndex::default(), &marks, NOW);
+        let projection = index.project(
+            &state,
+            &AttentionIndex::default(),
+            local(&marks, &Aliases::default()),
+        );
 
         assert!(projection.needs_you.is_empty());
         assert_eq!(projection.recent.len(), 1);
@@ -1206,7 +1293,11 @@ mod tests {
             TargetConnectionState::Live,
             Some(agents_snapshot(&[("p1", "blocked"), ("p2", "blocked")])),
         )]);
-        index.project(&state, &attention, &AgentMarks::default(), NOW);
+        index.project(
+            &state,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         let mut marks = AgentMarks::default();
         marks.apply(
@@ -1214,11 +1305,19 @@ mod tests {
             AgentMarkRequest::Snooze { minutes: Some(10) },
             NOW,
         );
-        let quiet = index.project(&state, &attention, &marks, NOW);
+        let quiet = index.project(&state, &attention, local(&marks, &Aliases::default()));
         assert_eq!(order(&quiet.needs_you), [pane_key("host-a", "p2")]);
 
         marks.expire(NOW + 10 * 60_000);
-        let awake = index.project(&state, &attention, &marks, NOW + 10 * 60_000);
+        let awake = index.project(
+            &state,
+            &attention,
+            LocalView {
+                marks: &marks,
+                aliases: &Aliases::default(),
+                now_ms: NOW + 10 * 60_000,
+            },
+        );
 
         assert_eq!(
             order(&awake.needs_you),
@@ -1236,7 +1335,11 @@ mod tests {
             TargetConnectionState::Live,
             Some(session_snapshot("p1", "abc123")),
         )]);
-        let first = index.project(&before, &attention, &AgentMarks::default(), NOW);
+        let first = index.project(
+            &before,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
         let identity = first.needs_you[0].agent.clone();
 
         let after = federation(vec![(
@@ -1244,7 +1347,11 @@ mod tests {
             TargetConnectionState::Live,
             Some(session_snapshot("p2", "abc123")),
         )]);
-        let moved = index.project(&after, &attention, &AgentMarks::default(), NOW);
+        let moved = index.project(
+            &after,
+            &attention,
+            local(&AgentMarks::default(), &Aliases::default()),
+        );
 
         assert_eq!(
             moved
@@ -1273,7 +1380,11 @@ mod tests {
             Some(session_snapshot("p1", "abc123")),
         )]);
         let identity = index
-            .project(&before, &attention, &AgentMarks::default(), NOW)
+            .project(
+                &before,
+                &attention,
+                local(&AgentMarks::default(), &Aliases::default()),
+            )
             .needs_you[0]
             .agent
             .clone();
@@ -1285,7 +1396,7 @@ mod tests {
             TargetConnectionState::Live,
             Some(session_snapshot("p2", "abc123")),
         )]);
-        let moved = index.project(&after, &attention, &marks, NOW);
+        let moved = index.project(&after, &attention, local(&marks, &Aliases::default()));
 
         assert!(
             moved.needs_you[0].marks.pinned,
@@ -1312,8 +1423,7 @@ mod tests {
         let projection = index.project(
             &state,
             &AttentionIndex::default(),
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert_eq!(projection.needs_you.len(), 1, "one identity is one card");
@@ -1346,8 +1456,7 @@ mod tests {
         let projection = index.project(
             &state,
             &AttentionIndex::default(),
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert_eq!(projection.needs_you.len(), 2);
@@ -1387,8 +1496,7 @@ mod tests {
         let projection = index.project(
             &state,
             &AttentionIndex::default(),
-            &AgentMarks::default(),
-            NOW,
+            local(&AgentMarks::default(), &Aliases::default()),
         );
 
         assert_eq!(
@@ -1417,6 +1525,91 @@ mod tests {
     /// The identity a pane-keyed agent gets. Written out here rather than
     /// hidden behind the production helper, so a test that asserts on identity
     /// would notice the format changing under it.
+    #[test]
+    fn a_local_name_is_shown_beside_the_host_own_word_and_never_instead_of_the_identity() {
+        let mut index = AgentCardIndex::default();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(json!({
+                "workspaces": [],
+                "panes": [{"pane_id": "p1"}],
+                "agents": [{"pane_id": "p1", "name": "builder", "agent_status": "blocked"}]
+            })),
+        )]);
+        let mut aliases = Aliases::default();
+        let agent = ResourceRef::Agent(pane_agent("host-a", "p1"));
+        aliases
+            .set(agent.clone(), "the flaky one", "builder")
+            .unwrap();
+        aliases.favourite(agent).unwrap();
+
+        let card = index
+            .project(
+                &state,
+                &AttentionIndex::default(),
+                local(&AgentMarks::default(), &aliases),
+            )
+            .needs_you
+            .remove(0);
+
+        assert_eq!(card.alias.as_deref(), Some("the flaky one"));
+        assert_eq!(
+            card.title, "builder",
+            "the host's own word is kept, so a client can show both"
+        );
+        assert!(card.favourite);
+        assert!(!card.alias_suspended);
+        assert_eq!(
+            card.agent.resource,
+            format!("pane{AGENT_KEY_SEPARATOR}p1"),
+            "a name is never part of the identity"
+        );
+    }
+
+    #[test]
+    fn a_name_over_an_agent_the_host_now_calls_something_else_is_suspended() {
+        let mut index = AgentCardIndex::default();
+        let mut aliases = Aliases::default();
+        aliases
+            .set(
+                ResourceRef::Agent(pane_agent("host-a", "p1")),
+                "the flaky one",
+                "builder",
+            )
+            .unwrap();
+        let state = federation(vec![(
+            "host-a",
+            TargetConnectionState::Live,
+            Some(json!({
+                "workspaces": [],
+                "panes": [{"pane_id": "p1"}],
+                "agents": [{"pane_id": "p1", "name": "customer demo", "agent_status": "blocked"}]
+            })),
+        )]);
+
+        let card = index
+            .project(
+                &state,
+                &AttentionIndex::default(),
+                local(&AgentMarks::default(), &aliases),
+            )
+            .needs_you
+            .remove(0);
+
+        assert!(card.alias.is_none(), "a suspended name is not applied");
+        assert!(card.alias_suspended, "and it is not forgotten either");
+        assert_eq!(card.title, "customer demo");
+    }
+
+    fn local<'a>(marks: &'a AgentMarks, aliases: &'a Aliases) -> LocalView<'a> {
+        LocalView {
+            marks,
+            aliases,
+            now_ms: NOW,
+        }
+    }
+
     fn pane_agent(target: &str, resource: &str) -> AgentId {
         AgentId::new(
             target,

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -1,0 +1,560 @@
+//! Names, favourites and jump slots that belong to this Super-Herdr and to
+//! nobody else's Herdr.
+//!
+//! A person running agents on five machines ends up with `w1`, `w3` and `wD`
+//! meaning "the compiler one", "the flaky one" and "the customer's". Herdr can
+//! be told to rename a workspace, but that changes it for everybody using that
+//! host and is somebody else's decision. So these are local: a label this
+//! installation shows, a set of destinations worth one action, and nine slots
+//! for the ones somebody jumps to constantly.
+//!
+//! Three rules, and the third is the whole difficulty:
+//!
+//! * **An alias is never an identity.** Everything is keyed by a qualified id
+//!   and looked up by it. A label is what gets drawn, and nothing routes,
+//!   resolves or matches by it — which is why two hosts can both have "build"
+//!   without anything colliding.
+//! * **Nothing here renames anything on a host.** Herdr's own rename is a
+//!   separate, explicit action; this never calls it, and a local alias sitting
+//!   over a Herdr label leaves that label alone.
+//! * **A reused id must not inherit a name.** Herdr's ids are server-local and
+//!   can come back: delete `w1` and the next workspace may be `w1` again. An
+//!   alias keyed only by that id would silently move onto a different
+//!   workspace, and the person would see a name they trust over something they
+//!   have never looked at. So an alias also records what the resource was
+//!   called when it was named. When that no longer matches, the alias is
+//!   *suspended* rather than applied or deleted: shown as needing confirmation,
+//!   because guessing either way is worse than asking.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::attention::{set_directory_permissions, set_file_permissions};
+use crate::model::{AgentId, PaneId, TabId, TargetSession, WorkspaceId};
+
+const ALIASES_VERSION: u32 = 1;
+const MAX_ALIASES_BYTES: u64 = 256 * 1024;
+const MAX_ALIASES: usize = 512;
+const MAX_FAVOURITES: usize = 64;
+pub const MAX_ALIAS_CHARACTERS: usize = 48;
+/// Slots are the digits somebody can actually press.
+pub const JUMP_SLOTS: std::ops::RangeInclusive<u8> = 1..=9;
+
+/// Anything that can be named, favourited or jumped to.
+///
+/// One enum rather than five stores, because the rules — bounded, qualified,
+/// never routing — are the same for all of them, and a person renaming a pane
+/// should not discover that panes were the kind nobody implemented.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResourceRef {
+    Target(TargetSession),
+    Workspace(WorkspaceId),
+    Tab(TabId),
+    Pane(PaneId),
+    Agent(AgentId),
+}
+
+impl std::fmt::Display for ResourceRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Target(id) => write!(formatter, "{id}"),
+            Self::Workspace(id) => write!(formatter, "{id}"),
+            Self::Tab(id) => write!(formatter, "{id}"),
+            Self::Pane(id) => write!(formatter, "{id}"),
+            Self::Agent(id) => write!(formatter, "{id}"),
+        }
+    }
+}
+
+/// A local name, and what the resource was called when it was given.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Alias {
+    pub label: String,
+    /// What the host called it at the time. Kept as evidence rather than as
+    /// display: it is how a reused id is told apart from the resource somebody
+    /// actually named.
+    pub observed: String,
+}
+
+/// Whether an alias may be shown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AliasState {
+    /// The resource still looks like the one that was named.
+    Current,
+    /// The host now calls it something else. It may have been renamed, or the
+    /// id may have been reused by something entirely different, and this
+    /// cannot tell which.
+    Suspended,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Aliases {
+    names: BTreeMap<ResourceRef, Alias>,
+    favourites: Vec<ResourceRef>,
+    slots: BTreeMap<u8, ResourceRef>,
+}
+
+impl Aliases {
+    /// Name something, recording what it is called now.
+    pub fn set(&mut self, resource: ResourceRef, label: &str, observed: &str) -> Result<()> {
+        let label = label.trim();
+        if label.is_empty() || label.chars().count() > MAX_ALIAS_CHARACTERS {
+            bail!("a name must be 1 to {MAX_ALIAS_CHARACTERS} characters");
+        }
+        if label.chars().any(char::is_control) {
+            bail!("a name must not contain control characters");
+        }
+        if self.names.len() >= MAX_ALIASES && !self.names.contains_key(&resource) {
+            bail!("at most {MAX_ALIASES} names can be kept");
+        }
+        self.names.insert(
+            resource,
+            Alias {
+                label: label.to_owned(),
+                observed: observed.to_owned(),
+            },
+        );
+        Ok(())
+    }
+
+    pub fn clear(&mut self, resource: &ResourceRef) -> bool {
+        self.names.remove(resource).is_some()
+    }
+
+    /// The name to show, and whether it can be trusted.
+    ///
+    /// `observed` is what the host calls the resource right now. A caller that
+    /// does not know passes what it has; a mismatch suspends rather than
+    /// retargets, because a name shown over the wrong resource is worse than
+    /// no name at all.
+    pub fn resolve(&self, resource: &ResourceRef, observed: &str) -> Option<(&str, AliasState)> {
+        let alias = self.names.get(resource)?;
+        let state = if alias.observed == observed {
+            AliasState::Current
+        } else {
+            AliasState::Suspended
+        };
+        Some((alias.label.as_str(), state))
+    }
+
+    /// Accept that a suspended alias still belongs to this resource.
+    ///
+    /// The person looked and said so. Nothing else can: the host offers no way
+    /// to tell a rename from a reuse.
+    pub fn confirm(&mut self, resource: &ResourceRef, observed: &str) -> bool {
+        let Some(alias) = self.names.get_mut(resource) else {
+            return false;
+        };
+        alias.observed = observed.to_owned();
+        true
+    }
+
+    pub fn favourite(&mut self, resource: ResourceRef) -> Result<bool> {
+        if let Some(index) = self.favourites.iter().position(|held| held == &resource) {
+            self.favourites.remove(index);
+            return Ok(false);
+        }
+        if self.favourites.len() >= MAX_FAVOURITES {
+            bail!("at most {MAX_FAVOURITES} favourites can be kept");
+        }
+        self.favourites.push(resource);
+        Ok(true)
+    }
+
+    pub fn is_favourite(&self, resource: &ResourceRef) -> bool {
+        self.favourites.contains(resource)
+    }
+
+    pub fn favourites(&self) -> &[ResourceRef] {
+        &self.favourites
+    }
+
+    /// Put something in a numbered slot, or clear one.
+    ///
+    /// A slot holds one thing: assigning over an occupied slot replaces it,
+    /// because that is what pressing a number is for, and the same resource
+    /// leaves whatever other slot it was in rather than answering to two.
+    pub fn set_slot(&mut self, slot: u8, resource: Option<ResourceRef>) -> Result<()> {
+        if !JUMP_SLOTS.contains(&slot) {
+            bail!(
+                "a jump slot must be between {} and {}",
+                JUMP_SLOTS.start(),
+                JUMP_SLOTS.end()
+            );
+        }
+        match resource {
+            Some(resource) => {
+                self.slots.retain(|_, held| held != &resource);
+                self.slots.insert(slot, resource);
+            }
+            None => {
+                self.slots.remove(&slot);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn slot(&self, slot: u8) -> Option<&ResourceRef> {
+        self.slots.get(&slot)
+    }
+
+    pub fn slots(&self) -> impl Iterator<Item = (u8, &ResourceRef)> {
+        self.slots.iter().map(|(slot, resource)| (*slot, resource))
+    }
+
+    /// Every target any name, favourite or slot refers to.
+    pub fn targets(&self) -> std::collections::BTreeSet<TargetSession> {
+        self.names
+            .keys()
+            .chain(self.favourites.iter())
+            .chain(self.slots.values())
+            .map(target_of)
+            .collect()
+    }
+
+    /// Forget everything about resources on a target that is no longer
+    /// configured.
+    ///
+    /// Removing a target from the configuration is a decision; keeping names
+    /// for its panes forever is not. Nothing is forgotten because a host was
+    /// merely unreachable — that is not a decision anybody made.
+    pub fn forget_target(&mut self, target: &TargetSession) -> bool {
+        let before = self.names.len() + self.favourites.len() + self.slots.len();
+        self.names.retain(|resource, _| !belongs(resource, target));
+        self.favourites
+            .retain(|resource| !belongs(resource, target));
+        self.slots.retain(|_, resource| !belongs(resource, target));
+        before != self.names.len() + self.favourites.len() + self.slots.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty() && self.favourites.is_empty() && self.slots.is_empty()
+    }
+}
+
+fn target_of(resource: &ResourceRef) -> TargetSession {
+    match resource {
+        ResourceRef::Target(id) => id.clone(),
+        ResourceRef::Workspace(id) => id.target_session(),
+        ResourceRef::Tab(id) => id.target_session(),
+        ResourceRef::Pane(id) => id.target_session(),
+        ResourceRef::Agent(id) => id.target_session(),
+    }
+}
+
+fn belongs(resource: &ResourceRef, target: &TargetSession) -> bool {
+    &target_of(resource) == target
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedAliases {
+    version: u32,
+    names: Vec<(ResourceRef, Alias)>,
+    favourites: Vec<ResourceRef>,
+    slots: Vec<(u8, ResourceRef)>,
+}
+
+impl From<&Aliases> for PersistedAliases {
+    fn from(aliases: &Aliases) -> Self {
+        Self {
+            version: ALIASES_VERSION,
+            names: aliases
+                .names
+                .iter()
+                .map(|(resource, alias)| (resource.clone(), alias.clone()))
+                .collect(),
+            favourites: aliases.favourites.clone(),
+            slots: aliases
+                .slots
+                .iter()
+                .map(|(slot, resource)| (*slot, resource.clone()))
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<PersistedAliases> for Aliases {
+    type Error = anyhow::Error;
+
+    fn try_from(persisted: PersistedAliases) -> Result<Self> {
+        if persisted.version != ALIASES_VERSION {
+            bail!("persisted aliases have an unsupported version");
+        }
+        if persisted.names.len() > MAX_ALIASES || persisted.favourites.len() > MAX_FAVOURITES {
+            bail!("persisted aliases hold more than the limits allow");
+        }
+        Ok(Self {
+            names: persisted.names.into_iter().collect(),
+            favourites: persisted.favourites,
+            slots: persisted
+                .slots
+                .into_iter()
+                .filter(|(slot, _)| JUMP_SLOTS.contains(slot))
+                .collect(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AliasStore {
+    path: PathBuf,
+}
+
+impl AliasStore {
+    pub fn discover() -> Result<Self> {
+        let root = if let Some(root) = env::var_os("XDG_STATE_HOME") {
+            PathBuf::from(root)
+        } else {
+            let home: OsString = env::var_os("HOME")
+                .context("XDG_STATE_HOME or HOME is required to persist Super-Herdr aliases")?;
+            PathBuf::from(home).join(".local/state")
+        };
+        Ok(Self {
+            path: root.join("super-herdr/aliases.json"),
+        })
+    }
+
+    pub fn at(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn load(&self) -> Result<Aliases> {
+        let metadata = match fs::metadata(&self.path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Aliases::default());
+            }
+            Err(error) => return Err(error).context("failed to inspect aliases"),
+        };
+        if metadata.len() > MAX_ALIASES_BYTES {
+            bail!("persisted aliases exceed the size limit");
+        }
+        let bytes = fs::read(&self.path).context("failed to read aliases")?;
+        let persisted: PersistedAliases =
+            serde_json::from_slice(&bytes).context("persisted aliases are invalid")?;
+        persisted.try_into()
+    }
+
+    pub fn save(&self, aliases: &Aliases) -> Result<()> {
+        let directory = self
+            .path
+            .parent()
+            .context("the aliases path has no parent directory")?;
+        fs::create_dir_all(directory).context("failed to create the aliases directory")?;
+        set_directory_permissions(directory)?;
+        let mut temporary = tempfile::Builder::new()
+            .prefix(".aliases-")
+            .tempfile_in(directory)
+            .context("failed to create a temporary aliases file")?;
+        set_file_permissions(temporary.path())?;
+        serde_json::to_writer(&mut temporary, &PersistedAliases::from(aliases))
+            .context("failed to encode aliases")?;
+        temporary
+            .write_all(b"\n")
+            .context("failed to finish aliases")?;
+        temporary
+            .as_file()
+            .sync_all()
+            .context("failed to synchronize aliases")?;
+        temporary
+            .persist(&self.path)
+            .context("failed to atomically replace aliases")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AliasState, AliasStore, Aliases, MAX_ALIAS_CHARACTERS, ResourceRef};
+    use crate::model::{PaneId, TargetSession, WorkspaceId};
+
+    fn workspace(target: &str, resource: &str) -> ResourceRef {
+        ResourceRef::Workspace(WorkspaceId::new(target, "work", resource))
+    }
+
+    #[test]
+    fn a_name_is_shown_and_never_routed_by() {
+        let mut aliases = Aliases::default();
+        let here = workspace("host-a", "w1");
+        let there = workspace("host-b", "w1");
+        aliases.set(here.clone(), "compiler", "w1").unwrap();
+
+        assert_eq!(
+            aliases.resolve(&here, "w1"),
+            Some(("compiler", AliasState::Current))
+        );
+        assert_eq!(
+            aliases.resolve(&there, "w1"),
+            None,
+            "two hosts may both call something w1 without sharing a name"
+        );
+    }
+
+    #[test]
+    fn an_id_that_came_back_as_something_else_does_not_inherit_the_name() {
+        let mut aliases = Aliases::default();
+        let workspace = workspace("host-a", "w1");
+        aliases
+            .set(workspace.clone(), "compiler", "toolchain")
+            .unwrap();
+
+        // The host now calls w1 something else: either it was renamed, or the
+        // id was reused. Nothing here can tell which.
+        let resolved = aliases.resolve(&workspace, "customer demo");
+
+        assert_eq!(
+            resolved,
+            Some(("compiler", AliasState::Suspended)),
+            "a name shown over the wrong resource is worse than no name at all"
+        );
+    }
+
+    #[test]
+    fn a_person_can_say_a_suspended_name_still_belongs() {
+        let mut aliases = Aliases::default();
+        let workspace = workspace("host-a", "w1");
+        aliases
+            .set(workspace.clone(), "compiler", "toolchain")
+            .unwrap();
+
+        assert!(aliases.confirm(&workspace, "toolchain v2"));
+
+        assert_eq!(
+            aliases.resolve(&workspace, "toolchain v2"),
+            Some(("compiler", AliasState::Current))
+        );
+    }
+
+    #[test]
+    fn a_name_is_bounded_and_free_of_control_characters() {
+        let mut aliases = Aliases::default();
+        let workspace = workspace("host-a", "w1");
+
+        assert!(aliases.set(workspace.clone(), "", "w1").is_err());
+        assert!(
+            aliases
+                .set(
+                    workspace.clone(),
+                    &"x".repeat(MAX_ALIAS_CHARACTERS + 1),
+                    "w1"
+                )
+                .is_err()
+        );
+        assert!(aliases.set(workspace.clone(), "two\nlines", "w1").is_err());
+        assert!(aliases.set(workspace, "  compiler  ", "w1").is_ok());
+    }
+
+    #[test]
+    fn a_favourite_toggles_and_a_slot_holds_one_thing() {
+        let mut aliases = Aliases::default();
+        let first = workspace("host-a", "w1");
+        let second = workspace("host-a", "w2");
+
+        assert!(aliases.favourite(first.clone()).unwrap());
+        assert!(aliases.is_favourite(&first));
+        assert!(!aliases.favourite(first.clone()).unwrap());
+        assert!(!aliases.is_favourite(&first));
+
+        aliases.set_slot(1, Some(first.clone())).unwrap();
+        aliases.set_slot(2, Some(first.clone())).unwrap();
+
+        assert_eq!(
+            aliases.slot(1),
+            None,
+            "one resource does not answer to two slots"
+        );
+        assert_eq!(aliases.slot(2), Some(&first));
+        aliases.set_slot(2, Some(second.clone())).unwrap();
+        assert_eq!(
+            aliases.slot(2),
+            Some(&second),
+            "a slot holds the newest thing put in it"
+        );
+        aliases.set_slot(2, None).unwrap();
+        assert_eq!(aliases.slot(2), None);
+        assert!(aliases.set_slot(0, Some(second)).is_err());
+    }
+
+    #[test]
+    fn removing_a_target_from_the_configuration_forgets_its_names() {
+        let mut aliases = Aliases::default();
+        let gone = TargetSession::new("host-a", "work");
+        aliases
+            .set(workspace("host-a", "w1"), "compiler", "w1")
+            .unwrap();
+        aliases
+            .set(
+                ResourceRef::Pane(PaneId::new("host-b", "work", "w1:p1")),
+                "kept",
+                "p1",
+            )
+            .unwrap();
+        aliases.favourite(workspace("host-a", "w2")).unwrap();
+        aliases
+            .set_slot(1, Some(workspace("host-a", "w2")))
+            .unwrap();
+
+        assert!(aliases.forget_target(&gone));
+
+        assert_eq!(aliases.resolve(&workspace("host-a", "w1"), "w1"), None);
+        assert!(aliases.slot(1).is_none());
+        assert!(aliases.favourites().is_empty());
+        assert!(
+            aliases
+                .resolve(
+                    &ResourceRef::Pane(PaneId::new("host-b", "work", "w1:p1")),
+                    "p1"
+                )
+                .is_some(),
+            "another host's names are not somebody else's configuration change"
+        );
+    }
+
+    #[test]
+    fn names_favourites_and_slots_survive_a_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = AliasStore::at(directory.path().join("aliases.json"));
+        let mut aliases = Aliases::default();
+        let workspace = workspace("host-a", "w1");
+        aliases
+            .set(workspace.clone(), "compiler", "toolchain")
+            .unwrap();
+        aliases.favourite(workspace.clone()).unwrap();
+        aliases.set_slot(3, Some(workspace.clone())).unwrap();
+
+        store.save(&aliases).unwrap();
+        let restored = store.load().unwrap();
+
+        assert_eq!(restored, aliases);
+        assert_eq!(
+            restored.resolve(&workspace, "toolchain"),
+            Some(("compiler", AliasState::Current)),
+            "the evidence a reused id is caught by has to survive too"
+        );
+        assert!(restored.is_favourite(&workspace));
+        assert_eq!(restored.slot(3), Some(&workspace));
+    }
+
+    #[test]
+    fn a_missing_file_is_nothing_named() {
+        let directory = tempfile::tempdir().unwrap();
+
+        assert!(
+            AliasStore::at(directory.path().join("absent.json"))
+                .load()
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -539,6 +539,7 @@ mod tests {
             // No socket is bound in this mode; the path is never used.
             socket: directory.path().join("unused.sock"),
             agent_marks: None,
+            aliases: None,
             attention_state: Some(directory.path().join("attention.json")),
             refresh_interval: Duration::from_secs(3600),
             web_port: None,

--- a/src/client.rs
+++ b/src/client.rs
@@ -521,6 +521,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         }
     }
 
@@ -610,6 +611,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         }]);
         let _ = directory;
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -2311,6 +2311,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,11 @@ const MAX_QUICK_REPLIES: usize = 8;
 /// How many places one target may offer to look in. A picker with a screenful
 /// of roots is a hierarchy again, which is the thing it exists to avoid.
 const MAX_TARGET_ROOTS: usize = 8;
+
+/// How many groupings one target may carry. Past a handful a tag stops
+/// narrowing anything, which is the only thing a tag is for.
+const MAX_TARGET_TAGS: usize = 8;
+const MAX_TAG_CHARACTERS: usize = 24;
 const MAX_QUICK_REPLY_LABEL_CHARACTERS: usize = 24;
 const MAX_QUICK_REPLY_SEND_BYTES: usize = 256;
 
@@ -578,6 +583,12 @@ pub struct Target {
     /// Ordered client candidates. A protocol mismatch advances to the next one.
     #[serde(default = "default_herdr_bins")]
     pub herdr_bins: Vec<String>,
+    /// Local groupings — work, home, lab, a pod name. Super-Herdr's own
+    /// labels for filtering and nothing else: a tag never reaches a host and
+    /// never takes part in identity, so two hosts tagged "work" are still two
+    /// entirely separate targets.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
     /// Directories the remote file picker may look inside on this host.
     ///
     /// Empty means the picker offers nothing for this target, which is the
@@ -819,6 +830,26 @@ impl Config {
                     .any(|binary| binary.trim().is_empty())
             {
                 bail!("target {:?} has an empty herdr_bins entry", target.name);
+            }
+            if target.tags.len() > MAX_TARGET_TAGS {
+                bail!(
+                    "target {:?} carries more than {MAX_TARGET_TAGS} tags",
+                    target.name
+                );
+            }
+            for tag in &target.tags {
+                if tag.is_empty()
+                    || tag.chars().count() > MAX_TAG_CHARACTERS
+                    || tag.chars().any(|character| {
+                        character.is_control() || character.is_whitespace() || character == ','
+                    })
+                {
+                    bail!(
+                        "target {:?} has a tag that is not 1 to {MAX_TAG_CHARACTERS} \
+                         characters without spaces or commas",
+                        target.name
+                    );
+                }
             }
             if target.roots.len() > MAX_TARGET_ROOTS {
                 bail!(
@@ -1353,6 +1384,30 @@ roots = ["/srv/build", "/home/example/work"]
     }
 
     #[test]
+    fn a_tag_is_a_short_word_without_spaces_or_commas() {
+        let good = Config::parse(
+            r#"
+[[targets]]
+name = "one"
+ssh = "host"
+tags = ["work", "lab"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(good.targets[0].tags, ["work", "lab"]);
+
+        for bad in ["\"two words\"", "\"with,comma\"", "\"\""] {
+            assert!(
+                Config::parse(&format!(
+                    "\n[[targets]]\nname = \"one\"\nssh = \"host\"\ntags = [{bad}]\n"
+                ))
+                .is_err(),
+                "a tag that cannot be typed as one word is not a grouping: {bad}"
+            );
+        }
+    }
+
+    #[test]
     fn a_target_offers_no_roots_by_default() {
         let config = Config::parse(
             r#"
@@ -1533,6 +1588,7 @@ name = "local"
                 socket: None,
                 herdr_bins: vec!["herdr".to_owned()],
                 roots: Vec::new(),
+                tags: Vec::new(),
             },
         )
         .unwrap();
@@ -1905,6 +1961,7 @@ name = "local"
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
         Config::add_target_file(Some(&path), first).unwrap();
 
@@ -1920,6 +1977,7 @@ name = "local"
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
         Config::add_target_file(Some(&path), second).unwrap();
 
@@ -1942,6 +2000,7 @@ name = "local"
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
         Config::add_target_file(Some(&path), target.clone()).unwrap();
         let before = fs::read(&path).unwrap();
@@ -1980,6 +2039,7 @@ ssh = "build-host"
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
 
         Config::replace_target_file(Some(&path), "development", replacement).unwrap();
@@ -2105,6 +2165,7 @@ ssh = "build-host"
                 socket: None,
                 herdr_bins: vec!["herdr".to_owned()],
                 roots: Vec::new(),
+                tags: Vec::new(),
             },
         )
         .unwrap();

--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -1695,6 +1695,34 @@ function openAgentFromAlert(agent) {
 // person moving between the TUI and this phone reads one inbox rather than two
 // views that disagree the moment a snapshot is a refresh apart.
 let inbox = null;
+// Filters and the landing view are remembered per browser, not per daemon.
+// They are one person's habit on one device — the phone that only ever wants
+// "needs you" and the laptop that wants everything — so they belong where that
+// device keeps its own preferences. Storage can be unavailable or refused, and
+// a page that cannot remember a filter still has to render one.
+const VIEW_KEY = 'super-herdr.view';
+
+function rememberedView() {
+  try {
+    return JSON.parse(localStorage.getItem(VIEW_KEY)) || {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function rememberView() {
+  try {
+    localStorage.setItem(VIEW_KEY, JSON.stringify({
+      state: filters.state,
+      target: filters.target,
+      provider: filters.provider,
+      hierarchy: el('hierarchy').open === true,
+    }));
+  } catch (_) {
+    // A browser that will not remember is not a reason to stop rendering.
+  }
+}
+
 // What is being shown of it. A filter is a view, never a different request:
 // hiding a card here does not change what the daemon sends or what it holds,
 // so a filtered-out agent that starts waiting is still one chip away.
@@ -1736,6 +1764,7 @@ function chip(label, group, value, container) {
   button.setAttribute('aria-pressed', filters[group] === value ? 'true' : 'false');
   button.onclick = () => {
     filters[group] = value;
+    rememberView();
     renderInbox();
   };
   container.append(button);
@@ -1813,12 +1842,21 @@ function renderCard(card, section) {
   row.className = 'row';
   const name = document.createElement('span');
   name.className = 'name';
-  name.textContent = text(card.title) || 'agent';
+  // The local name when there is one that still fits, and the host's own word
+  // underneath it. Never instead of the identity, which the meta line carries.
+  name.textContent = text(card.alias) || text(card.title) || 'agent';
   const badge = document.createElement('span');
   badge.className = 'badge';
   badge.textContent = text(card.status) || 'unknown';
   badge.classList.add(card.stale ? 'gone' : phase(text(card.status)));
   row.append(name, badge);
+  if (card.favourite) {
+    const star = document.createElement('span');
+    star.className = 'badge';
+    star.textContent = '★';
+    star.setAttribute('aria-label', 'favourite');
+    row.append(star);
+  }
   const meta = document.createElement('div');
   meta.className = 'card-meta';
   const where = document.createElement('span');
@@ -1835,6 +1873,18 @@ function renderCard(card, section) {
   open.append(row, meta);
   item.append(open);
 
+  if (card.alias || card.alias_suspended) {
+    const note = document.createElement('div');
+    note.className = 'card-meta';
+    // A suspended name is neither shown as the name nor dropped: the host
+    // calls this something else now, and nothing here can tell a rename from
+    // an id that came back as a different agent.
+    note.textContent = card.alias_suspended
+      ? 'your name for this may be out of date'
+      : `host calls it ${text(card.title)}`;
+    item.append(note);
+  }
+
   const marks = card.marks || {};
   // A gone agent has nothing left to pin, mute or snooze, and storing a mark
   // against an identity that no longer exists would only keep it alive in a
@@ -1843,6 +1893,18 @@ function renderCard(card, section) {
     const strip = document.createElement('div');
     strip.className = 'card-marks';
     markChip(card, 'pin', marks.pinned ? 'Pinned' : 'Pin', Boolean(marks.pinned), strip);
+    const favourite = document.createElement('button');
+    favourite.className = 'chip';
+    favourite.type = 'button';
+    favourite.dataset.mark = 'favourite';
+    favourite.textContent = card.favourite ? 'Favourite' : 'Add favourite';
+    favourite.setAttribute('aria-pressed', card.favourite ? 'true' : 'false');
+    favourite.onclick = () => send({
+      type: 'local.favourite',
+      request: nextCommandRequest++,
+      resource: { kind: 'agent', ...card.agent },
+    });
+    strip.append(favourite);
     markChip(card, 'mute', marks.muted ? 'Muted' : 'Mute', Boolean(marks.muted), strip);
     markChip(
       card, 'snooze', marks.snoozed_until_ms ? 'Snoozed' : 'Snooze',
@@ -1871,7 +1933,20 @@ function renderCard(card, section) {
   return item;
 }
 
+let viewRestored = false;
+
+function restoreView() {
+  if (viewRestored) return;
+  viewRestored = true;
+  const held = rememberedView();
+  for (const group of ['state', 'target', 'provider']) {
+    if (typeof held[group] === 'string') filters[group] = held[group];
+  }
+  if (held.hierarchy === true) el('hierarchy').open = true;
+}
+
 function renderInbox() {
+  restoreView();
   const container = el('inbox-sections');
   container.innerHTML = '';
   if (!inbox) {
@@ -2330,6 +2405,7 @@ for (const button of document.querySelectorAll('.keys button')) {
     el('line').focus();
   };
 }
+el('hierarchy').ontoggle = () => rememberView();
 el('picker-search-form').onsubmit = event => {
   event.preventDefault();
   searchPicker();

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use crate::agent_card::AgentCardProjection;
 use crate::agent_marks::AgentMarkRequest;
+use crate::aliases::ResourceRef;
 use crate::attention::AttentionEvent;
 use crate::config::QuickReply;
 use crate::model::{AgentId, PaneId, TargetSession};
@@ -42,6 +43,27 @@ pub struct ClientId(u64);
 
 /// Work the I/O layer must perform. Route effects are addressed to a pane
 /// rather than a client, because a route is shared.
+/// One change to this installation's own names, favourites and slots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalChange {
+    Name {
+        resource: ResourceRef,
+        label: Option<String>,
+        observed: String,
+    },
+    ConfirmName {
+        resource: ResourceRef,
+        observed: String,
+    },
+    Favourite {
+        resource: ResourceRef,
+    },
+    Slot {
+        slot: u8,
+        resource: Option<ResourceRef>,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Effect {
     Send {
@@ -174,6 +196,14 @@ pub enum Effect {
         request: u64,
         agent: AgentId,
         mark: AgentMarkRequest,
+    },
+    /// Name, favourite or slot one resource locally. Routed and not decided:
+    /// the daemon owns the durable list, for the same reason it owns attention
+    /// history — two writers would overwrite each other's file.
+    LocalNaming {
+        client: ClientId,
+        request: u64,
+        change: LocalChange,
     },
     /// Look inside one of a target's configured roots. The broker routes it
     /// and checks nothing: which roots exist is configuration the daemon
@@ -515,6 +545,45 @@ impl Broker {
                 // delivered late enough to have been asked for afterwards is
                 // an interruption about something already over.
             }
+            ClientMessage::NameResource {
+                request,
+                resource,
+                label,
+                observed,
+            } => effects.push(Effect::LocalNaming {
+                client,
+                request,
+                change: LocalChange::Name {
+                    resource,
+                    label,
+                    observed,
+                },
+            }),
+            ClientMessage::ConfirmResourceName {
+                request,
+                resource,
+                observed,
+            } => effects.push(Effect::LocalNaming {
+                client,
+                request,
+                change: LocalChange::ConfirmName { resource, observed },
+            }),
+            ClientMessage::FavouriteResource { request, resource } => {
+                effects.push(Effect::LocalNaming {
+                    client,
+                    request,
+                    change: LocalChange::Favourite { resource },
+                })
+            }
+            ClientMessage::SetJumpSlot {
+                request,
+                slot,
+                resource,
+            } => effects.push(Effect::LocalNaming {
+                client,
+                request,
+                change: LocalChange::Slot { slot, resource },
+            }),
             ClientMessage::ListRemoteDirectory {
                 request,
                 target,

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -37,10 +37,11 @@ use tokio::task::JoinHandle;
 
 use crate::agent_card::{AgentCardIndex, agent_key_for_pane};
 use crate::agent_marks::{AgentMarkStore, AgentMarks};
+use crate::aliases::{AliasStore, Aliases};
 use crate::attention::{AttentionEventKind, AttentionIndex, AttentionStore, unix_time_ms};
 use crate::clipboard;
 use crate::config::{Config, Device, Target, TransportConfig};
-use crate::daemon::broker::{Broker, ClientId, Effect};
+use crate::daemon::broker::{Broker, ClientId, Effect, LocalChange};
 use crate::daemon::web;
 use crate::model::{PaneId, TargetSession};
 use crate::notifications::NotificationQueue;
@@ -73,6 +74,9 @@ const MAX_PENDING_PAIRING_APPROVALS: usize = 16;
 #[derive(Debug, Clone)]
 pub struct DaemonOptions {
     pub socket: PathBuf,
+    /// Where local names, favourites and jump slots live. `None` discovers the
+    /// standard location.
+    pub aliases: Option<PathBuf>,
     /// Where the durable agent marks live. `None` discovers the standard
     /// location; a test points this somewhere disposable.
     pub agent_marks: Option<PathBuf>,
@@ -114,6 +118,7 @@ impl DaemonOptions {
         Ok(Self {
             socket: root.join("super-herdr/daemon.sock"),
             agent_marks: None,
+            aliases: None,
             attention_state: None,
             refresh_interval: CONFIG_REFRESH_INTERVAL,
             web_port: None,
@@ -706,6 +711,11 @@ struct Daemon {
     agent_cards: AgentCardIndex,
     agent_marks: AgentMarks,
     agent_mark_store: Option<AgentMarkStore>,
+    /// Local names, favourites and jump slots. Held here because they are
+    /// display state the daemon applies once, so every client shows the same
+    /// name rather than each keeping its own list.
+    aliases: Aliases,
+    alias_store: Option<AliasStore>,
     /// Alerts for paired devices. A second sink beside the desktop's own,
     /// which the frontend runs against its attention mirror — this one lives
     /// here because the point of it is a phone learning that an agent is
@@ -1002,6 +1012,34 @@ async fn run(
     // The device sink borrows the desktop's filters, coalescing and rate
     // limits, and is switched on separately: wanting alerts on a phone is not
     // the same request as wanting them on the laptop being sat at.
+    let alias_store = match options.aliases.clone() {
+        Some(path) => Some(AliasStore::at(path)),
+        None => AliasStore::discover().ok(),
+    };
+    let mut aliases = alias_store
+        .as_ref()
+        .and_then(|store| store.load().ok())
+        .unwrap_or_default();
+    // A target somebody removed from the configuration is a decision; its
+    // names going with it follows from that decision rather than from a host
+    // being briefly unreachable.
+    let configured = active
+        .targets
+        .iter()
+        .map(crate::state::target_key)
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut forgot_any = false;
+    for stale in aliases
+        .targets()
+        .into_iter()
+        .filter(|target| !configured.contains(target))
+        .collect::<Vec<_>>()
+    {
+        forgot_any |= aliases.forget_target(&stale);
+    }
+    if forgot_any && let Some(store) = alias_store.as_ref() {
+        let _ = store.save(&aliases);
+    }
     let mut device_notifications = active.notifications.clone();
     device_notifications.enabled = device_notifications.devices;
     let notify_devices = device_notifications.enabled;
@@ -1031,6 +1069,8 @@ async fn run(
         agent_cards: AgentCardIndex::default(),
         agent_marks,
         agent_mark_store,
+        aliases,
+        alias_store,
         device_notifications: NotificationQueue::new(device_notifications, None),
         command_timeout: Duration::from_secs(active.transport.command_timeout_seconds),
         inputs: inputs.clone(),
@@ -1821,6 +1861,56 @@ impl Daemon {
                     destination,
                     name,
                 } => self.begin_between(client, request, source, path, destination, name),
+                Effect::LocalNaming {
+                    client,
+                    request,
+                    change,
+                } => {
+                    let outcome = match change {
+                        LocalChange::Name {
+                            resource,
+                            label: Some(label),
+                            observed,
+                        } => self.aliases.set(resource, &label, &observed).map(|()| true),
+                        LocalChange::Name {
+                            resource,
+                            label: None,
+                            ..
+                        } => Ok(self.aliases.clear(&resource)),
+                        LocalChange::ConfirmName { resource, observed } => {
+                            Ok(self.aliases.confirm(&resource, &observed))
+                        }
+                        LocalChange::Favourite { resource } => {
+                            self.aliases.favourite(resource).map(|_| true)
+                        }
+                        LocalChange::Slot { slot, resource } => {
+                            self.aliases.set_slot(slot, resource).map(|()| true)
+                        }
+                    };
+                    match outcome {
+                        Ok(changed) => {
+                            if changed {
+                                if let Some(store) = self.alias_store.as_ref() {
+                                    // A failed write costs the next restart
+                                    // these names and nothing else.
+                                    let _ = store.save(&self.aliases);
+                                }
+                                pending.extend(self.project_agent_cards());
+                            }
+                            if let Some(outbox) = self.outboxes.get(&client) {
+                                let _ = outbox.send(ServerMessage::OperationResult {
+                                    request,
+                                    applied: true,
+                                    message: String::new(),
+                                    plugin_run: None,
+                                });
+                            }
+                        }
+                        // A bounded list that is full, or a name that is not
+                        // one, is answered rather than silently dropped.
+                        Err(error) => self.refuse(client, request, error.to_string()),
+                    }
+                }
                 Effect::ListRemoteDirectory {
                     client,
                     request,
@@ -3036,9 +3126,15 @@ impl Daemon {
         if self.agent_marks.expire(now_ms) {
             self.persist_agent_marks();
         }
-        let projection =
-            self.agent_cards
-                .project(&self.state, &self.attention, &self.agent_marks, now_ms);
+        let projection = self.agent_cards.project(
+            &self.state,
+            &self.attention,
+            crate::agent_card::LocalView {
+                marks: &self.agent_marks,
+                aliases: &self.aliases,
+                now_ms,
+            },
+        );
         self.broker.agent_cards_updated(projection)
     }
 
@@ -3190,6 +3286,7 @@ mod tests {
         let options = DaemonOptions {
             socket: directory.path().join("daemon.sock"),
             agent_marks: None,
+            aliases: None,
             attention_state: Some(directory.path().join("attention.json")),
             refresh_interval: Duration::from_secs(3600),
             web_port: Some(port),
@@ -3291,6 +3388,7 @@ mod tests {
             let options = DaemonOptions {
                 socket: directory.path().join("daemon.sock"),
                 agent_marks: None,
+                aliases: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 // Pinned: these tests are about the socket, not the file.
                 refresh_interval: Duration::from_secs(3600),
@@ -3546,6 +3644,7 @@ mod tests {
             DaemonOptions {
                 socket: socket.clone(),
                 agent_marks: None,
+                aliases: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_millis(50),
                 web_port: None,
@@ -3824,6 +3923,7 @@ mod tests {
             DaemonOptions {
                 socket: socket.clone(),
                 agent_marks: None,
+                aliases: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
@@ -4191,6 +4291,7 @@ mod tests {
                 DaemonOptions {
                     socket: socket.clone(),
                     agent_marks: None,
+                    aliases: None,
                     attention_state: Some(directory.path().join("attention.json")),
                     refresh_interval: Duration::from_secs(3600),
                     web_port: None,
@@ -4261,6 +4362,7 @@ mod tests {
             DaemonOptions {
                 socket: socket.clone(),
                 agent_marks: None,
+                aliases: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: Some(port),
@@ -4913,6 +5015,7 @@ mod tests {
             DaemonOptions {
                 socket: socket.clone(),
                 agent_marks: None,
+                aliases: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
@@ -4992,6 +5095,7 @@ mod tests {
             DaemonOptions {
                 socket: socket.clone(),
                 agent_marks: None,
+                aliases: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,
@@ -5033,6 +5137,7 @@ mod tests {
         let options = DaemonOptions {
             socket: harness.socket(),
             agent_marks: None,
+            aliases: None,
             attention_state: Some(harness.directory.path().join("attention.json")),
             refresh_interval: Duration::from_secs(3600),
             web_port: None,
@@ -5061,6 +5166,7 @@ mod tests {
             DaemonOptions {
                 socket: socket.clone(),
                 agent_marks: None,
+                aliases: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -3356,6 +3356,7 @@ mod tests {
                 socket: None,
                 herdr_bins: vec!["/nonexistent/herdr".to_owned()],
                 roots: Vec::new(),
+                tags: Vec::new(),
             }],
             ..empty_config()
         }
@@ -3374,6 +3375,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         });
         config
     }
@@ -3567,6 +3569,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         }
     }
 
@@ -3913,6 +3916,7 @@ mod tests {
                 socket: None,
                 herdr_bins: vec!["/nonexistent/herdr".to_owned()],
                 roots: Vec::new(),
+                tags: Vec::new(),
             }],
             devices: Vec::new(),
             quick_replies: None,
@@ -4817,6 +4821,7 @@ mod tests {
                 socket: None,
                 herdr_bins: vec!["/nonexistent/herdr".to_owned()],
                 roots: Vec::new(),
+                tags: Vec::new(),
             },
             &Default::default(),
             crate::clipboard::OPAQUE,
@@ -4835,6 +4840,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["/nonexistent/herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
         let error = super::accept_copy(
             &destination,

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -744,6 +744,7 @@ mod tests {
             DaemonOptions {
                 socket: directory.path().join("unused.sock"),
                 agent_marks: None,
+                aliases: None,
                 attention_state: Some(directory.path().join("attention.json")),
                 refresh_interval: Duration::from_secs(3600),
                 web_port: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent_card;
 pub mod agent_marks;
+pub mod aliases;
 pub mod attention;
 pub use super_herdr_bridge as bridge;
 pub mod client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod protocol;
 pub mod remote_files;
 pub mod resource_action;
 pub mod screen;
+pub mod ssh_config;
 pub mod state;
 pub mod terminal;
 pub mod transport;

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,27 @@ enum DeviceCommands {
 
 #[derive(Debug, Subcommand)]
 enum TargetCommands {
+    /// Offer the hosts already in an OpenSSH configuration.
+    ///
+    /// Prints what it found and adds nothing. Naming aliases with `--add` is
+    /// what adds them, and each is probed on its own before it is written.
+    Import {
+        /// An OpenSSH configuration to read. Defaults to ~/.ssh/config.
+        #[arg(long, value_name = "PATH")]
+        ssh_config: Option<PathBuf>,
+        /// Aliases to add. Without this, nothing is written.
+        #[arg(long = "add", value_name = "ALIAS")]
+        add: Vec<String>,
+        /// Tag every alias added by this run.
+        #[arg(long = "tag", value_name = "TAG")]
+        tags: Vec<String>,
+        /// Add an alias even if it did not answer.
+        #[arg(long)]
+        force: bool,
+        /// Per-host probe timeout.
+        #[arg(long, value_name = "SECONDS")]
+        timeout: Option<u64>,
+    },
     /// Add a local or SSH Herdr host to the TOML configuration.
     Add {
         /// Stable name used to qualify this host's Herdr IDs.
@@ -419,7 +440,7 @@ async fn run() -> Result<ExitCode> {
     }
     let command = match command {
         Commands::Target { command } => {
-            return run_target_command(cli.config.as_deref(), command);
+            return run_target_command(cli.config.as_deref(), command).await;
         }
         Commands::Device { command } => {
             return run_device_command(cli.config.as_deref(), command);
@@ -737,7 +758,7 @@ fn run_device_command(
     }
 }
 
-fn run_target_command(
+async fn run_target_command(
     config_path: Option<&std::path::Path>,
     command: TargetCommands,
 ) -> Result<ExitCode> {
@@ -766,6 +787,7 @@ fn run_target_command(
                 // considered decision about a host, written where it can be
                 // read back, rather than a flag typed once while adding one.
                 roots: Vec::new(),
+                tags: Vec::new(),
             };
             let path = Config::add_target_file(config_path, target)?;
             stdout_line(format_args!("added target {name:?} to {}", path.display()))?;
@@ -856,6 +878,109 @@ fn run_target_command(
                 path.display()
             ))?;
             stdout_line(format_args!("no Herdr session was stopped or restarted"))?;
+            Ok(ExitCode::SUCCESS)
+        }
+        TargetCommands::Import {
+            ssh_config,
+            add,
+            tags,
+            force,
+            timeout,
+        } => {
+            let path = ssh_config
+                .or_else(super_herdr::ssh_config::default_path)
+                .context("no OpenSSH configuration to read; pass --ssh-config")?;
+            let hosts = super_herdr::ssh_config::load(&path)?;
+            let (config, config_path) = Config::load(config_path)?;
+            let existing = config
+                .targets
+                .iter()
+                .map(|target| target.name.as_str())
+                .collect::<std::collections::BTreeSet<_>>();
+
+            if add.is_empty() {
+                // A preview and nothing else. A first run that silently
+                // adopted forty hosts, half of them jump boxes, would be a
+                // federation nobody asked for.
+                println!("{} host(s) in {}", hosts.len(), path.display());
+                for host in &hosts {
+                    println!(
+                        "  {}{}",
+                        host.summary(),
+                        if existing.contains(host.alias.as_str()) {
+                            "  (already configured)"
+                        } else {
+                            ""
+                        }
+                    );
+                }
+                println!("\nAdd them by name: super-herdr target import --add NAME [--add NAME]");
+                return Ok(ExitCode::SUCCESS);
+            }
+
+            let timeout =
+                Duration::from_secs(timeout.unwrap_or(config.transport.command_timeout_seconds));
+            let mut candidates = Vec::new();
+            for alias in &add {
+                if existing.contains(alias.as_str()) {
+                    println!("{alias}: already configured, left alone");
+                    continue;
+                }
+                if !hosts.iter().any(|host| &host.alias == alias) {
+                    println!("{alias}: not in {}", path.display());
+                    continue;
+                }
+                candidates.push(Target {
+                    name: alias.clone(),
+                    ssh: Some(alias.clone()),
+                    discover_sessions: true,
+                    session: None,
+                    socket: None,
+                    herdr_bins: vec!["herdr".to_owned()],
+                    roots: Vec::new(),
+                    tags: tags.clone(),
+                });
+            }
+
+            // Probed together and reported apart: one host being unreachable
+            // says nothing about the others, and a wizard that gave up on the
+            // first failure would be one people run once.
+            let probing = Config {
+                targets: candidates.clone(),
+                ..config.clone()
+            };
+            let reports = if candidates.is_empty() {
+                Vec::new()
+            } else {
+                probe_all(&probing, timeout).await?
+            };
+
+            let mut added = 0;
+            for candidate in candidates {
+                let report = reports
+                    .iter()
+                    .find(|report| report.target == candidate.name);
+                if report.is_some_and(|report| report.ok) || force {
+                    Config::add_target_file(Some(&config_path), candidate.clone())?;
+                    println!("{}: added", candidate.name);
+                    added += 1;
+                    continue;
+                }
+                // Reported and not written. An alias that names a machine
+                // Herdr is not on is a target that would fail on every refresh
+                // afterwards, and adding it anyway is how a federation fills
+                // with entries nobody meant.
+                println!(
+                    "{}: not added; {}",
+                    candidate.name,
+                    report
+                        .and_then(|report| report.error.clone())
+                        .unwrap_or_else(|| "it was not probed".to_owned())
+                );
+            }
+            if added > 0 {
+                println!("\nWrote {} target(s) to {}", added, config_path.display());
+            }
             Ok(ExitCode::SUCCESS)
         }
         TargetCommands::List => {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -39,6 +39,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::agent_card::AgentCardProjection;
 use crate::agent_marks::AgentMarkRequest;
+use crate::aliases::ResourceRef;
 use crate::attention::AttentionEvent;
 use crate::config::QuickReply;
 use crate::model::{AgentId, PaneId, TargetSession};
@@ -365,6 +366,39 @@ pub enum ClientMessage {
     ///
     /// `glob` is what makes the query a pattern; without it the query matches
     /// as literal text, so somebody searching for `[` finds a file called `[`.
+    /// Name, favourite, or slot one qualified resource locally.
+    ///
+    /// None of this reaches a host. A local name sits over Herdr's own label
+    /// and leaves it alone; renaming on the host is a separate, explicit
+    /// action, because it changes what everybody using that host sees.
+    #[serde(rename = "local.name")]
+    NameResource {
+        request: u64,
+        resource: ResourceRef,
+        /// Absent clears the name.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+        /// What the host calls it now, as the client is currently showing it.
+        /// Recorded so an id the host later reuses cannot inherit the name.
+        observed: String,
+    },
+    /// Accept that a suspended name still belongs to this resource.
+    #[serde(rename = "local.confirm_name")]
+    ConfirmResourceName {
+        request: u64,
+        resource: ResourceRef,
+        observed: String,
+    },
+    #[serde(rename = "local.favourite")]
+    FavouriteResource { request: u64, resource: ResourceRef },
+    /// Put a resource in a numbered jump slot, or clear the slot.
+    #[serde(rename = "local.slot")]
+    SetJumpSlot {
+        request: u64,
+        slot: u8,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resource: Option<ResourceRef>,
+    },
     #[serde(rename = "files.search")]
     SearchRemoteFiles {
         request: u64,
@@ -702,6 +736,7 @@ mod tests {
         AgentCardSection,
     };
     use crate::agent_marks::{AgentMarkRequest, AgentMarkState, NotifyMode};
+    use crate::aliases::ResourceRef;
     use crate::attention::{AttentionEvent, AttentionEventKind};
     use crate::model::{AgentId, PaneId, TargetSession, WorkspaceId};
     use crate::operation::Operation;
@@ -843,6 +878,26 @@ mod tests {
         round_trip_client(ClientMessage::ClearSeenAttention);
         round_trip_client(ClientMessage::SubscribeAgentCards);
         round_trip_client(ClientMessage::SubscribeNotifications);
+        round_trip_client(ClientMessage::NameResource {
+            request: 16,
+            resource: ResourceRef::Workspace(WorkspaceId::new("first", "default", "w1")),
+            label: Some("compiler".to_owned()),
+            observed: "w1".to_owned(),
+        });
+        round_trip_client(ClientMessage::ConfirmResourceName {
+            request: 17,
+            resource: ResourceRef::Agent(AgentId::new("first", "default", "a1")),
+            observed: "reviewer".to_owned(),
+        });
+        round_trip_client(ClientMessage::FavouriteResource {
+            request: 18,
+            resource: ResourceRef::Pane(pane()),
+        });
+        round_trip_client(ClientMessage::SetJumpSlot {
+            request: 19,
+            slot: 3,
+            resource: Some(ResourceRef::Target(TargetSession::new("first", "default"))),
+        });
         round_trip_client(ClientMessage::UnsubscribeNotifications);
         round_trip_client(ClientMessage::ListRemoteDirectory {
             request: 14,
@@ -906,6 +961,9 @@ mod tests {
                     stale: false,
                     actionable: true,
                     last_change_ms: Some(1_700_000_000_000),
+                    alias: Some("reviewer".to_owned()),
+                    alias_suspended: false,
+                    favourite: true,
                     marks: AgentMarkState {
                         pinned: true,
                         muted: false,

--- a/src/remote_files.rs
+++ b/src/remote_files.rs
@@ -367,6 +367,7 @@ mod tests {
             socket: None,
             herdr_bins: Vec::new(),
             roots: roots.iter().map(|root| (*root).to_owned()).collect(),
+            tags: Vec::new(),
         }
     }
 

--- a/src/ssh_config.rs
+++ b/src/ssh_config.rs
@@ -1,0 +1,342 @@
+//! Reading the hosts somebody already has in their OpenSSH configuration.
+//!
+//! Anybody with several machines already wrote them down once. Asking them to
+//! write the same names into a second file, correctly, before Super-Herdr works
+//! at all is the step where people stop — so this reads what is there and
+//! offers it.
+//!
+//! It offers and never takes. Parsing a configuration is a suggestion; adding a
+//! target is a decision, made by naming the aliases wanted. A first run that
+//! silently adopted forty hosts, half of them jump boxes and CI runners, would
+//! be a federation nobody asked for and a probe against machines nobody meant
+//! to touch.
+//!
+//! What is parsed is deliberately a fraction of the format. `Host` blocks and
+//! their `HostName`, `User` and `Port` are enough to show somebody which
+//! machine an alias means; `Match` blocks, canonicalisation and the rest change
+//! what ssh does without changing which aliases exist, and reimplementing them
+//! would mean a second, worse ssh. Nothing here is used to *connect* — that
+//! stays ssh's job, given the alias — so a detail this skips cannot change
+//! where a connection goes.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// How many files an `Include` chain may pull in, and how deep it may go.
+/// A configuration that fans out further than this is not one this should be
+/// reading at startup.
+const MAX_INCLUDE_DEPTH: usize = 3;
+const MAX_FILES: usize = 64;
+const MAX_HOSTS: usize = 512;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshHost {
+    pub alias: String,
+    pub hostname: Option<String>,
+    pub user: Option<String>,
+    pub port: Option<u16>,
+}
+
+impl SshHost {
+    /// One line describing what this alias means, for a preview somebody reads
+    /// before choosing.
+    pub fn summary(&self) -> String {
+        let mut summary = self.alias.clone();
+        if let Some(hostname) = &self.hostname {
+            let user = self
+                .user
+                .as_ref()
+                .map(|user| format!("{user}@"))
+                .unwrap_or_default();
+            summary.push_str(&format!("  {user}{hostname}"));
+        }
+        if let Some(port) = self.port {
+            summary.push_str(&format!(":{port}"));
+        }
+        summary
+    }
+}
+
+/// Read the aliases from a configuration file and everything it includes.
+pub fn load(path: &Path) -> Result<Vec<SshHost>> {
+    let mut seen = BTreeSet::new();
+    let mut hosts = Vec::new();
+    read_into(path, 0, &mut seen, &mut hosts)?;
+    hosts.truncate(MAX_HOSTS);
+    Ok(hosts)
+}
+
+/// Where OpenSSH keeps a user's configuration.
+pub fn default_path() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".ssh/config"))
+}
+
+fn read_into(
+    path: &Path,
+    depth: usize,
+    seen: &mut BTreeSet<PathBuf>,
+    hosts: &mut Vec<SshHost>,
+) -> Result<()> {
+    if depth > MAX_INCLUDE_DEPTH || seen.len() >= MAX_FILES || !seen.insert(path.to_path_buf()) {
+        return Ok(());
+    }
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    for (host, include) in parse_into(&text) {
+        match (host, include) {
+            (Some(host), _) => hosts.push(host),
+            (None, Some(pattern)) => {
+                for included in expand_include(path, &pattern) {
+                    // A file that cannot be read is skipped rather than fatal:
+                    // an Include naming something absent is ordinary, and
+                    // refusing to show any hosts because of it would be worse
+                    // than showing the ones that were readable.
+                    let _ = read_into(&included, depth + 1, seen, hosts);
+                }
+            }
+            (None, None) => {}
+        }
+    }
+    Ok(())
+}
+
+/// Aliases and includes, in the order they appear.
+fn parse_into(text: &str) -> Vec<(Option<SshHost>, Option<String>)> {
+    let mut found: Vec<(Option<SshHost>, Option<String>)> = Vec::new();
+    let mut current: Vec<usize> = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (keyword, value) = match line.split_once([' ', '\t', '=']) {
+            Some((keyword, value)) => (
+                keyword.to_ascii_lowercase(),
+                value.trim().trim_start_matches('=').trim(),
+            ),
+            None => (line.to_ascii_lowercase(), ""),
+        };
+        match keyword.as_str() {
+            "host" => {
+                current.clear();
+                for alias in value.split_whitespace() {
+                    // A pattern is not a host somebody can be offered: `*` and
+                    // `web-?` name whatever matches later, and a negation names
+                    // what does not. Offering one would produce a target whose
+                    // destination ssh cannot resolve.
+                    if alias.contains(['*', '?']) || alias.starts_with('!') {
+                        continue;
+                    }
+                    current.push(found.len());
+                    found.push((
+                        Some(SshHost {
+                            alias: alias.to_owned(),
+                            hostname: None,
+                            user: None,
+                            port: None,
+                        }),
+                        None,
+                    ));
+                }
+            }
+            // A Match block changes which options apply, not which aliases
+            // exist. Ending the current block is enough: options inside it are
+            // not attributed to the last Host, which would misdescribe it.
+            "match" => current.clear(),
+            "include" => found.push((None, Some(value.to_owned()))),
+            "hostname" | "user" | "port" => {
+                for index in &current {
+                    let Some((Some(host), _)) = found.get_mut(*index) else {
+                        continue;
+                    };
+                    match keyword.as_str() {
+                        "hostname" => host.hostname = Some(value.to_owned()),
+                        "user" => host.user = Some(value.to_owned()),
+                        _ => host.port = value.parse().ok(),
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    found
+}
+
+/// Turn one `Include` value into the files it names.
+///
+/// Relative paths are relative to the including file's directory, which is what
+/// ssh does. Globs are expanded only one level and only by literal directory
+/// reading, because the alternative is a glob crate for a feature that lists
+/// somebody's own files.
+fn expand_include(from: &Path, pattern: &str) -> Vec<PathBuf> {
+    let mut expanded = Vec::new();
+    for entry in pattern.split_whitespace() {
+        let entry = entry.trim_matches('"');
+        let path = if let Some(rest) = entry.strip_prefix("~/") {
+            let Some(home) = std::env::var_os("HOME") else {
+                continue;
+            };
+            PathBuf::from(home).join(rest)
+        } else if entry.starts_with('/') {
+            PathBuf::from(entry)
+        } else {
+            from.parent().unwrap_or(Path::new(".")).join(entry)
+        };
+        let Some(name) = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+        else {
+            continue;
+        };
+        if !name.contains(['*', '?']) {
+            expanded.push(path);
+            continue;
+        }
+        let Some(directory) = path.parent() else {
+            continue;
+        };
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        let prefix = name.split(['*', '?']).next().unwrap_or_default().to_owned();
+        for entry in entries.flatten() {
+            let candidate = entry.file_name().to_string_lossy().into_owned();
+            if candidate.starts_with(&prefix) && entry.path().is_file() {
+                expanded.push(entry.path());
+            }
+        }
+    }
+    expanded.sort();
+    expanded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SshHost, load, parse_into};
+
+    fn hosts(text: &str) -> Vec<SshHost> {
+        parse_into(text)
+            .into_iter()
+            .filter_map(|(host, _)| host)
+            .collect()
+    }
+
+    #[test]
+    fn aliases_carry_enough_to_tell_which_machine_they_mean() {
+        let parsed =
+            hosts("Host build\n  HostName build.internal.example\n  User deploy\n  Port 2222\n");
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].alias, "build");
+        assert_eq!(
+            parsed[0].summary(),
+            "build  deploy@build.internal.example:2222"
+        );
+    }
+
+    #[test]
+    fn a_pattern_is_not_a_host_anybody_can_be_offered() {
+        let parsed = hosts("Host *\n  User default\n\nHost web-?\n\nHost !secret prod\n");
+
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|host| host.alias.as_str())
+                .collect::<Vec<_>>(),
+            ["prod"],
+            "a wildcard names whatever matches later, which is not a machine to add"
+        );
+    }
+
+    #[test]
+    fn one_block_naming_several_aliases_produces_several_hosts() {
+        let parsed = hosts("Host build ci\n  HostName shared.example\n");
+
+        assert_eq!(parsed.len(), 2);
+        assert!(
+            parsed
+                .iter()
+                .all(|host| host.hostname.as_deref() == Some("shared.example")),
+            "options in a block belong to every alias it named"
+        );
+    }
+
+    #[test]
+    fn options_after_a_match_block_are_not_attributed_to_the_last_host() {
+        let parsed =
+            hosts("Host build\n  HostName build.example\n\nMatch host anything\n  User root\n");
+
+        assert_eq!(parsed[0].hostname.as_deref(), Some("build.example"));
+        assert_eq!(
+            parsed[0].user, None,
+            "a Match block changes which options apply, not which host they describe"
+        );
+    }
+
+    #[test]
+    fn keywords_are_case_insensitive_and_may_use_equals() {
+        let parsed = hosts("HOST=build\n  hostname=build.example\n  PORT = 2200\n");
+
+        assert_eq!(parsed[0].alias, "build");
+        assert_eq!(parsed[0].hostname.as_deref(), Some("build.example"));
+        assert_eq!(parsed[0].port, Some(2200));
+    }
+
+    #[test]
+    fn comments_and_blank_lines_are_not_hosts() {
+        assert!(hosts("# Host commented\n\n   \n").is_empty());
+    }
+
+    #[test]
+    fn an_include_pulls_in_the_hosts_it_names() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join("extra"),
+            "Host lab\n  HostName lab.example\n",
+        )
+        .unwrap();
+        let main = directory.path().join("config");
+        std::fs::write(&main, "Include extra\n\nHost build\n").unwrap();
+
+        let parsed = load(&main).unwrap();
+
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|host| host.alias.as_str())
+                .collect::<Vec<_>>(),
+            ["lab", "build"]
+        );
+    }
+
+    #[test]
+    fn an_include_that_names_nothing_readable_does_not_hide_the_rest() {
+        let directory = tempfile::tempdir().unwrap();
+        let main = directory.path().join("config");
+        std::fs::write(&main, "Include absent\n\nHost build\n").unwrap();
+
+        let parsed = load(&main).unwrap();
+
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|host| host.alias.as_str())
+                .collect::<Vec<_>>(),
+            ["build"],
+            "an Include naming something absent is ordinary"
+        );
+    }
+
+    #[test]
+    fn a_configuration_that_includes_itself_terminates() {
+        let directory = tempfile::tempdir().unwrap();
+        let main = directory.path().join("config");
+        std::fs::write(&main, "Include config\n\nHost build\n").unwrap();
+
+        let parsed = load(&main).unwrap();
+
+        assert_eq!(parsed.len(), 1);
+    }
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -153,6 +153,9 @@ fn targets_for_discovered_sessions(
             socket: Some(session.socket_path),
             herdr_bins: target.herdr_bins.clone(),
             roots: target.roots.clone(),
+            // Discovery splits one configured target into one per session.
+            // They are the same machine, so they carry the same groupings.
+            tags: target.tags.clone(),
         })
         .collect()
 }
@@ -949,6 +952,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
 
         assert_eq!(
@@ -992,6 +996,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
 
         assert!(targets_for_discovered_sessions(&target, Vec::new()).is_empty());

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -405,6 +405,7 @@ struct TargetForm {
     /// Carried, never edited: a browsing bound belongs in configuration, and a
     /// form that dropped it would quietly empty a picker on the next save.
     roots: Vec<String>,
+    tags: Vec<String>,
     field: TargetFormField,
     error: Option<String>,
     test_state: TargetTestState,
@@ -424,6 +425,7 @@ impl TargetForm {
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
             field: TargetFormField::Name,
             error: None,
             test_state: TargetTestState::Untested,
@@ -443,6 +445,7 @@ impl TargetForm {
             socket: target.socket.clone(),
             herdr_bins: target.herdr_bins.clone(),
             roots: target.roots.clone(),
+            tags: target.tags.clone(),
             field: TargetFormField::Name,
             error: None,
             test_state: TargetTestState::Untested,
@@ -465,6 +468,7 @@ impl TargetForm {
             // adding a machine, and a form that dropped them would quietly
             // empty a picker on the next save.
             roots: self.roots.clone(),
+            tags: self.tags.clone(),
         }
     }
 
@@ -8067,6 +8071,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
         let key = TargetSession::new("workstation", "example-session");
 
@@ -8992,6 +8997,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
         Config::add_target_file(Some(&path), existing.clone()).unwrap();
         let mut app = App {
@@ -9031,6 +9037,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
         let mut duplicate = TargetForm::add();
         duplicate.name = "existing".to_owned();
@@ -9147,6 +9154,7 @@ mod tests {
             socket: None,
             herdr_bins: vec!["herdr".to_owned()],
             roots: Vec::new(),
+            tags: Vec::new(),
         };
         let frame_area = ratatui::layout::Rect::new(0, 0, 120, 40);
         let mut app = App {

--- a/tools/page-harness.mjs
+++ b/tools/page-harness.mjs
@@ -125,6 +125,19 @@ class StubEventSource {
   close() {}
 }
 globalThis.EventSource = StubEventSource;
+// A browser that remembers, and one that refuses to. Both have to work.
+let stored = {};
+let storageWorks = true;
+globalThis.localStorage = {
+  getItem(key) {
+    if (!storageWorks) throw new Error('storage is blocked');
+    return Object.prototype.hasOwnProperty.call(stored, key) ? stored[key] : null;
+  },
+  setItem(key, value) {
+    if (!storageWorks) throw new Error('storage is blocked');
+    stored[key] = String(value);
+  },
+};
 // Object URLs are a browser thing; the page revokes what it creates, so the
 // stub counts both to catch a blob left behind.
 let objectUrls = 0;
@@ -458,7 +471,12 @@ const sections = () => page.el('inbox-sections').children;
 // put on it. Reaching through it here keeps the assertions about behaviour
 // rather than about which element happens to carry the handler.
 const openOf = one => one.children[0];
-const marksOf = one => (one.children[1] ? one.children[1].children : []);
+// Found by what it holds rather than by position: a card grows a note when it
+// carries a local name, and an index would quietly start measuring that.
+const marksOf = one => (
+  one.children.find(child => child.children.some(held => held.dataset && held.dataset.mark))
+    || { children: [] }
+).children;
 const markChip = (one, kind) => marksOf(one).find(chip => chip.dataset.mark === kind);
 const cardsIn = index => sections()[index].children.slice(1);
 const chipFor = (group, value) => page.el('inbox-filters').children
@@ -526,7 +544,7 @@ check(
   openOf(cardsIn(0)[1]).children[1].children[1].textContent === 'host not connected',
 );
 check('a gone agent offers nothing to mark', marksOf(cardsIn(0)[0]).length === 0);
-check('a stale card still offers its marks', marksOf(cardsIn(0)[1]).length === 3);
+check('a stale card still offers its marks', marksOf(cardsIn(0)[1]).length === 4);
 
 // Opening a card routes to its own qualified pane and settles its attention.
 deliver(projection({ needs_you: [card('p1', { unread: true })] }));
@@ -962,3 +980,40 @@ check('choosing a search result fills the whole path',
 // The picker belongs to the pane being watched.
 page.observe({ target: 'first', session: 'main', resource: 'w1:p2' }, 'other');
 check('watching another pane clears the picker', entries().length === 0);
+
+// A local name is shown over the host's own word and never instead of the
+// identity, and a favourite is one more thing this installation remembers.
+deliver(projection({
+  needs_you: [
+    card('p1', { alias: 'the flaky one', favourite: true }),
+    card('p2', { alias_suspended: true }),
+  ],
+}));
+const nameOf = one => openOf(one).children[0].children[0].textContent;
+const noteOf = one => one.children[1].textContent;
+check('a local name is what the card says', nameOf(cardsIn(0)[0]) === 'the flaky one');
+check('the host word is kept underneath', noteOf(cardsIn(0)[0]) === 'host calls it p1');
+check(
+  'a favourite is marked',
+  openOf(cardsIn(0)[0]).children[0].children[2].textContent === '★',
+);
+check(
+  'a suspended name is neither shown nor dropped',
+  nameOf(cardsIn(0)[1]) === 'p2' && noteOf(cardsIn(0)[1]).includes('out of date'),
+);
+
+sent.length = 0;
+markChip(cardsIn(0)[1], 'favourite').onclick();
+const favourited = sent.find(one => one.body.type === 'local.favourite');
+check('favouriting names the qualified agent',
+  favourited.body.resource.kind === 'agent' && favourited.body.resource.resource === 'p2');
+
+// Filters are remembered per browser, and a browser that refuses to remember
+// still renders one.
+stored = {};
+chipFor('state', 'working').onclick();
+check('a chosen filter is written down', JSON.parse(stored['super-herdr.view']).state === 'working');
+storageWorks = false;
+chipFor('state', 'all').onclick();
+check('a browser that will not remember still filters', sections().length >= 1);
+storageWorks = true;


### PR DESCRIPTION
Stacked on #23.

## Local names, favourites and jump slots

A person running agents on five machines ends up with `w1`, `w3` and `wD` meaning "the compiler one", "the flaky one" and "the customer's". Herdr can rename a workspace, but that changes it for everybody on that host and is somebody else's decision. So these are local, and **Herdr's own rename stays a separate, explicit action that nothing here calls.**

An alias is never an identity: everything is keyed by a qualified id and looked up by one.

**The part worth reviewing** is the last backlog bullet — *never silently retargeting an alias*. Herdr's ids are server-local **and reusable**: delete `w1` and the next workspace may be `w1` again. An alias keyed only by that id moves silently onto a different workspace, and the person reads a name they trust over something they have never looked at.

So an alias also records what the host called the resource when it was named. When that stops matching, the alias is **suspended** — shown as needing confirmation, neither applied nor deleted. Nothing here can tell a rename from a reuse, so it asks. A person can confirm it; only a person can.

Names for a target *removed from the configuration* are forgotten, because removing it was a decision. Nothing is forgotten because a host was briefly unreachable, which is not.

Aliases are stored and settable for every resource kind and **rendered on agent cards**; the TUI hierarchy still shows Herdr's own labels. The backlog says so rather than claiming otherwise.

## SSH config import

Anybody with several machines already listed them in `~/.ssh/config`. **It offers and never takes** — running the import prints what it found and writes nothing; `--add` is what adds. A first run that silently adopted forty hosts, half of them jump boxes, would be a federation nobody asked for and a probe against machines nobody meant to touch.

Each named alias is probed on its own before it is written; one host being unreachable says nothing about the others. Verified both paths locally, including that an unreachable host is reported and the config left unchanged.

The parser is deliberately a fraction of the format. Patterns and negations are skipped, options after a `Match` block are not attributed to the last `Host`, includes are followed and bounded, and a self-including config terminates. Nothing parsed here is used to *connect* — that stays ssh's job, given the alias — so a detail it skips cannot change where a connection goes.

## Also here

- **Network choices** in the README as four peer options with what each needs and who can see the traffic. The default bridge is described as what it is: needs no Tailscale, TLS terminates there, so it is a relay being trusted.
- **The native Windows question**, answered in `ROADMAP.md` rather than started. Permissions are already portable behind `cfg` gates; the real coupling is twenty `UnixStream` uses on two paths, one of which is how Herdr's API is reached *on a target* and is already carried by SSH. Plausible as a control plane, not scheduled — a platform nobody can test is one that is broken and does not know it.

## Checks

428 tests · 198 page-harness assertions · fmt, clippy (host + macOS target), check-docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdRHimPZdtFsZgAnmpCRUE
