### PR TITLE
Bump sha2 to 0.11 and fix the one call site it breaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,7 +1839,7 @@ dependencies = [
  "rqrr",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "super-herdr-bridge",
  "tempfile",
  "tokio",
@@ -1845,7 +1856,7 @@ dependencies = [
  "futures-util",
  "rustls",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "tokio-tungstenite",
 ]
@@ -1955,7 +1966,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -2359,7 +2370,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ qrcode = { version = "0.14.1", default-features = false }
 ratatui = "0.30"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 super-herdr-bridge = { path = "crates/bridge", default-features = false }
 tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"], optional = true }
 futures-util = "0.3"
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite = { version = "0.30", default-features = false, features = ["handshake"] }
 

--- a/src/file_save.rs
+++ b/src/file_save.rs
@@ -161,7 +161,7 @@ impl FileSave {
                 self.length
             );
         }
-        let digest = format!("{:x}", self.hasher.finalize());
+        let digest = hex(&self.hasher.finalize());
         if !self.digest.is_empty() && digest != self.digest {
             bail!("that file did not match the digest its host reported");
         }
@@ -175,6 +175,15 @@ impl FileSave {
             .with_context(|| format!("failed to save {}", self.destination.display()))?;
         Ok(self.destination)
     }
+}
+
+/// A digest as the wire spells it.
+///
+/// Written out rather than formatted with `{:x}`: `sha2` stopped implementing
+/// `LowerHex` on its output in 0.11, and the two other digests in this crate
+/// were already spelled this way.
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 /// Where a saved file goes when nobody said.
@@ -202,7 +211,24 @@ mod tests {
     use sha2::{Digest, Sha256};
 
     fn digest_of(bytes: &[u8]) -> String {
-        format!("{:x}", Sha256::new().chain_update(bytes).finalize())
+        super::hex(&Sha256::new().chain_update(bytes).finalize())
+    }
+
+    #[test]
+    fn a_digest_is_the_standard_value_spelled_the_way_the_wire_expects() {
+        // A known answer rather than a round trip. Every other test here
+        // compares a digest against one this module computed, which would
+        // agree with itself even if a library change altered the format — and
+        // the format is what a host's own `sha256sum` output is matched
+        // against, so a change in it fails a transfer rather than a test.
+        assert_eq!(
+            digest_of(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            digest_of(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #15, whose CI failed.

## What broke

`sha2` 0.11 stopped implementing `LowerHex` on its digest output, so the one place spelling a digest with `format!("{:x}", …)` no longer compiles:

```
error[E0277]: the trait bound `Array<u8, …>: LowerHex` is not satisfied
   --> src/file_save.rs:164:38
```

That is the only breakage in the workspace. The two older digests here — `pairing::hex` and `clipboard::sha256_hex` — already iterate bytes and were unaffected; the file save path was written recently and used the shorter spelling.

## What this does

- Bumps `sha2` to 0.11 in both the root crate and `crates/bridge`, so the workspace holds one version rather than two. (Two still appear in `Cargo.lock` via `termwiz` and `wezterm-blob-leases`, which is theirs to move.)
- Fixes the call site by iterating bytes, matching the two existing helpers.
- **Adds a known-answer test** for the save path's digest.

## Why the extra test

Every other test in `file_save` compares a digest against one the same module computed. That agrees with itself even if a library change altered the format — uppercase, truncated, a different encoding — and the format is exactly what a host's own `sha256sum` output is matched against. A change there fails a *transfer*, not a test.

The clipboard path already pinned `sha256("abc")` to its standard value, and that test passing is how this bump was confirmed to still produce lowercase hex. The save path now has the same anchor.

## Checks

429 tests (was 428) · `fmt`, `clippy --all-targets -D warnings` on host and `x86_64-apple-darwin` clean · page and bridge harnesses unchanged at 198 and 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdRHimPZdtFsZgAnmpCRUE
