### PR TITLE
Release 0.7.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Tagged releases and their generated change lists are available on the
 The notes below retain upgrade and security information that should not be
 inferred from commit titles alone.
 
+## 0.7.23
+
+- Fixed creating a workspace not moving to it. 0.7.22 said it followed Herdr's
+  focus and moved nowhere at all. Nothing refreshed a target when an operation
+  completed, so at the instant a result landed the federation still described
+  the session as it was beforehand. The frontend adopted that focus, selected
+  the pane the person was already on, and the refresh carrying the new
+  workspace then arrived to find a selection it must not disturb. The frontend
+  now waits for a focus the session did not already hold, and the daemon asks
+  the target for a snapshot when an applied operation changes what a snapshot
+  would say. Creating a tab, splitting a pane and moving a workspace were
+  affected the same way.
+
 ## 0.7.22
 
 - Fixed the selection jumping to another machine after creating a workspace.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-herdr"
-version = "0.7.22"
+version = "0.7.23"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-herdr"
-version = "0.7.22"
+version = "0.7.23"
 edition = "2024"
 publish = false
 description = "A multi-host control plane for persistent Herdr coding-agent sessions"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ brew install mikro-design/tap/super-herdr
 Debian and Ubuntu packages are published for amd64 and arm64:
 
 ```sh
-version=0.7.22
+version=0.7.23
 arch=amd64 # or arm64
 package="super-herdr_${version}-1_${arch}.deb"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/v${version}/${package}"
@@ -58,7 +58,7 @@ sudo dpkg -i "./${package}"
 Other Linux users can install a prebuilt archive:
 
 ```sh
-tag=v0.7.22
+tag=v0.7.23
 target=x86_64-unknown-linux-gnu # or aarch64-unknown-linux-gnu
 archive="super-herdr-${tag}-${target}.tar.gz"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/${tag}/${archive}"


### PR DESCRIPTION
Version bump, changelog entry, and the README install examples that
`tools/check-docs.mjs` validates against the package version.

## What ships

One fix (#33), and it is the fix 0.7.22 said it carried.

Creating a workspace did not move to it — 0.7.22 moved nowhere at all. Nothing
refreshed a target when an operation completed, so the state a result arrived
with still described the session as it was beforehand; the frontend adopted that
focus, selected the pane the person was already on, and the refresh carrying the
new workspace then found a selection it must not disturb. Creating a tab,
splitting a pane and moving a workspace went the same way.

The frontend now waits for a focus the session did not already hold, and the
daemon asks the target for a snapshot when an applied operation changes what a
snapshot would say.

## Gates

`cargo fmt --check`, `node tools/check-docs.mjs` (release examples now read
0.7.23), `cargo test --locked` (421 passing), and
`cargo clippy --all-targets -- -D warnings` all pass locally.

Tag `v0.7.23` goes on the merge commit after this lands, which is what triggers
the publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J