### PR TITLE
Release 0.7.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Tagged releases and their generated change lists are available on the
 The notes below retain upgrade and security information that should not be
 inferred from commit titles alone.
 
+## 0.7.24
+
+- Fixed the browser client stalling on any connection slower than a shared
+  network. Every successful read of a target moved a `last_success` timestamp,
+  and the daemon decided whether to republish a target by comparing whole
+  values — so every read looked like a change, and every change sent the entire
+  target, every workspace, pane and agent, to every attached client several
+  times a second. Against one session with nine panes and seven agents that was
+  two megabytes every twenty seconds to a viewer doing nothing; it is now 342
+  kilobytes. Nothing displayed the timestamp that caused it. An update is now
+  rare rather than small: each one is still a whole snapshot, and sending a
+  difference instead is still to come.
+- Added `apt install super-herdr`, served from a signed repository at
+  https://mikro-design.github.io/apt, with a one-line installer that adds the
+  repository and installs in a single command. The last ten releases stay
+  installable, so a version can be pinned or stepped back to. `dpkg -i` is gone
+  from the README: it resolves no dependencies and never upgrades.
+- An apt install that fails because the system has half-configured packages now
+  says so, and names them, rather than passing on an error about whichever
+  unrelated package is broken.
+
 ## 0.7.23
 
 - Fixed creating a workspace not moving to it. 0.7.22 said it followed Herdr's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-herdr"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-herdr"
-version = "0.7.23"
+version = "0.7.24"
 edition = "2024"
 publish = false
 description = "A multi-host control plane for persistent Herdr coding-agent sessions"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To install one release without adding the repository at all, take its `.deb`
 from the releases page and let apt resolve the dependencies:
 
 ```sh
-version=0.7.23
+version=0.7.24
 arch=amd64 # or arm64
 package="super-herdr_${version}-1_${arch}.deb"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/v${version}/${package}"
@@ -84,7 +84,7 @@ sudo apt install "./${package}"
 On Linux without Homebrew or apt, take a prebuilt archive:
 
 ```sh
-tag=v0.7.23
+tag=v0.7.24
 target=x86_64-unknown-linux-gnu # or aarch64-unknown-linux-gnu
 archive="super-herdr-${tag}-${target}.tar.gz"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/${tag}/${archive}"


### PR DESCRIPTION
Version bump, changelog, and the README install examples that
`tools/check-docs.mjs` validates against the package version.

## What ships

- **Fixed (#38):** the browser client stalling on anything slower than a shared
  network. A `last_success` timestamp moved on every read of a target, and the
  daemon republished whole targets whenever anything differed — so every read
  shipped every workspace, pane and agent to every client, several times a
  second. **2059 KiB per 20s → 342 KiB**, measured against one real session.
  Nothing displayed the timestamp that caused it.
- **Added (#35, #36):** `apt install super-herdr` from a signed repository, in
  one line. Ten releases stay installable so a version can be pinned.
- **Added (#37):** an apt failure caused by half-configured packages now names
  them instead of passing on an error about something unrelated.

## Gates

`cargo fmt --check`, `node tools/check-docs.mjs` (examples now read 0.7.24),
`cargo test --locked` (422 passing), `cargo clippy --all-targets -- -D warnings`.

Tag `v0.7.24` goes on the merge commit, which triggers the publish job. The apt
repository and the Homebrew tap are updated after the release exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J