### PR TITLE
Explain an apt failure instead of pre-empting one

### DIFF
--- a/packaging/install-apt.sh
+++ b/packaging/install-apt.sh
@@ -36,6 +36,34 @@ case "${architecture}" in
     ;;
 esac
 
+# apt refuses every install transaction while any package is half-configured,
+# and it refuses this one with a complaint about whichever unrelated package is
+# broken. Somebody who ran a one-line installer and got told about
+# libnvidia-compute has no reason to connect the two, so the state is checked
+# before anything is added to their system, and named.
+# Only the states that actually block. `triggers-pending` and `triggers-awaited`
+# are cleared by the next dpkg run and are common on a healthy system, so
+# refusing on those would turn a working install into a false alarm.
+broken="$(dpkg-query -W -f='${Package} ${Status}\n' 2> /dev/null \
+  | awk '$NF == "unpacked" || $NF == "half-configured" || $NF == "half-installed" { print $1 }' \
+  | sort -u)"
+remaining="$(echo "${broken}" | sed '/^$/d' | wc -l)"
+if [[ -n "${broken}" ]]; then
+  cat >&2 <<EOF
+This system has packages that are not fully installed, and apt will not install
+anything else until they are sorted out. It is not related to Super-Herdr:
+
+$(echo "${broken}" | head -5 | sed 's/^/  /')$([[ "${remaining}" -gt 5 ]] && printf '\n  ... and %d more' "$(( remaining - 5 ))")
+
+Fix them first, then run this again:
+
+  sudo apt --fix-broken install
+
+If that does not clear it, try: sudo dpkg --configure -a
+EOF
+  exit 1
+fi
+
 for tool in curl gpg; do
   if ! command -v "${tool}" > /dev/null 2>&1; then
     echo "Installing ${tool}, which this needs to verify the repository."

--- a/packaging/install-apt.sh
+++ b/packaging/install-apt.sh
@@ -36,34 +36,6 @@ case "${architecture}" in
     ;;
 esac
 
-# apt refuses every install transaction while any package is half-configured,
-# and it refuses this one with a complaint about whichever unrelated package is
-# broken. Somebody who ran a one-line installer and got told about
-# libnvidia-compute has no reason to connect the two, so the state is checked
-# before anything is added to their system, and named.
-# Only the states that actually block. `triggers-pending` and `triggers-awaited`
-# are cleared by the next dpkg run and are common on a healthy system, so
-# refusing on those would turn a working install into a false alarm.
-broken="$(dpkg-query -W -f='${Package} ${Status}\n' 2> /dev/null \
-  | awk '$NF == "unpacked" || $NF == "half-configured" || $NF == "half-installed" { print $1 }' \
-  | sort -u)"
-remaining="$(echo "${broken}" | sed '/^$/d' | wc -l)"
-if [[ -n "${broken}" ]]; then
-  cat >&2 <<EOF
-This system has packages that are not fully installed, and apt will not install
-anything else until they are sorted out. It is not related to Super-Herdr:
-
-$(echo "${broken}" | head -5 | sed 's/^/  /')$([[ "${remaining}" -gt 5 ]] && printf '\n  ... and %d more' "$(( remaining - 5 ))")
-
-Fix them first, then run this again:
-
-  sudo apt --fix-broken install
-
-If that does not clear it, try: sudo dpkg --configure -a
-EOF
-  exit 1
-fi
-
 for tool in curl gpg; do
   if ! command -v "${tool}" > /dev/null 2>&1; then
     echo "Installing ${tool}, which this needs to verify the repository."
@@ -94,7 +66,37 @@ apt-get update -o Dir::Etc::sourcelist="${source_list}" \
   -o Dir::Etc::sourceparts=/dev/null -o APT::Get::List-Cleanup=0
 
 echo "Installing super-herdr."
-apt-get install -y super-herdr
+if ! apt-get install -y super-herdr; then
+  # apt declines a transaction while another package is left half configured,
+  # and it declines this one by naming whichever unrelated package is broken.
+  # Somebody who ran a one-line installer and was told about libnvidia-compute
+  # has no reason to connect the two, so the state is read here and explained.
+  #
+  # After the failure rather than before it, deliberately. Half-configured
+  # packages do not always block — apt copes with plenty of them — and a check
+  # that ran first would refuse installs that were going to succeed, which is
+  # worse than the confusing error it set out to replace.
+  broken="$(dpkg-query -W -f='${Package} ${Status}\n' 2> /dev/null \
+    | awk '$NF == "unpacked" || $NF == "half-configured" || $NF == "half-installed" { print $1 }' \
+    | sort -u | sed '/^$/d')"
+  if [[ -n "${broken}" ]]; then
+    count="$(echo "${broken}" | wc -l)"
+    cat >&2 <<REASON
+
+That failure is about this system, not about Super-Herdr. These packages are
+not fully installed, and apt will not complete any transaction until they are:
+
+$(echo "${broken}" | head -5 | sed 's/^/  /')$([[ "${count}" -gt 5 ]] && printf '\n  ... and %d more' "$(( count - 5 ))")
+
+Sort them out, then run this again:
+
+  sudo apt --fix-broken install
+
+If that does not clear it, try: sudo dpkg --configure -a
+REASON
+  fi
+  exit 1
+fi
 
 cat <<EOF
 


### PR DESCRIPTION
Found on the first real run of the one-line installer: it failed, and the error
was about NVIDIA.

`apt` declines a transaction while another package is left half configured, and
it declines *this* one by naming whichever unrelated package is broken. Somebody
who ran a one-line installer and was told about `libnvidia-compute` has no way
to connect the two, and no reason to suspect their own system rather than the
thing they just tried to install.

So the installer now reads dpkg's state and explains it — **after apt has
actually declined, and only then**:

```
That failure is about this system, not about Super-Herdr. These packages are
not fully installed, and apt will not complete any transaction until they are:

  libnvidia-cfg1-580
  libnvidia-compute-580
  ... and 17 more

Sort them out, then run this again:

  sudo apt --fix-broken install
```

## Why after, and not before

The first version of this PR checked up front and refused. **It would have
blocked the install that then succeeded on the machine it was written for.**
Nineteen packages sat half configured there; `apt --fix-broken install` cleared
them and apt installed Super-Herdr without complaint — but nothing in a dpkg
status line says which of those two futures you are in.

A check that cannot tell "apt will refuse" from "apt will cope" and guesses
*refuse* is worse than the confusing error it replaced. Refusing an install that
would have worked is a failure the person cannot get past; a confusing error is
one they can at least paste somewhere.

apt decides whether the transaction can proceed — it is qualified to, and this
script is not. The explanation appears where it is useful and nowhere else.

## Verified

The one-line installer now has a complete successful run behind it:
`super-herdr 0.7.23-1 install ok installed`, from the signed repository, via
`curl … | sudo bash`. The diagnosis path was rendered against a simulated
failure, and produces nothing on a system with no half-configured packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J
