### PR TITLE
Release 0.7.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ Tagged releases and their generated change lists are available on the
 The notes below retain upgrade and security information that should not be
 inferred from commit titles alone.
 
+## 0.7.21
+
+- Fixed file transfers to and from hosts without GNU coreutils. Every transfer
+  script hashed with `sha256sum`, which a stock macOS does not have, so
+  transfers failed there with an error about a shell script rather than about a
+  missing program. The scripts now try `sha256sum`, `shasum -a 256`, then
+  `openssl`.
+- Added an agent inbox: a daemon-owned projection of agents into needs-you,
+  working and recent, keyed by qualified agent identity and re-resolved against
+  the live federation before anything is sent. The browser opens on it with the
+  full hierarchy one tap away, and agents can be pinned, muted or snoozed.
+- Agent identity now prefers the agent session Herdr reports where one is
+  present, so an agent that moves pane keeps its card, its place in the queue
+  and any pin. The field is optional and absent at protocol 19, so panes remain
+  the fallback.
+- Browser quick replies are configured rather than inferred. Herdr's documented
+  API does not describe what a blocked agent is asking, so semantic response
+  buttons remain deliberately unavailable rather than guessed from terminal
+  contents. Configure them with `[[quick_replies]]`.
+- Added opt-in paired-device attention alerts under the desktop's existing
+  filters, coalescing and rate limits, with per-agent needs-you-only, mute and
+  snooze modes. Alerts carry bounded metadata only and reach a device while its
+  page is running; waking a closed browser needs Web Push and is not built.
+- Added file transfer surfaces that the protocol has carried since it was
+  written but no client offered: browser fetch from a target with size, source
+  and digest shown before any byte moves, a bounded remote file picker over
+  configured roots, and desktop save and host-to-host transfer from the same
+  right-click menus.
+- Added `super-herdr doctor`, a read-only pass over configuration, targets, the
+  daemon socket, the browser route, pairing, clipboard, notifications and
+  transfer dependencies. It reports corrective commands without running them and
+  redacts host names, destinations, paths and URLs so its output can be shared.
+- Added `super-herdr plugins`, showing what is installed on every host and what
+  differs. Plugins are matched by the source they were installed from rather
+  than by the server-local id a host gave them. Produces a pinned lockfile and
+  an install plan; it runs nothing.
+- Added local names, favourites and numbered jump slots that never rename a
+  Herdr resource. A name is suspended rather than applied when the host calls
+  the resource something else, because a reused id must not inherit a name.
+- Added `super-herdr target import`, which lists the hosts in an OpenSSH
+  configuration and adds only the aliases named explicitly, probing each on its
+  own first. Targets can carry local tags.
+- Documented the four ways a paired device can reach a daemon as peer choices,
+  and added a threat model for the proposed remote development preview, which
+  remains unimplemented.
+
 ## 0.7.20
 
 - Prepared the repository for public contributions with a security policy,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-herdr"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-herdr"
-version = "0.7.20"
+version = "0.7.21"
 edition = "2024"
 publish = false
 description = "A multi-host control plane for persistent Herdr coding-agent sessions"

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -82,8 +82,9 @@ it?" while the inbox answers "what needs me now?"
 - [ ] Complete the deployed-bridge and real-phone qualification in
       `ROADMAP.md` before treating the hosted path as dependable.
 - [ ] Run the required release checks on the merged plugin-action build.
-- [ ] Publish the next tagged release so Homebrew, Debian, and archive users
-      receive the plugin actions already merged after `v0.7.20`.
+- [x] Publish the next tagged release so Homebrew, Debian, and archive users
+      receive the plugin actions already merged after `v0.7.20`. Released as
+      `v0.7.21`.
 - [ ] Verify the Homebrew formula and every published binary from the release.
 - [ ] Record the exact released commit and phone/browser matrix in
       `TESTING.md`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ brew install mikro-design/tap/super-herdr
 Debian and Ubuntu packages are published for amd64 and arm64:
 
 ```sh
-version=0.7.20
+version=0.7.21
 arch=amd64 # or arm64
 package="super-herdr_${version}-1_${arch}.deb"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/v${version}/${package}"
@@ -47,7 +47,7 @@ sudo dpkg -i "./${package}"
 Other Linux users can install a prebuilt archive:
 
 ```sh
-tag=v0.7.20
+tag=v0.7.21
 target=x86_64-unknown-linux-gnu # or aarch64-unknown-linux-gnu
 archive="super-herdr-${tag}-${target}.tar.gz"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/${tag}/${archive}"


### PR DESCRIPTION
Version bump and changelog for **v0.7.21**. No code changes — `Cargo.toml`, `Cargo.lock`, the README install examples, and `CHANGELOG.md`.

Merging this and then pushing the `v0.7.21` tag is what triggers the publish job.

## Why this release matters to anybody already installed

**File transfers to and from a stock macOS host have never worked.** Every transfer script hashed with `sha256sum`, which is GNU coreutils and is not on macOS, so transfers failed with an error about a shell script rather than about a missing program — on a platform this project documents as supported. Fixed in #19.

## What else it carries

The agent inbox and per-agent marks (#20), configurable quick replies and paired-device alerts (#21), the file transfer surfaces (#22), `super-herdr doctor` and the plugin fleet inventory (#23), local names and the SSH config importer (#24), and the remote preview threat model (#25).

## Verified on this commit

428 tests · 198 page-harness assertions · 13 bridge-harness assertions · `fmt`, `clippy --all-targets -D warnings` on host and `x86_64-apple-darwin` · `check-docs` reports release examples now at 0.7.21.

## Not verified, and worth knowing before publishing

- **Nothing here has run on a real phone.** Every phone-side surface in this release — the inbox, alerts, quick replies, the file picker — has been exercised against a stub DOM and nothing else.
- **The macOS digest fix was found by reading, not by reproducing.** There is no macOS target here to test a transfer against.
- **The `agent_session` identity path is proven by tests only**, because the field is absent at protocol 19 and the Herdr available here is 0.8.0.
- The Homebrew formula is updated from the checksums this release publishes, so that step comes after the tag.

`TESTING.md` asks for the released commit and a phone/browser matrix to be recorded. That entry cannot be written honestly until somebody pairs a phone against this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdRHimPZdtFsZgAnmpCRUE
