### PR TITLE
Release 0.7.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Tagged releases and their generated change lists are available on the
 The notes below retain upgrade and security information that should not be
 inferred from commit titles alone.
 
+## 0.7.22
+
+- Fixed the selection jumping to another machine after creating a workspace.
+  The operation follows Herdr's focus, but nothing recorded whose focus to
+  follow, so the frontend fell back to its startup rule and selected a pane on
+  whichever live target held the most agents, workspaces and panes. Creating a
+  tab, splitting a pane and moving a workspace jumped the same way. The session
+  the operation acted on is now carried with it, and a session that has not
+  reported its new focus yet is waited for rather than replaced.
+- Rewrote the README opening around the questions the product answers — which
+  agent needs you, what you can safely send it, and which machine and session
+  receives it — rather than the parts it is assembled from.
+- Updated `sha2` to 0.11, `base64` to 0.23.1 and `toml` to 1.1.5.
+
 ## 0.7.21
 
 - Fixed file transfers to and from hosts without GNU coreutils. Every transfer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-herdr"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-herdr"
-version = "0.7.21"
+version = "0.7.22"
 edition = "2024"
 publish = false
 description = "A multi-host control plane for persistent Herdr coding-agent sessions"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ brew install mikro-design/tap/super-herdr
 Debian and Ubuntu packages are published for amd64 and arm64:
 
 ```sh
-version=0.7.21
+version=0.7.22
 arch=amd64 # or arm64
 package="super-herdr_${version}-1_${arch}.deb"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/v${version}/${package}"
@@ -58,7 +58,7 @@ sudo dpkg -i "./${package}"
 Other Linux users can install a prebuilt archive:
 
 ```sh
-tag=v0.7.21
+tag=v0.7.22
 target=x86_64-unknown-linux-gnu # or aarch64-unknown-linux-gnu
 archive="super-herdr-${tag}-${target}.tar.gz"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/${tag}/${archive}"


### PR DESCRIPTION
Version bump, changelog entry, and the README install examples that
`tools/check-docs.mjs` validates against the package version.

## What ships

- **Fixed:** the selection jumping to another machine after creating a
  workspace (#31). The operation follows Herdr's focus, but nothing recorded
  *whose* focus to follow, so the frontend fell back to its startup rule and
  selected a pane on whichever live target held the most agents, workspaces and
  panes. Creating a tab, splitting a pane and moving a workspace jumped the same
  way. Worth upgrading for if you run more than one machine.
- **Changed:** the README opening now leads with the questions the product
  answers rather than the parts it is assembled from (#30).
- **Dependencies:** `sha2` 0.11, `base64` 0.23.1, `toml` 1.1.5.

## Gates

`cargo fmt --check`, `node tools/check-docs.mjs` (release examples now read
0.7.22), `cargo test --locked` (419 passing), and
`cargo clippy --all-targets -- -D warnings` all pass locally.

Tag `v0.7.22` goes on the merge commit after this lands, matching how v0.7.21
was tagged, which is what triggers the publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J