### PR TITLE
Install from apt in one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,22 +39,27 @@ clipboard you use.
 
 ### 1. Install
 
-With Homebrew on macOS or Linux:
+On macOS, or Linux with Homebrew:
 
 ```sh
 brew install mikro-design/tap/super-herdr
 ```
 
-On Debian and Ubuntu:
+On Debian or Ubuntu:
 
 ```sh
 curl -fsSL https://mikro-design.github.io/apt/install.sh | sudo bash
 ```
 
-That adds the signed package repository and installs Super-Herdr, so every
-upgrade after it arrives with `apt upgrade`. amd64 and arm64 are both published.
+Either way, later versions arrive with `brew upgrade` or `apt upgrade`. amd64
+and arm64 are published for both.
 
-To do the same thing without piping a script to a shell:
+<details>
+<summary>Other ways to install</summary>
+
+The Debian one-liner adds a signed package repository and installs from it.
+These are the same four commands, for anyone who would rather not pipe a script
+to a root shell:
 
 ```sh
 sudo install -d -m 0755 /usr/share/keyrings
@@ -76,7 +81,7 @@ curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/v${vers
 sudo apt install "./${package}"
 ```
 
-Other Linux users can install a prebuilt archive:
+On Linux without Homebrew or apt, take a prebuilt archive:
 
 ```sh
 tag=v0.7.23
@@ -87,8 +92,11 @@ tar xzf "${archive}"
 sudo install -m 0755 "super-herdr-${tag}-${target}/super-herdr" /usr/local/bin/
 ```
 
-All macOS and Linux packages, checksums, and build attestations are on the
+Every package, checksum, and build attestation is on the
 [releases page](https://github.com/mikro-design/super-herdr/releases/latest).
+Building from source is covered under [Build from source](#build-from-source).
+
+</details>
 
 ### 2. Add a Herdr machine
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,16 @@ With Homebrew on macOS or Linux:
 brew install mikro-design/tap/super-herdr
 ```
 
-On Debian and Ubuntu, add the package repository once:
+On Debian and Ubuntu:
+
+```sh
+curl -fsSL https://mikro-design.github.io/apt/install.sh | sudo bash
+```
+
+That adds the signed package repository and installs Super-Herdr, so every
+upgrade after it arrives with `apt upgrade`. amd64 and arm64 are both published.
+
+To do the same thing without piping a script to a shell:
 
 ```sh
 sudo install -d -m 0755 /usr/share/keyrings
@@ -53,18 +62,11 @@ curl -fsSL https://mikro-design.github.io/apt/super-herdr.gpg \
   | sudo tee /usr/share/keyrings/super-herdr.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/super-herdr.gpg] https://mikro-design.github.io/apt stable main" \
   | sudo tee /etc/apt/sources.list.d/super-herdr.list > /dev/null
-sudo apt update
+sudo apt update && sudo apt install super-herdr
 ```
 
-Then, now and for every release after it:
-
-```sh
-sudo apt install super-herdr
-```
-
-amd64 and arm64 are both published. To install one release without adding the
-repository, take its `.deb` from the releases page and let apt resolve the
-dependencies:
+To install one release without adding the repository at all, take its `.deb`
+from the releases page and let apt resolve the dependencies:
 
 ```sh
 version=0.7.23

--- a/packaging/install-apt.sh
+++ b/packaging/install-apt.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Add the Super-Herdr APT repository and install Super-Herdr.
+#
+# Published to the repository root, so the whole install is one line:
+#
+#   curl -fsSL https://mikro-design.github.io/apt/install.sh | sudo bash
+#
+# Nobody reads four commands off a README to try something. The commands are
+# still in the README for anyone who would rather run them, and this does
+# exactly those and nothing else, which is why it is short enough to read
+# before piping it anywhere.
+set -euo pipefail
+
+repository="https://mikro-design.github.io/apt"
+keyring="/usr/share/keyrings/super-herdr.gpg"
+source_list="/etc/apt/sources.list.d/super-herdr.list"
+
+if ! command -v apt-get > /dev/null 2>&1; then
+  echo "This installs a Debian package and needs apt." >&2
+  echo "On macOS or other Linux: brew install mikro-design/tap/super-herdr" >&2
+  exit 1
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run this as root: curl -fsSL ${repository}/install.sh | sudo bash" >&2
+  exit 1
+fi
+
+architecture="$(dpkg --print-architecture)"
+case "${architecture}" in
+  amd64 | arm64) ;;
+  *)
+    echo "No Debian package is published for ${architecture}." >&2
+    echo "Prebuilt archives and sources: https://github.com/mikro-design/super-herdr" >&2
+    exit 1
+    ;;
+esac
+
+for tool in curl gpg; do
+  if ! command -v "${tool}" > /dev/null 2>&1; then
+    echo "Installing ${tool}, which this needs to verify the repository."
+    apt-get update -qq
+    apt-get install -y --no-install-recommends "${tool}"
+  fi
+done
+
+echo "Adding the Super-Herdr repository."
+install -d -m 0755 "$(dirname "${keyring}")"
+
+# Written through a temporary file so an interrupted download cannot leave a
+# truncated keyring in place, which apt reports as a signature failure rather
+# than as the half-written file it is.
+staged="$(mktemp)"
+trap 'rm -f "${staged}"' EXIT
+curl -fsSL "${repository}/super-herdr.gpg" -o "${staged}"
+if ! gpg --show-keys "${staged}" > /dev/null 2>&1; then
+  echo "The downloaded key is not a valid OpenPGP key; refusing to install it." >&2
+  exit 1
+fi
+install -m 0644 "${staged}" "${keyring}"
+
+echo "deb [signed-by=${keyring}] ${repository} stable main" > "${source_list}"
+
+echo "Updating package lists."
+apt-get update -o Dir::Etc::sourcelist="${source_list}" \
+  -o Dir::Etc::sourceparts=/dev/null -o APT::Get::List-Cleanup=0
+
+echo "Installing super-herdr."
+apt-get install -y super-herdr
+
+cat <<EOF
+
+Installed $(super-herdr --version 2> /dev/null || echo super-herdr).
+
+  super-herdr target add desktop --local --discover-sessions
+  super-herdr
+
+Upgrades arrive with apt upgrade from now on.
+EOF

