### PR TITLE
Adopt a followed focus from state the operation produced

### DIFF
--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -160,6 +160,10 @@ enum Input {
     OperationDone {
         client: ClientId,
         request: u64,
+        /// The session to re-snapshot once this lands, when the operation was
+        /// the kind that changes what a snapshot would say. Typing into a pane
+        /// is not: it changes a terminal, which the federation does not carry.
+        refresh: Option<TargetSession>,
         applied: bool,
         message: String,
         plugin_run: Option<plugin::PluginRun>,
@@ -1631,12 +1635,21 @@ impl Daemon {
             Input::OperationDone {
                 client,
                 request,
+                refresh,
                 applied,
                 message,
                 plugin_run,
-            } => self
-                .broker
-                .operation_completed(client, request, applied, message, plugin_run),
+            } => {
+                // An operation that landed changed the session a moment ago, so
+                // the federation describes it wrongly until the next snapshot.
+                // Ask for that snapshot rather than publishing a result whose
+                // state this daemon already knows is behind it.
+                if let Some(session) = refresh.filter(|_| applied) {
+                    self.refresh_target(&session);
+                }
+                self.broker
+                    .operation_completed(client, request, applied, message, plugin_run)
+            }
             Input::RelayFinished {
                 client,
                 request,
@@ -1988,6 +2001,17 @@ impl Daemon {
         }
     }
 
+    /// Ask one target's supervisor for a snapshot now.
+    ///
+    /// Advisory, and deliberately not awaited: the answer arrives as a
+    /// federation update like every other, and a target that is slow, wedged or
+    /// backing off is not made to answer faster by being asked twice.
+    fn refresh_target(&self, key: &TargetSession) {
+        if let Some(store) = self.store.as_ref() {
+            store.refresh_now(key);
+        }
+    }
+
     /// Re-read the durable configuration off the loop. One refresh runs at a
     /// time, so a slow discovery on an unreachable host cannot queue up behind
     /// itself.
@@ -2292,6 +2316,7 @@ impl Daemon {
             let _ = inputs.send(Input::OperationDone {
                 client,
                 request,
+                refresh: None,
                 applied,
                 message,
                 plugin_run: None,
@@ -2878,6 +2903,7 @@ impl Daemon {
             let _ = self.inputs.send(Input::OperationDone {
                 client,
                 request,
+                refresh: None,
                 applied: false,
                 message: format!("{source_key} is not a configured target"),
                 plugin_run: None,
@@ -2888,6 +2914,7 @@ impl Daemon {
             let _ = self.inputs.send(Input::OperationDone {
                 client,
                 request,
+                refresh: None,
                 applied: false,
                 message: format!("{destination_key} is not a configured target"),
                 plugin_run: None,
@@ -2924,6 +2951,7 @@ impl Daemon {
             let _ = inputs.send(Input::OperationDone {
                 client,
                 request,
+                refresh: Some(destination_key),
                 applied,
                 message,
                 plugin_run,

--- a/src/state.rs
+++ b/src/state.rs
@@ -351,6 +351,11 @@ impl SupervisorOptions {
 pub struct FederationStore {
     receiver: watch::Receiver<FederationState>,
     shutdown: watch::Sender<bool>,
+    /// One per supervised target, used to ask for a snapshot now rather than
+    /// at the next deadline. Nothing about a target changes on our schedule:
+    /// an operation we just ran on it changed it a moment ago, and waiting out
+    /// the interval publishes a federation that is known to be wrong.
+    nudges: BTreeMap<TargetSession, watch::Sender<u64>>,
     tasks: Vec<JoinHandle<()>>,
 }
 
@@ -370,8 +375,11 @@ impl FederationStore {
         let (updates, receiver) = watch::channel(initial_state);
         let (shutdown, shutdown_receiver) = watch::channel(false);
         let mut tasks = Vec::with_capacity(config.targets.len());
+        let mut nudges = BTreeMap::new();
 
         for target in config.targets {
+            let (nudge, nudge_receiver) = watch::channel(0);
+            nudges.insert(target_key(&target), nudge);
             tasks.push(tokio::spawn(supervise_target(
                 target,
                 config.transport.clone(),
@@ -379,14 +387,30 @@ impl FederationStore {
                 options.clone(),
                 updates.clone(),
                 shutdown_receiver.clone(),
+                nudge_receiver,
             )));
         }
 
         Self {
             receiver,
             shutdown,
+            nudges,
             tasks,
         }
+    }
+
+    /// Ask one target's supervisor to take a snapshot now.
+    ///
+    /// Advisory: a supervisor mid-request finishes that one first, and a
+    /// disconnected target still waits out its backoff. Returns whether a
+    /// supervisor was there to ask, so a caller naming an unknown target is
+    /// not told something happened.
+    pub fn refresh_now(&self, key: &TargetSession) -> bool {
+        let Some(nudge) = self.nudges.get(key) else {
+            return false;
+        };
+        nudge.send_modify(|counter| *counter = counter.wrapping_add(1));
+        true
     }
 
     pub fn subscribe(&self) -> watch::Receiver<FederationState> {
@@ -417,6 +441,7 @@ async fn supervise_target<T>(
     options: SupervisorOptions,
     updates: watch::Sender<FederationState>,
     mut shutdown: watch::Receiver<bool>,
+    mut nudge: watch::Receiver<u64>,
 ) where
     T: SnapshotTransport,
 {
@@ -479,6 +504,12 @@ async fn supervise_target<T>(
                         }
                         continue;
                     }
+                    nudged = nudge.changed() => {
+                        if nudged.is_err() {
+                            return;
+                        }
+                        continue;
+                    }
                     () = sleep_until(refresh_deadline) => continue,
                     result = transport.open_change_stream(
                         &target,
@@ -504,7 +535,8 @@ async fn supervise_target<T>(
                 }
             }
             let Some(changes) = change_stream.as_mut() else {
-                if wait_for_deadline_or_shutdown(refresh_deadline, &mut shutdown).await {
+                if wait_for_deadline_or_shutdown(refresh_deadline, &mut shutdown, &mut nudge).await
+                {
                     return;
                 }
                 continue;
@@ -512,6 +544,12 @@ async fn supervise_target<T>(
             let event_result = tokio::select! {
                 changed = shutdown.changed() => {
                     if changed.is_err() || *shutdown.borrow() {
+                        return;
+                    }
+                    continue;
+                }
+                nudged = nudge.changed() => {
+                    if nudged.is_err() {
                         return;
                     }
                     continue;
@@ -530,23 +568,30 @@ async fn supervise_target<T>(
                 TargetUpdateMode::Polling,
                 Some(error.message),
             );
-            if wait_for_deadline_or_shutdown(refresh_deadline, &mut shutdown).await {
+            if wait_for_deadline_or_shutdown(refresh_deadline, &mut shutdown, &mut nudge).await {
                 return;
             }
             continue;
         }
-        if wait_for_delay_or_shutdown(delay, &mut shutdown).await {
+        if wait_for_delay_or_shutdown(delay, &mut shutdown, &mut nudge).await {
             return;
         }
     }
 }
 
+/// Wait out a refresh deadline, returning whether the supervisor should stop.
+///
+/// A nudge ends the wait early: something changed the target on purpose and is
+/// waiting to see it. A dropped nudge sender means the store is gone, which is
+/// the same news as a shutdown.
 async fn wait_for_deadline_or_shutdown(
     deadline: Instant,
     shutdown: &mut watch::Receiver<bool>,
+    nudge: &mut watch::Receiver<u64>,
 ) -> bool {
     tokio::select! {
         changed = shutdown.changed() => changed.is_err() || *shutdown.borrow(),
+        nudged = nudge.changed() => nudged.is_err(),
         () = sleep_until(deadline) => false,
     }
 }
@@ -558,9 +603,14 @@ fn snapshot_pane_ids(snapshot: &Value) -> Vec<String> {
         .collect()
 }
 
-async fn wait_for_delay_or_shutdown(delay: Duration, shutdown: &mut watch::Receiver<bool>) -> bool {
+async fn wait_for_delay_or_shutdown(
+    delay: Duration,
+    shutdown: &mut watch::Receiver<bool>,
+    nudge: &mut watch::Receiver<u64>,
+) -> bool {
     tokio::select! {
         changed = shutdown.changed() => changed.is_err() || *shutdown.borrow(),
+        nudged = nudge.changed() => nudged.is_err(),
         () = sleep(delay) => false,
     }
 }
@@ -1186,6 +1236,75 @@ mod tests {
             reconnected.targets[&second_key].connection,
             TargetConnectionState::Live
         );
+
+        store.shutdown().await;
+    }
+
+    /// Nothing changes a target on the refresh interval's schedule. An
+    /// operation the daemon just ran changed it a moment ago, and a client told
+    /// the operation applied would otherwise act on a federation that still
+    /// describes the session as it was beforehand.
+    #[tokio::test]
+    async fn a_nudge_takes_a_snapshot_before_the_refresh_interval() {
+        let config = Config::parse(
+            r#"
+                [[targets]]
+                name = "host-a"
+                session = "dev"
+            "#,
+        )
+        .unwrap();
+        let key = TargetSession::new("host-a", "dev");
+        let (snapshot_tx, snapshot_rx) = mpsc::unbounded_channel();
+        let (_event_tx, event_rx) = mpsc::unbounded_channel();
+        let transport = Arc::new(FakeTransport {
+            scripts: BTreeMap::from([(key.clone(), Arc::new(Mutex::new(snapshot_rx)))]),
+            events: BTreeMap::from([(key.clone(), Arc::new(Mutex::new(event_rx)))]),
+        });
+        // An hour, so nothing but the nudge can explain a second snapshot.
+        let options = SupervisorOptions {
+            command_timeout: Duration::from_secs(1),
+            refresh_interval: Duration::from_secs(3600),
+            initial_backoff: Duration::from_millis(1),
+            maximum_backoff: Duration::from_millis(4),
+        };
+
+        snapshot_tx.send(Ok(snapshot("w1:p1"))).unwrap();
+        let store = FederationStore::start(config, transport, options);
+        let mut receiver = store.subscribe();
+        wait_for(&mut receiver, |state| {
+            state.targets[&key]
+                .snapshot
+                .as_ref()
+                .is_some_and(|snapshot| {
+                    snapshot
+                        .panes
+                        .contains_key(&PaneId::new("host-a", "dev", "w1:p1"))
+                })
+        })
+        .await;
+
+        // What the operation created, waiting to be read.
+        snapshot_tx.send(Ok(snapshot("w2:p1"))).unwrap();
+        assert!(store.refresh_now(&key));
+        let updated = wait_for(&mut receiver, |state| {
+            state.targets[&key]
+                .snapshot
+                .as_ref()
+                .is_some_and(|snapshot| {
+                    snapshot
+                        .panes
+                        .contains_key(&PaneId::new("host-a", "dev", "w2:p1"))
+                })
+        })
+        .await;
+        assert_eq!(
+            updated.targets[&key].connection,
+            TargetConnectionState::Live
+        );
+
+        // A target nobody supervises is not quietly reported as refreshed.
+        assert!(!store.refresh_now(&TargetSession::new("host-b", "dev")));
 
         store.shutdown().await;
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{self, IsTerminal, Read, Stdout, Write};
 use std::path::PathBuf;
 use std::thread;
@@ -686,6 +686,31 @@ struct ActiveRoute {
     last_sequence: Option<u64>,
 }
 
+/// A focus to adopt once the session that was acted on reports one the
+/// operation could have produced.
+///
+/// The daemon does not refresh a target when an operation completes: it runs
+/// the command, reports the result, and lets the federation arrive on its own
+/// five-second cadence. So at the moment a result lands the state still holds
+/// the session as it was before, focus included. Adopting that focus selects
+/// the pane the person was already on and consumes the follow, and the refresh
+/// that finally carries the new workspace arrives to find a selection it must
+/// not disturb. The panes held beforehand are what tell the two apart.
+struct FollowedFocus {
+    session: TargetSession,
+    /// Panes the session was known to hold when the operation landed. Every
+    /// operation that follows focus creates a pane, so a focus inside this set
+    /// is state the daemon has not refreshed yet.
+    before: BTreeSet<PaneId>,
+    /// Stop waiting eventually. A session that never reports again must not
+    /// leave the frontend with nothing selected.
+    deadline: Instant,
+}
+
+/// Two polling intervals. Long enough that an ordinary refresh arrives first,
+/// short enough that a wedged target does not leave the frontend empty.
+const FOLLOW_FOCUS_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// What a frontend needs to remember about an operation while the daemon runs
 /// it, since the result comes back carrying only a request identifier.
 struct PendingOperation {
@@ -858,11 +883,11 @@ struct CloseConfirmation {
 struct App {
     selected_pane: Option<PaneId>,
     selection_explicit: bool,
-    /// Set when an operation that follows server focus has landed, naming the
-    /// session whose focus to adopt. Consumed by the next reconciliation, which
-    /// would otherwise fall back to the startup heuristic and choose a pane on
-    /// an unrelated machine.
-    follow_focus_session: Option<TargetSession>,
+    /// Set when an operation that follows server focus has landed. Held until
+    /// the session it names reports a focus the operation could have produced,
+    /// because nothing refreshes a target when an operation completes and the
+    /// federation still describes the session as it was beforehand.
+    followed_focus: Option<FollowedFocus>,
     restore_pending: Option<PaneId>,
     state_store: Option<UiStateStore>,
     mode: InputMode,
@@ -935,7 +960,7 @@ impl Default for App {
         Self {
             selected_pane: None,
             selection_explicit: false,
-            follow_focus_session: None,
+            followed_focus: None,
             restore_pending: None,
             state_store: None,
             mode: InputMode::Terminal,
@@ -1191,14 +1216,14 @@ pub async fn run(config: Config, config_path: PathBuf) -> Result<()> {
                 let Some(event) = event else {
                     break Err(anyhow::anyhow!("the daemon stopped serving this frontend"));
                 };
-                handle_daemon_event(event, &mut app);
+                handle_daemon_event(event, &mut app, &updates.borrow().clone());
                 // Frames are drained in bounded batches so a busy pane cannot
                 // starve input.
                 for _ in 1..ROUTE_EVENT_DRAIN_LIMIT {
                     let Ok(event) = daemon_events.try_recv() else {
                         break;
                     };
-                    handle_daemon_event(event, &mut app);
+                    handle_daemon_event(event, &mut app, &updates.borrow().clone());
                 }
                 should_draw = true;
             }
@@ -2002,7 +2027,7 @@ fn refresh_attention(app: &mut App) {
 
 fn select_pane(app: &mut App, pane: PaneId) {
     app.selection_explicit = true;
-    app.follow_focus_session = None;
+    app.followed_focus = None;
     app.restore_pending = None;
     app.selection = None;
     app.selection_autoscroll = None;
@@ -5115,21 +5140,29 @@ fn reconcile_selection(state: &FederationState, app: &mut App) {
         return;
     }
 
-    // An operation that follows server focus named the session it acted on.
-    // Adopting that session's focus is the whole point of following: creating a
-    // workspace should land on the workspace just created, and the startup
-    // heuristic below would instead pick whichever machine is busiest, which is
-    // routinely a different one.
-    if let Some(session) = app.follow_focus_session.clone() {
-        let followed = state
+    // An operation that follows server focus named the session it acted on, and
+    // the panes that session held before it ran. Adopting that session's focus
+    // is the whole point of following: creating a workspace should land on the
+    // workspace just created, and the startup heuristic below would instead
+    // pick whichever machine is busiest, which is routinely a different one.
+    if let Some(followed) = app.followed_focus.as_ref() {
+        let focused = state
             .targets
-            .get(&session)
+            .get(&followed.session)
             .filter(|target| target.connection == TargetConnectionState::Live)
             .and_then(|target| target.snapshot.as_deref())
             .and_then(|snapshot| snapshot.focused_pane.clone());
-        match followed {
+        // A focus the session already held is the state the operation ran
+        // against, not its result. Waiting for one it did not hold is what
+        // makes this land on the new workspace rather than back where the
+        // person started.
+        let created = focused
+            .clone()
+            .filter(|pane| !followed.before.contains(pane));
+        let expired = Instant::now() >= followed.deadline;
+        match created.or_else(|| expired.then_some(focused).flatten()) {
             Some(pane) => {
-                app.follow_focus_session = None;
+                app.followed_focus = None;
                 // The operation's own result line survives the selection it
                 // caused; `select_pane` clears the message for navigation the
                 // person did instead of something they were told about.
@@ -5138,10 +5171,14 @@ fn reconcile_selection(state: &FederationState, app: &mut App) {
                 app.message = reported;
                 return;
             }
-            // Herdr has not reported the new focus yet, or the session is
-            // reconnecting. Wait for it rather than choosing somewhere else and
-            // moving the person a second time when it arrives.
-            None => return,
+            // Still waiting on the refresh that carries the operation's result.
+            // Choosing anything now would move the person twice, and the second
+            // move is the one that cannot happen: a selection this makes is a
+            // selection the refresh is forbidden to disturb.
+            None if !expired => return,
+            // The session never reported. Fall through rather than leave the
+            // frontend with nothing selected.
+            None => app.followed_focus = None,
         }
     }
 
@@ -5283,7 +5320,11 @@ fn desired_access(pane: &PaneId, selected: &PaneId) -> TerminalAccess {
 }
 
 /// Apply one message from the daemon that is not federation state.
-fn handle_daemon_event(message: ServerMessage, app: &mut App) {
+///
+/// `state` is the federation as last published. It is read, never adopted: an
+/// operation result needs to know what its session held before the operation to
+/// recognise the refresh that follows it.
+fn handle_daemon_event(message: ServerMessage, app: &mut App, state: &FederationState) {
     match message {
         ServerMessage::PaneFrame {
             pane,
@@ -5379,7 +5420,17 @@ fn handle_daemon_event(message: ServerMessage, app: &mut App) {
                 if let Some(pending) = pending.filter(|pending| pending.follow_server_focus) {
                     app.selection_explicit = false;
                     app.selected_pane = None;
-                    app.follow_focus_session = Some(pending.follow_session);
+                    let before = state
+                        .targets
+                        .get(&pending.follow_session)
+                        .and_then(|target| target.snapshot.as_deref())
+                        .map(|snapshot| snapshot.panes.keys().cloned().collect())
+                        .unwrap_or_default();
+                    app.followed_focus = Some(FollowedFocus {
+                        session: pending.follow_session,
+                        before,
+                        deadline: Instant::now() + FOLLOW_FOCUS_TIMEOUT,
+                    });
                 }
             } else {
                 app.message = Some(format!("Herdr action failed: {message}"));
@@ -8098,6 +8149,7 @@ mod tests {
                 message: "remote digest did not match".to_owned(),
             },
             &mut app,
+            &FederationState::default(),
         );
 
         let message = app.message.unwrap_or_default();
@@ -10485,10 +10537,96 @@ mod tests {
         state
     }
 
-    /// Creating a workspace clears the selection so the new one can be adopted
-    /// from server focus. Which server is not a detail: the startup heuristic
-    /// picks whichever machine has the most on it, so without the followed
-    /// session an operation on a quiet target moved the person to a busy one.
+    /// The bug this exists for: nothing refreshes a target when an operation
+    /// completes, so at the moment the result lands the federation still holds
+    /// the session as it was before. Adopting that focus selects the pane the
+    /// person was already on, and the refresh carrying the new workspace then
+    /// finds a selection it is forbidden to disturb — so the new workspace is
+    /// never reached at all.
+    #[test]
+    fn a_followed_focus_waits_for_the_refresh_that_carries_the_new_workspace() {
+        let session = TargetSession::new("host-a", "work");
+        let existing = PaneId::new("host-a", "work", "w1:p1");
+        let created = PaneId::new("host-a", "work", "w2:p1");
+
+        // What the federation says while the operation runs, and still says
+        // when its result arrives.
+        let mut stale = FederationState::default();
+        stale.targets.insert(
+            session.clone(),
+            runtime(
+                session.clone(),
+                TargetConnectionState::Live,
+                Some(NormalizedSnapshot::from_value(
+                    &session,
+                    &json!({
+                        "workspaces": [{"workspace_id": "w1"}],
+                        "panes": [{"pane_id": "w1:p1"}],
+                        "focused_pane_id": "w1:p1"
+                    }),
+                )),
+            ),
+        );
+
+        let mut app = App {
+            selected_pane: Some(existing.clone()),
+            selection_explicit: true,
+            ..App::default()
+        };
+        app.pending_operations.insert(
+            7,
+            super::PendingOperation {
+                description: "created workspace \"notes\"".to_owned(),
+                follow_server_focus: true,
+                follow_session: session.clone(),
+                clipboard_feedback: None,
+            },
+        );
+
+        super::handle_daemon_event(
+            crate::protocol::ServerMessage::OperationResult {
+                request: 7,
+                applied: true,
+                message: "ok".to_owned(),
+                plugin_run: None,
+            },
+            &mut app,
+            &stale,
+        );
+        assert_eq!(app.selected_pane, None);
+
+        // Reconciling against the state the result arrived with must not
+        // consume the follow: this focus is what the operation ran against.
+        reconcile_selection(&stale, &mut app);
+        assert_eq!(app.selected_pane, None);
+        assert!(app.followed_focus.is_some());
+
+        // The refresh that carries the new workspace is the one to adopt.
+        let mut refreshed = FederationState::default();
+        refreshed.targets.insert(
+            session.clone(),
+            runtime(
+                session.clone(),
+                TargetConnectionState::Live,
+                Some(NormalizedSnapshot::from_value(
+                    &session,
+                    &json!({
+                        "workspaces": [{"workspace_id": "w1"}, {"workspace_id": "w2"}],
+                        "panes": [{"pane_id": "w1:p1"}, {"pane_id": "w2:p1"}],
+                        "focused_pane_id": "w2:p1"
+                    }),
+                )),
+            ),
+        );
+        reconcile_selection(&refreshed, &mut app);
+
+        assert_eq!(app.selected_pane, Some(created));
+        assert!(app.followed_focus.is_none());
+    }
+
+    /// Which server the focus comes from is not a detail: the startup heuristic
+    /// picks whichever machine has the most on it, so an operation on a quiet
+    /// target moved the person to a busy one.
     #[test]
     fn a_followed_focus_lands_on_the_session_the_operation_acted_on() {
         let acted_on = TargetSession::new("host-a", "work");
@@ -10536,28 +10674,29 @@ mod tests {
             ),
         );
 
-        // What the operation result leaves behind: no selection, and the
-        // session whose focus to adopt.
         let mut app = App {
             selected_pane: None,
-            follow_focus_session: Some(acted_on),
-            message: Some("Herdr: created workspace \"notes\" on host-a:work".to_owned()),
+            followed_focus: Some(super::FollowedFocus {
+                session: acted_on,
+                before: std::collections::BTreeSet::from([PaneId::new("host-a", "work", "w1:p1")]),
+                deadline: Instant::now() + super::FOLLOW_FOCUS_TIMEOUT,
+            }),
+            message: Some("Herdr: created workspace \"notes\"".to_owned()),
             ..App::default()
         };
         reconcile_selection(&state, &mut app);
 
         assert_eq!(app.selected_pane, Some(created));
         assert!(app.selection_explicit);
-        // Consumed, so a later reconciliation does not move the person again.
-        assert_eq!(app.follow_focus_session, None);
+        assert!(app.followed_focus.is_none());
         // The result the person was shown outlives the selection it caused.
         assert_eq!(
             app.message.as_deref(),
-            Some("Herdr: created workspace \"notes\" on host-a:work")
+            Some("Herdr: created workspace \"notes\"")
         );
 
-        // Without a followed session the startup heuristic still chooses the
-        // busiest machine, which is correct at startup and was the bug here.
+        // Without one the startup heuristic still chooses the busiest machine,
+        // which is correct at startup and was the bug here.
         let mut app = App {
             selected_pane: None,
             ..App::default()
@@ -10566,29 +10705,21 @@ mod tests {
         assert_eq!(app.selected_pane, Some(elsewhere));
     }
 
-    /// A followed session that has not reported its new focus yet is waited
-    /// for. Choosing anything else would move the person twice.
+    /// Waiting is bounded. A session that never reports its new focus must not
+    /// leave the frontend with nothing selected.
     #[test]
-    fn a_followed_focus_waits_for_the_session_to_report_one() {
-        let acted_on = TargetSession::new("host-a", "work");
-        let busiest = TargetSession::new("host-b", "work");
+    fn a_followed_focus_stops_waiting_once_its_deadline_passes() {
+        let session = TargetSession::new("host-a", "work");
+        let existing = PaneId::new("host-a", "work", "w1:p1");
 
         let mut state = FederationState::default();
         state.targets.insert(
-            acted_on.clone(),
+            session.clone(),
             runtime(
-                acted_on.clone(),
-                TargetConnectionState::Backoff { attempt: 1 },
-                None,
-            ),
-        );
-        state.targets.insert(
-            busiest.clone(),
-            runtime(
-                busiest.clone(),
+                session.clone(),
                 TargetConnectionState::Live,
                 Some(NormalizedSnapshot::from_value(
-                    &busiest,
+                    &session,
                     &json!({
                         "panes": [{"pane_id": "w1:p1"}],
                         "focused_pane_id": "w1:p1"
@@ -10597,15 +10728,29 @@ mod tests {
             ),
         );
 
+        // Still waiting: the only focus on offer is the one held beforehand.
         let mut app = App {
             selected_pane: None,
-            follow_focus_session: Some(acted_on.clone()),
+            followed_focus: Some(super::FollowedFocus {
+                session: session.clone(),
+                before: std::collections::BTreeSet::from([existing.clone()]),
+                deadline: Instant::now() + super::FOLLOW_FOCUS_TIMEOUT,
+            }),
             ..App::default()
         };
         reconcile_selection(&state, &mut app);
-
         assert_eq!(app.selected_pane, None);
-        assert_eq!(app.follow_focus_session, Some(acted_on));
+
+        // Expired: take that session's focus rather than jumping to another
+        // machine or leaving the frontend empty.
+        app.followed_focus = Some(super::FollowedFocus {
+            session,
+            before: std::collections::BTreeSet::from([existing.clone()]),
+            deadline: Instant::now() - Duration::from_secs(1),
+        });
+        reconcile_selection(&state, &mut app);
+        assert_eq!(app.selected_pane, Some(existing));
+        assert!(app.followed_focus.is_none());
     }
 
     fn layout_with_panes(


### PR DESCRIPTION
0.7.22 claimed to land on a newly created workspace and did not move at all.
This is the actual cause, in both places it lives.

## Cause

Nothing refreshes a target when an operation completes — `Input::OperationDone`
reported the result and stopped there. The federation arrives on its own
cadence (`refresh_interval`, 5s), so **at the instant a result lands the state
still describes the session as it was beforehand**, old focus included.

`reconcile_selection` runs every render frame, so it fired immediately against
that stale state, read a `focused_pane` that was `Some` (just old), selected the
pane the person was already on, and consumed the follow. The refresh that
finally carried the new workspace then hit the early return that stops
federation updates redirecting keystrokes. Nothing moved, ever.

The 0.7.22 guard only waited when focus was `None`. A stale snapshot's focus
isn't `None` — it's stale.

## Change

**Frontend.** `FollowedFocus` records the panes the session held when the
operation landed. Every operation that follows focus creates a pane, so a focus
inside that set is state the refresh has not reached and is waited out; a focus
outside it is the operation's result. Bounded at 10s, after which the session's
own focus is taken rather than leaving nothing selected.

**Daemon.** `FederationStore::refresh_now` nudges one target's supervisor, which
wakes from its refresh deadline, change stream, or backoff and snapshots
immediately. An applied operation that changes what a snapshot would say asks
for one. Typing into a pane does not — that changes a terminal, which the
federation does not carry. Advisory and never awaited, so a wedged target cannot
hold the daemon loop; the interval stays the backstop.

Either half alone leaves the other wrong: without the frontend change the
refresh still races the reconcile, and without the daemon change the jump waits
out a poll interval.

## Verification

- Frontend test reconciles against the state a result *arrives with*, requires
  the follow to survive it, then adopts the refresh carrying the new workspace.
  With 0.7.22's logic restored it selects `host-a:work:w1:p1` — the pane the
  person started on — which is the reported bug.
- Store test gives a supervisor a one-hour interval so only a nudge can explain
  a second snapshot. Fails without one.
- `cargo fmt --check`, `node tools/check-docs.mjs`, `cargo test --locked` (421
  passing), `cargo clippy --all-targets -- -D warnings`.

**Still not verified end to end:** `herdr workspace create` needs a terminal
this headless machine cannot spawn (`ghostty error -2`). The difference from
0.7.22 is that the failing case is now reproduced in a test rather than assumed
away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J