### PR TITLE
Serve the Debian packages from an APT repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,33 @@ With Homebrew on macOS or Linux:
 brew install mikro-design/tap/super-herdr
 ```
 
-Debian and Ubuntu packages are published for amd64 and arm64:
+On Debian and Ubuntu, add the package repository once:
+
+```sh
+sudo install -d -m 0755 /usr/share/keyrings
+curl -fsSL https://mikro-design.github.io/apt/super-herdr.gpg \
+  | sudo tee /usr/share/keyrings/super-herdr.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/super-herdr.gpg] https://mikro-design.github.io/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/super-herdr.list > /dev/null
+sudo apt update
+```
+
+Then, now and for every release after it:
+
+```sh
+sudo apt install super-herdr
+```
+
+amd64 and arm64 are both published. To install one release without adding the
+repository, take its `.deb` from the releases page and let apt resolve the
+dependencies:
 
 ```sh
 version=0.7.23
 arch=amd64 # or arm64
 package="super-herdr_${version}-1_${arch}.deb"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/v${version}/${package}"
-sudo dpkg -i "./${package}"
+sudo apt install "./${package}"
 ```
 
 Other Linux users can install a prebuilt archive:

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -20,6 +20,57 @@ rendered checksums match before the release exists.
 This is not automated, because pushing to the tap needs credentials that this
 repository deliberately does not hold.
 
+## Publishing a release to the APT repository
+
+`apt install super-herdr` is served by
+[`mikro-design/apt`](https://github.com/mikro-design/apt), a second repository
+published with GitHub Pages. It is separate from this one so that released
+binaries never enter this repository's history, and so that publishing and
+source do not share push permissions.
+
+Unlike a Homebrew formula, an APT repository is **signed**. `apt` does not
+verify packages; it verifies an index, and trusts the packages that index names
+by checksum. The index is therefore the whole security boundary, and the
+private key that signs it is deliberately not held by this repository's CI —
+the same reason the Homebrew step above is manual. A leaked signing key is worse
+than leaked push access: it signs an index served from anywhere, by anyone, and
+there is nothing to revoke short of getting a new key onto every machine that
+installed the old one.
+
+1. Tag a release and wait for the `CI and Release` workflow, as above.
+2. From a checkout of this repository, on the machine holding the signing key:
+
+   ```sh
+   scripts/publish-apt-repo.sh 0.7.23 ../apt "${SUPER_HERDR_APT_KEY}"
+   ```
+
+   That downloads the release's `.deb` packages, checks them against the
+   release's own `SHA256SUMS`, copies them into the pool, prunes to the last ten
+   releases, renders the index, signs it, and verifies the result.
+3. Commit and push the `apt` checkout. The script prints the exact commands and
+   deliberately does not run them: publishing is the irreversible step.
+
+The three scripts are separate because only one of them needs the key.
+`render-apt-repo.sh` is reproducible and runs anywhere; `sign-apt-repo.sh` runs
+where the key is; `verify-apt-repo.sh` reads only published bytes and re-checks
+every signature, index checksum and package checksum the way a client would.
+
+### The signing key
+
+Generate it once, on the machine that will keep it:
+
+```sh
+gpg --quick-generate-key "Super-Herdr <mikrodesign@proton.me>" ed25519 sign 2y
+```
+
+An expiry means a forgotten key stops being trusted rather than living forever;
+it can be extended at any time with `gpg --quick-set-expire`. Keep the
+revocation certificate GnuPG writes into `openpgp-revocs.d` somewhere other than
+the machine holding the key.
+
+The public half is exported into the repository as `super-herdr.gpg` on every
+publish, which is the file the README tells users to install.
+
 ## No Arch package
 
 There is deliberately no AUR package. Publishing to the AUR authenticates only

--- a/scripts/publish-apt-repo.sh
+++ b/scripts/publish-apt-repo.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Publish one release into a checked-out APT repository.
+#
+# The Debian analogue of the manual Homebrew step in packaging/README.md, and
+# manual for the same reason: it signs, and the signing key deliberately does
+# not live in this repository's CI. What it automates is everything either side
+# of the signature, because those are the steps that are easy to get subtly
+# wrong by hand.
+#
+# Packages are taken from the GitHub release and checked against that release's
+# own SHA256SUMS before they are indexed. A repository that serves a package the
+# release did not publish is the failure this exists to prevent, so it is
+# checked here rather than assumed from a successful download.
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 <version> <apt-repo-checkout> <signing-key-id> [keep]" >&2
+  echo "  keep: how many releases to leave installable (default 10)" >&2
+  exit 2
+fi
+
+version="$1"
+repo="$2"
+key="$3"
+keep="${4:-10}"
+source_repo="${SUPER_HERDR_REPO:-mikro-design/super-herdr}"
+pool="${repo}/pool/main/s/super-herdr"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ ! -d "${repo}/.git" ]]; then
+  echo "${repo} is not a git checkout of the apt repository" >&2
+  exit 1
+fi
+
+staging="$(mktemp -d)"
+trap 'rm -rf "${staging}"' EXIT
+
+echo "fetching v${version} from ${source_repo}"
+gh release download "v${version}" --repo "${source_repo}" --dir "${staging}" \
+  --pattern '*.deb' --pattern 'SHA256SUMS'
+
+# The release's own manifest is the authority on what it published. Checking
+# against it here means a truncated download, a wrong tag, or an asset replaced
+# after the fact fails now rather than on somebody's machine.
+echo "verifying against the release manifest"
+(cd "${staging}" && sha256sum -c --ignore-missing SHA256SUMS)
+
+packages="$(find "${staging}" -name '*.deb' | wc -l)"
+if [[ "${packages}" -ne 2 ]]; then
+  echo "expected 2 Debian packages in v${version}, found ${packages}" >&2
+  exit 1
+fi
+
+mkdir -p "${pool}"
+cp "${staging}"/*.deb "${pool}/"
+
+# Old versions stay installable so `apt install super-herdr=0.7.22-1` works and
+# a bad release can be stepped back from, but not forever: the pool is served
+# from a static host with a size budget, and nobody pins a version from a year
+# ago. Sorted by Debian version rather than by name, because 0.7.9 sorts after
+# 0.7.10 as a string and pruning the wrong one is silent.
+mapfile -t versions < <(
+  find "${pool}" -name '*.deb' -print0 \
+    | xargs -0 -r -n1 dpkg-deb --field 2>/dev/null \
+    | awk '/^Version: /{ print $2 }' \
+    | sort -u -V
+)
+if [[ "${#versions[@]}" -gt "${keep}" ]]; then
+  drop=$(( ${#versions[@]} - keep ))
+  for stale in "${versions[@]:0:${drop}}"; do
+    echo "pruning ${stale}"
+    find "${pool}" -name "super-herdr_${stale}_*.deb" -delete
+  done
+fi
+
+"${here}/render-apt-repo.sh" "${repo}"
+"${here}/sign-apt-repo.sh" "${repo}" "${key}"
+"${here}/verify-apt-repo.sh" "${repo}"
+
+cat <<EOF
+
+Rendered and signed. Nothing is published until this is pushed:
+
+  git -C "${repo}" add -A
+  git -C "${repo}" commit -m "super-herdr ${version}"
+  git -C "${repo}" push origin main
+EOF

--- a/scripts/render-apt-repo.sh
+++ b/scripts/render-apt-repo.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Render an APT repository from the Debian packages already in its pool.
+#
+# `apt` does not verify packages; it verifies an index, and trusts the packages
+# that index names by checksum. So the index is the whole security boundary,
+# and it is generated here from the packages themselves rather than written
+# down anywhere a copy could drift.
+#
+# The pool is the input: whatever `.deb` files are under pool/main/s/super-herdr
+# are the versions this repository offers. Populating it is the caller's job,
+# because which releases stay installable is a decision and not a detail.
+#
+# Signing is separate, in scripts/sign-apt-repo.sh. This script needs no key and
+# is safe to run anywhere, which is what makes the index reproducible: the same
+# pool renders the same bytes whether CI or a laptop rendered them.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <repository-directory>" >&2
+  exit 2
+fi
+
+repo="$1"
+suite="stable"
+component="main"
+pool="pool/${component}/s/super-herdr"
+architectures=(amd64 arm64)
+
+if [[ ! -d "${repo}/${pool}" ]]; then
+  echo "no pool at ${repo}/${pool}; nothing to publish" >&2
+  exit 1
+fi
+
+packages="$(find "${repo}/${pool}" -name '*.deb' | wc -l)"
+if [[ "${packages}" -eq 0 ]]; then
+  echo "no Debian packages in ${repo}/${pool}" >&2
+  exit 1
+fi
+
+# Rebuilt rather than updated. An index that accumulates edits is an index that
+# can disagree with its pool, and the disagreement is invisible until an install
+# fails against a checksum nobody rechecked.
+rm -rf "${repo}/dists"
+
+for architecture in "${architectures[@]}"; do
+  binary="dists/${suite}/${component}/binary-${architecture}"
+  mkdir -p "${repo}/${binary}"
+  # Paths in the index are relative to the repository root, so the index is
+  # rendered from there and stays correct under any URL it is served from.
+  (
+    cd "${repo}"
+    apt-ftparchive --arch "${architecture}" packages "${pool}" > "${binary}/Packages"
+    gzip -9 --keep --force "${binary}/Packages"
+  )
+  count="$(grep -c '^Package: ' "${repo}/${binary}/Packages" || true)"
+  if [[ "${count}" -eq 0 ]]; then
+    echo "no ${architecture} packages found in ${pool}" >&2
+    exit 1
+  fi
+  echo "${architecture}: ${count} package(s)"
+done
+
+# `apt` refuses a Release file whose Suite, Codename or Architectures do not
+# cover what the source line asked for, so these are stated rather than left to
+# whatever apt-ftparchive infers from the directory it was pointed at.
+#
+# Written elsewhere and moved into place: a redirect creates its target before
+# the command runs, and apt-ftparchive would then find an empty Release file in
+# the directory it is indexing and list it as one of its own contents.
+release="$(mktemp)"
+trap 'rm -f "${release}"' EXIT
+
+(
+  cd "${repo}"
+  apt-ftparchive \
+    -o "APT::FTPArchive::Release::Origin=super-herdr" \
+    -o "APT::FTPArchive::Release::Label=super-herdr" \
+    -o "APT::FTPArchive::Release::Suite=${suite}" \
+    -o "APT::FTPArchive::Release::Codename=${suite}" \
+    -o "APT::FTPArchive::Release::Components=${component}" \
+    -o "APT::FTPArchive::Release::Architectures=${architectures[*]}" \
+    -o "APT::FTPArchive::Release::Description=Super-Herdr released Debian packages" \
+    release "dists/${suite}" > "${release}"
+)
+mv "${release}" "${repo}/dists/${suite}/Release"
+trap - EXIT
+
+echo "rendered ${repo}/dists/${suite}/Release from ${packages} package(s)"

--- a/scripts/sign-apt-repo.sh
+++ b/scripts/sign-apt-repo.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Sign a rendered APT repository, and export the key that verifies it.
+#
+# Separate from rendering because it is the only step that needs the private
+# key. Rendering is reproducible and runs anywhere; signing runs where the key
+# is, which is deliberately not this repository's CI. See packaging/README.md.
+#
+# Both signatures are written. `InRelease` is what modern apt fetches, and
+# `Release.gpg` is what older clients look for; publishing one and not the other
+# strands whichever client asked for the missing file.
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <repository-directory> <signing-key-id>" >&2
+  exit 2
+fi
+
+repo="$1"
+key="$2"
+suite="stable"
+release="${repo}/dists/${suite}/Release"
+
+if [[ ! -f "${release}" ]]; then
+  echo "no ${release}; run scripts/render-apt-repo.sh first" >&2
+  exit 1
+fi
+
+if ! gpg --list-secret-keys "${key}" > /dev/null 2>&1; then
+  echo "no secret key for ${key} in this keyring" >&2
+  exit 1
+fi
+
+# A passphrase-protected key needs somewhere to ask for the passphrase, and
+# GnuPG asks on the terminal it was told about rather than the one it inherited.
+# Without this a signature fails with "Inappropriate ioctl for device", which
+# says nothing about passphrases to anyone who has not met it before.
+if [[ -z "${GPG_TTY:-}" ]] && tty_name="$(tty 2> /dev/null)"; then
+  export GPG_TTY="${tty_name}"
+fi
+if [[ -z "${GPG_TTY:-}" ]]; then
+  echo "warning: no terminal for a passphrase prompt; run this from a shell" >&2
+fi
+
+gpg --batch --yes --default-key "${key}" \
+  --clearsign --output "${repo}/dists/${suite}/InRelease" "${release}"
+gpg --batch --yes --default-key "${key}" \
+  --detach-sign --armor --output "${repo}/dists/${suite}/Release.gpg" "${release}"
+
+# The public key ships beside the repository it verifies. Dearmoured, because a
+# `signed-by` keyring is read as binary and an ASCII-armoured file placed there
+# fails at verification rather than at download, where the cause is legible.
+gpg --export "${key}" > "${repo}/super-herdr.gpg"
+
+echo "signed ${suite} with ${key}"
+echo "exported $(basename "${repo}")/super-herdr.gpg"

--- a/scripts/verify-apt-repo.sh
+++ b/scripts/verify-apt-repo.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Verify a rendered APT repository against itself, before it is published.
+#
+# `apt` trusts an index, and the index is only as good as its agreement with the
+# pool it describes. A stale index names a checksum no file has any more, and
+# the failure surfaces on somebody else's machine as a hash mismatch with
+# nothing to act on. Everything checked here is checked from the published
+# bytes, the way a client would read them.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <repository-directory>" >&2
+  exit 2
+fi
+
+repo="$1"
+suite="stable"
+dist="${repo}/dists/${suite}"
+
+for required in "${dist}/Release" "${dist}/InRelease" "${dist}/Release.gpg" "${repo}/super-herdr.gpg"; do
+  if [[ ! -f "${required}" ]]; then
+    echo "missing ${required}" >&2
+    exit 1
+  fi
+done
+
+# The signature verifies against the exported key, not against whatever the
+# signing machine happens to trust. That is the check a client performs, and it
+# catches signing with a key users were never given.
+keyring="$(mktemp)"
+trap 'rm -f "${keyring}"' EXIT
+gpg --no-default-keyring --keyring "${keyring}" --import "${repo}/super-herdr.gpg" 2> /dev/null
+
+for signature in InRelease Release.gpg; do
+  if ! gpg --no-default-keyring --keyring "${keyring}" --verify \
+      "${dist}/${signature}" $([[ "${signature}" == "Release.gpg" ]] && echo "${dist}/Release") \
+      > /dev/null 2>&1; then
+    echo "${signature} does not verify against the published key" >&2
+    exit 1
+  fi
+done
+
+# InRelease is a signed copy of Release rather than a second opinion. A client
+# fetching one and a client fetching the other must be told the same thing.
+if ! diff -q <(gpg --no-default-keyring --keyring "${keyring}" \
+    --decrypt "${dist}/InRelease" 2> /dev/null) "${dist}/Release" > /dev/null; then
+  echo "InRelease and Release disagree" >&2
+  exit 1
+fi
+
+# Every index the Release file vouches for must still be the file on disk.
+indexes=0
+while read -r digest size path; do
+  [[ -n "${path}" ]] || continue
+  actual="${dist}/${path}"
+  if [[ ! -f "${actual}" ]]; then
+    echo "Release names ${path}, which is not in the repository" >&2
+    exit 1
+  fi
+  if [[ "$(sha256sum "${actual}" | awk '{ print $1 }')" != "${digest}" ]]; then
+    echo "${path} does not match the checksum in Release" >&2
+    exit 1
+  fi
+  if [[ "$(stat -c %s "${actual}")" != "${size}" ]]; then
+    echo "${path} does not match the size in Release" >&2
+    exit 1
+  fi
+  indexes=$(( indexes + 1 ))
+done < <(awk '/^SHA256:/ { inside = 1; next } /^[^ ]/ { inside = 0 } inside' "${dist}/Release")
+
+if [[ "${indexes}" -eq 0 ]]; then
+  echo "Release vouches for no indexes at all" >&2
+  exit 1
+fi
+
+# And every package an index offers must be the file the pool holds. This is the
+# checksum a client verifies after downloading, so a mismatch here is exactly
+# the install failure it would cause.
+offered=0
+for packages in "${dist}"/*/binary-*/Packages; do
+  [[ -f "${packages}" ]] || continue
+  while read -r filename digest size; do
+    package="${repo}/${filename}"
+    if [[ ! -f "${package}" ]]; then
+      echo "${packages} offers ${filename}, which is not in the pool" >&2
+      exit 1
+    fi
+    if [[ "$(sha256sum "${package}" | awk '{ print $1 }')" != "${digest}" ]]; then
+      echo "${filename} does not match the checksum in ${packages}" >&2
+      exit 1
+    fi
+    if [[ "$(stat -c %s "${package}")" != "${size}" ]]; then
+      echo "${filename} does not match the size in ${packages}" >&2
+      exit 1
+    fi
+    offered=$(( offered + 1 ))
+  done < <(awk '
+    /^Filename: / { filename = $2 }
+    /^SHA256: / { digest = $2 }
+    /^Size: / { size = $2 }
+    /^$/ { if (filename != "") print filename, digest, size; filename = "" }
+    END { if (filename != "") print filename, digest, size }
+  ' "${packages}")
+done
+
+if [[ "${offered}" -eq 0 ]]; then
+  echo "no package is offered by any index" >&2
+  exit 1
+fi
+
+echo "verified ${suite}: ${indexes} index(es), ${offered} package entr(ies), signed and consistent"


### PR DESCRIPTION
`apt install super-herdr` now works. The repository is live at
**https://mikro-design.github.io/apt** and this points people at it.

The packages were always correct. What was missing was somewhere to serve them
from: users curled a `.deb` and ran `dpkg -i`, which resolves no dependencies
and never upgrades, so every release was a manual reinstall nobody was told
about.

## Why this is more than the Homebrew equivalent

`apt` does not verify packages. It verifies an **index**, and trusts the
packages that index names by checksum — so the index is the whole security
boundary. A Homebrew formula carries its own checksum and needs no signature;
an APT index needs one, and a signature needs a key that exists for the life of
the project.

That key is **not** held by this repository's CI, for the reason
`packaging/README.md` already gives for the Homebrew step. A leaked signing key
is worse than leaked push access: it signs an index served from anywhere, by
anyone, and nothing revokes it short of getting a new key onto every machine
that installed the old one.

## Four scripts, because only one of them needs the key

- **`render-apt-repo.sh`** — builds the index from whatever the pool holds.
  No key, runs anywhere. Rebuilds rather than updates: an index that
  accumulates edits can disagree with its pool, and the disagreement is
  invisible until an install fails.
- **`sign-apt-repo.sh`** — signs where the key is. Writes both `InRelease` and
  `Release.gpg`, so neither modern nor older clients are stranded.
- **`verify-apt-repo.sh`** — reads only published bytes and re-checks every
  signature, index checksum and package checksum the way a client would.
- **`publish-apt-repo.sh`** — the Debian analogue of the manual Homebrew step.
  Takes the release's own packages, checks them against that release's
  `SHA256SUMS` *before* indexing anything, prunes to the last ten releases, and
  stops before pushing.

## Verification

Tested with real `apt` against the live URL, using the README's own commands in
an isolated apt root:

- the published key fetches and matches the signing fingerprint
- `apt update` accepts the signature over HTTPS
- `apt-cache policy` offers `0.7.23-1` as the candidate
- `apt-get download` returned a `.deb` byte-identical to the release's own
- the binary inside reports `super-herdr 0.7.23`
- `libc6 (>= 2.28)` is satisfied — zero dependency complaints

The verifier was checked against a swapped package, a removed package, an
edited index, an edited `Release`, an `InRelease` disagreeing with its
`Release`, a desynced compressed index, and an index signed with a key users
were never given. Each is refused.

## Also

`dpkg -i` is gone from the README even for the one-off case — `apt install
./file.deb` resolves dependencies where `dpkg -i` fails with a cryptic error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J