--- a/scripts/publish-apt-repo.sh
+++ b/scripts/publish-apt-repo.sh
@@ -73,6 +73,10 @@ if [[ "${#versions[@]}" -gt "${keep}" ]]; then
   done
 fi
 
+# The one-line installer is served from the repository root, so it ships with
+# the repository it configures and cannot drift from it.
+install -m 0755 "${here}/../packaging/install-apt.sh" "${repo}/install.sh"
+
 "${here}/render-apt-repo.sh" "${repo}"
 "${here}/sign-apt-repo.sh" "${repo}" "${key}"
 "${here}/verify-apt-repo.sh" "${repo}"


### PR DESCRIPTION
Installing was four commands, and four commands to try one program is a bad
answer. It is now one:

```sh
curl -fsSL https://mikro-design.github.io/apt/install.sh | sudo bash
```

**Already live** at https://mikro-design.github.io/apt/install.sh — this PR is
the documentation and the source of that script.

## The installer

Adding a signed third-party repository genuinely does take those four steps, so
the script does them: fetch the key, check it parses as an OpenPGP key before
trusting it, write the source list, update, install.

- Staged through a temporary file, so an interrupted download cannot leave a
  truncated keyring — which apt reports as a signature failure rather than as
  the half-written file it is.
- Refuses on a non-apt system, with a pointer to Homebrew.
- Refuses on an architecture with no published package.
- Installs `curl`/`gpg` only if they are missing.

It is served from the repository root rather than from GitHub, so the script
that configures a repository always ships with the repository it configures.
`publish-apt-repo.sh` copies it in on every publish, and the served copy was
checked byte-identical to the source.

## The README

The install section had grown to five code blocks with no signal about which
one a reader wanted. Homebrew and the Debian one-liner now stand alone and
cover macOS and every Debian derivative; the manual repository commands, the
single-release `.deb`, and the prebuilt archive move behind a fold.

The manual commands stay, because piping a script to a root shell is a thing
plenty of people will not do and this project should not make it the only route.

## Verified against the live repository

- `install.sh` serves and is byte-identical to `packaging/install-apt.sh`
- `apt update` accepts the signature
- candidate resolves to `0.7.23-1`
- `apt-get download super-herdr=0.7.14-1` succeeds — the pool now carries ten
  releases, so an old version is pinnable and a bad release can be stepped back
  from

**Not verified:** a real `sudo bash` run of the installer. It needs root on a
machine I should not be changing, and the guards are tested but the install path
is not. That is the one thing worth doing before trusting this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J