### PR TITLE
Lead the README with the question the product answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,25 @@
 [![Latest release](https://img.shields.io/github/v/release/mikro-design/super-herdr)](https://github.com/mikro-design/super-herdr/releases/latest)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-Super-Herdr puts persistent Herdr sessions from all your machines in one terminal
-UI. Pair a phone when you need to read output, answer a prompt, or send a file
-away from your desk.
+An agent on one of your machines is blocked, waiting for an answer, and you are
+not at that desk.
 
-- One TUI for local and SSH-connected Herdr sessions
-- Phone access through an explicit device-login flow
-- Attention tracking across hosts, sessions, workspaces, and agents
-- Verified file transfer for images, PDFs, Office documents, and other files
+Super-Herdr is the cross-machine inbox and control plane for the Herdr sessions
+you already run. It answers three questions, from one terminal UI or from a
+paired phone:
+
+- **Which agent needs you?** Attention tracking across every host, session,
+  workspace, and agent, with the waiting ones first.
+- **What can you safely send it?** Nothing reaches a pane — a keystroke, a
+  paste, or an uploaded file — from a connection that does not hold that
+  pane's control lease.
+- **Which machine and session will receive it?** Every agent is addressed by
+  target and Herdr session, so a machine connecting or disconnecting never
+  redirects your next keystroke.
+
+Pairing a phone needs no Tailscale client, no shared Wi-Fi, and no inbound route
+to your computer. Read the output, answer the prompt, send the file, and get
+back to what you were doing.
 
 Herdr continues to own every shell, agent, workspace, and terminal history.
 Super-Herdr never automatically starts, stops, restarts, or takes over a Herdr


### PR DESCRIPTION
The README opened by describing what Super-Herdr is assembled from — persistent
Herdr sessions in one terminal UI — before saying why anyone would want that.
The three questions the browser is actually designed to answer were already
written down in `PRODUCT_BACKLOG.md`, where nobody evaluating the project reads
them.

This moves them up to the top of the README: which agent needs you, what you
can safely send it, and which machine and session receives it. The four old
bullets survive as answers rather than as a parts list.

Two facts move up with them:

- **The control lease.** Enforced in `daemon::broker` for typing, pasting and
  uploading alike (`src/daemon/broker.rs:1475`, and the
  `pasting_and_uploading_need_the_lease_that_typing_needs` test at line 3330),
  it was previously visible only in the security section.
- **Pairing needs no Tailscale client, no shared Wi-Fi, and no inbound route.**
  This was buried in the pairing steps, and it is the thing that distinguishes
  Super-Herdr from every other way to reach a machine from a phone.

No claim is added that the tree does not yet keep. Per-action route
re-resolution is still open in `PRODUCT_BACKLOG.md` and is deliberately still
absent from the README.

Nothing below the fold changes: the public-preview warning, the "Herdr owns
every shell" paragraph, and every section from **Get started** down are
untouched. One file, one commit.

## Why now

Trailing 14 days: 165 views from 83 unique visitors, against 13 installable
downloads of `v0.7.21` and ~1 Homebrew formula fetch per release. People are
arriving and not installing. The old opening asked them to already know what
Herdr federation was worth. The 14-day traffic window makes this a usable
before/after measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J