### PR TITLE
Stop republishing a target that only moved its clock

### DIFF
--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -3118,9 +3118,6 @@ mod tests {
         );
     }
 
-    /// The bound belongs to the rendered path alone: a frame subscriber is
-    /// already stopped by the socket it is not draining.
-    #[test]
     /// The flood this was written for: an event-driven target reports success
     /// several times a second, and every report moved `last_success`. Comparing
     /// whole values made that a change, so the entire target — every workspace,
@@ -3164,6 +3161,9 @@ mod tests {
         ));
     }
 
+    /// The bound belongs to the rendered path alone: a frame subscriber is
+    /// already stopped by the socket it is not draining.
+    #[test]
     fn a_frame_subscriber_is_not_bounded_by_the_screen_limit() {
         let mut broker = broker();
         let tui = greet(&mut broker);

--- a/src/daemon/broker.rs
+++ b/src/daemon/broker.rs
@@ -863,7 +863,11 @@ impl Broker {
     pub fn federation_updated(&mut self, state: FederationState) -> Vec<Effect> {
         let mut changes = Vec::new();
         for (key, target) in &state.targets {
-            if self.state.targets.get(key) != Some(target) {
+            let changed = match self.state.targets.get(key) {
+                Some(previous) => previous.differs_for_clients(target),
+                None => true,
+            };
+            if changed {
                 changes.push(ServerMessage::TargetState {
                     target: key.clone(),
                     state: Some(target.clone()),
@@ -3117,6 +3121,49 @@ mod tests {
     /// The bound belongs to the rendered path alone: a frame subscriber is
     /// already stopped by the socket it is not draining.
     #[test]
+    /// The flood this was written for: an event-driven target reports success
+    /// several times a second, and every report moved `last_success`. Comparing
+    /// whole values made that a change, so the entire target — every workspace,
+    /// pane and agent — went to every client each time, for a timestamp nothing
+    /// renders. Measured against one real session it was two megabytes in
+    /// twenty seconds, which a phone away from the house cannot drain.
+    #[test]
+    fn a_target_that_only_moved_its_clock_is_not_republished() {
+        let mut broker = broker();
+        let client = greet(&mut broker);
+        let quiet = federation(target_state(
+            TargetConnectionState::Live,
+            &["w1:p1"],
+            Some(1),
+        ));
+        broker.federation_updated(quiet.clone());
+        broker.handle(client, ClientMessage::SubscribeState);
+
+        // What a successful read does when nothing on the host moved.
+        let mut ticked = quiet.clone();
+        for target in ticked.targets.values_mut() {
+            target.last_success = Some(std::time::SystemTime::now());
+            target.retry_at = Some(std::time::SystemTime::now());
+        }
+        let effects = broker.federation_updated(ticked.clone());
+        assert!(
+            messages_for(&effects, client).is_empty(),
+            "a moved clock is not news: {:?}",
+            messages_for(&effects, client)
+        );
+
+        // Anything a client can see still goes out.
+        let mut changed = ticked;
+        for target in changed.targets.values_mut() {
+            target.connection = TargetConnectionState::Backoff { attempt: 1 };
+        }
+        let effects = broker.federation_updated(changed);
+        assert!(matches!(
+            messages_for(&effects, client).as_slice(),
+            [ServerMessage::TargetState { state: Some(_), .. }]
+        ));
+    }
+
     fn a_frame_subscriber_is_not_bounded_by_the_screen_limit() {
         let mut broker = broker();
         let tui = greet(&mut broker);

--- a/src/state.rs
+++ b/src/state.rs
@@ -296,6 +296,29 @@ pub struct TargetRuntimeState {
 }
 
 impl TargetRuntimeState {
+    /// Whether this differs in a way a client could act on.
+    ///
+    /// `last_success` and `retry_at` are this process's own bookkeeping. They
+    /// move on every successful read — several times a second on an
+    /// event-driven target — and nothing renders either of them. Deciding
+    /// whether to republish by comparing whole values therefore republished
+    /// always: twelve kilobytes of workspaces, panes and agents, to every
+    /// attached client, for a timestamp none of them display. On a desk that is
+    /// invisible. On a phone away from the house it is megabytes a minute
+    /// through a relay, and the stream backs up faster than the page drains it.
+    pub fn differs_for_clients(&self, other: &Self) -> bool {
+        self.key != other.key
+            || self.endpoint != other.endpoint
+            || self.connection != other.connection
+            || self.update_mode != other.update_mode
+            || self.event_error != other.event_error
+            || self.connection_generation != other.connection_generation
+            || self.selected_herdr_bin != other.selected_herdr_bin
+            || self.roots != other.roots
+            || self.snapshot != other.snapshot
+            || self.last_error != other.last_error
+    }
+
     fn new(target: &Target) -> Self {
         Self {
             key: target_key(target),


### PR DESCRIPTION
**The browser works on shared wifi and dies off it.** This is why.

Every successful snapshot read sets `last_success`, and an event-driven target
reports success several times a second. The broker decided whether to republish
a target by comparing whole values — so that timestamp made every read a
change, and every change sent the **entire** target (every workspace, pane and
agent) to every attached client.

Measured against one real session, nine panes and seven agents, to a viewer
doing nothing:

| | before | after |
|---|---|---|
| total over 20s | 2059 KiB | **342 KiB** |
| `state.target` messages | 158 | **23** |
| per minute | ~6 MB | **~820 KiB** |

At a desk that is invisible. Through the relay to a phone away from the house it
is the whole problem: the stream arrives faster than the page drains it, the
backlog grows, and what the person sees is a browser that has stopped rather
than a terminal that is busy.

## The change

`last_success` and `retry_at` are this process's own bookkeeping. Neither the
TUI nor the browser reads either of them — outside test constructors nothing in
the tree does. They are excluded from the comparison that decides whether a
client is told, while still being kept, and still being sent whenever something
a client can act on changes alongside them.

The 23 updates that remain are real: agents working, panes changing.

## Not fixed here

This makes an update **rare, not small**. A `state.target` is still a whole
snapshot of around twelve kilobytes. Sending a difference instead is the next
thing worth doing, and would take the idle cost close to nothing.

## Verified

Measured before and after against the same live Herdr session with the numbers
above, not inferred. Regression test covers both directions: a moved clock
publishes nothing, a connection change still publishes. Full gates pass — fmt,
check-docs, 422 tests, clippy with `-D warnings`.

The second commit restores a `#[test]` that the first one's insertion took from
the neighbouring test, which clippy caught as a duplicated attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J