### PR TITLE
Ask for a pane the viewport can actually draw

### DIFF
--- a/src/daemon/app.html
+++ b/src/daemon/app.html
@@ -886,6 +886,10 @@ function runStyle(style) {
   return parts.join(';');
 }
 
+// The smallest size this page will draw a terminal at. Both the fit and the
+// size asked for are derived from it, so they cannot disagree.
+const MINIMUM_FONT_PIXELS = 12;
+
 function measure() {
   const host = el('screen');
   const probe = document.createElement('span');
@@ -907,9 +911,11 @@ function refit() {
   const reference = measure().width;
   const room = host.clientWidth - 2 * 0.7 * parseFloat(getComputedStyle(document.body).fontSize);
   const wanted = 14 * (room / screen.width) / reference;
-  // Below twelve pixels an 80-column pane technically fits but is not
-  // readable on a phone. Preserve legibility and let the terminal pan instead.
-  host.style.fontSize = `${Math.max(12, Math.min(16, wanted))}px`;
+  // Legibility is the floor, not the fit: a pane wider than this viewport can
+  // draw is panned rather than shrunk into unreadability. The subscription asks
+  // for a width that fits at this same size, so panning is now the exception it
+  // was meant to be rather than what every phone got.
+  host.style.fontSize = `${clamp(wanted, MINIMUM_FONT_PIXELS, 16)}px`;
   cell = measure();
 }
 
@@ -997,16 +1003,49 @@ function observe(pane, label) {
   subscribeScreen(pane);
 }
 
+// What this viewport can actually show, in character cells.
+//
+// The size matters more than it looks: the first subscriber to a pane opens the
+// route, and the route is opened at the size it asked for. Asking for eighty
+// columns from a phone therefore did two things, both wrong. It reshaped the
+// pane to a width nobody was looking at, re-wrapping the output for a terminal
+// that exists only in this request. And eighty columns cannot be drawn legibly
+// on a phone, so a third of every line sat off the right edge, reachable only
+// by panning and indistinguishable from output that was never sent.
+//
+// Measured at the smallest size `refit` will use, because a pane that fits only
+// at a size this page refuses to render is a pane that does not fit.
+function viewportCells() {
+  const host = el('screen');
+  const previous = host.style.fontSize;
+  host.style.fontSize = `${MINIMUM_FONT_PIXELS}px`;
+  const cell = measure();
+  host.style.fontSize = previous;
+  const padding = 2 * 0.7 * parseFloat(getComputedStyle(document.body).fontSize);
+  const room = Math.max(1, host.clientWidth - padding);
+  const height = Math.max(1, host.clientHeight);
+  // A terminal narrower than this is not worth reading, and one wider than a
+  // desktop is not worth asking a host to render.
+  const cols = clamp(Math.floor(room / (cell.width || 1)), 40, 200);
+  const rows = clamp(Math.floor(height / (cell.height || 1)), 10, 60);
+  return { cols, rows };
+}
+
+function clamp(value, low, high) {
+  return Math.max(low, Math.min(high, Number.isFinite(value) ? value : low));
+}
+
 // `screen` rather than `frames`: this page has no emulator and wants none.
 // One definition, because three callers ask for the same thing — opening a
 // pane, recovering from a gap, and recovering from a dropped connection.
 function subscribeScreen(pane) {
+  const { cols, rows } = viewportCells();
   send({
     type: 'pane.subscribe',
     pane,
     access: 'observe',
-    cols: 80,
-    rows: 24,
+    cols,
+    rows,
     representation: 'screen',
   });
 }

--- a/src/daemon/web.rs
+++ b/src/daemon/web.rs
@@ -692,8 +692,14 @@ mod tests {
         );
         assert_eq!(APP.matches("class=\"code-box\"").count(), 8);
         assert!(APP.contains("el('code').onpaste"));
-        assert!(APP.contains("Math.max(12"));
+        // The legibility floor, which is also the size the subscription asks
+        // for a pane to fit at. One constant, because a page that renders at a
+        // size it did not ask for is a page with output off the edge.
+        assert!(APP.contains("MINIMUM_FONT_PIXELS = 12"));
+        assert!(APP.contains("clamp(wanted, MINIMUM_FONT_PIXELS"));
+        assert!(APP.contains("host.style.fontSize = `${MINIMUM_FONT_PIXELS}px`"));
         assert!(!APP.contains("Math.max(7"));
+        assert!(!APP.contains("cols: 80,"));
         assert!(APP.contains("interactive-widget=resizes-content"));
         assert!(APP.contains("type=\"file\""));
         assert!(APP.contains("type: 'upload.begin'"));

--- a/tools/page-harness.mjs
+++ b/tools/page-harness.mjs
@@ -27,6 +27,7 @@ const node = id => {
       select() { this.selected = true; },
       getBoundingClientRect: () => ({ width: 8, height: 16 }),
       clientWidth: 800,
+      clientHeight: 400,
       appendChild(child) { this.children.push(child); },
     };
     held.classList = {
@@ -254,6 +255,20 @@ deliver({ type: 'attention.history', events: [] });
 // Watching a pane: observing, and no keyboard offered.
 page.observe(pane, 'first/main/w1:p1');
 check('subscribes on observe', sent.some(one => one.body.type === 'pane.subscribe'));
+// The route is opened at the size the first subscriber asks for, so asking for
+// a fixed eighty columns reshaped the pane and pushed a third of every line off
+// a phone's screen. The request is derived from the viewport now, and stays
+// inside bounds a terminal is worth rendering at.
+{
+  const subscribe = sent.find(one => one.body.type === 'pane.subscribe').body;
+  check('the size asked for is not a fixed 80x24',
+    !(subscribe.cols === 80 && subscribe.rows === 24));
+  check('the columns asked for suit the viewport',
+    subscribe.cols >= 40 && subscribe.cols <= 200);
+  check('the rows asked for suit the viewport',
+    subscribe.rows >= 10 && subscribe.rows <= 60);
+  check('the rows asked for follow the height on offer', subscribe.rows === 25);
+}
 check('no keyboard while observing', page.el('keyboard').hidden === true);
 check('control is offered', page.el('control').hidden === false);
 


### PR DESCRIPTION
**Reported from a phone: "text is cut on the right edge — I do not see the full
output."** It was not a rendering detail. The browser was reshaping the pane.

The page subscribed with a fixed `cols: 80, rows: 24`, and **the first
subscriber to a pane opens the route at the size it asks for**
(`broker.rs:1362`). From a phone that did two things, both wrong:

- **It reshaped the pane.** The panes in the session this was found on are
  **54 columns**. Attaching a phone re-wrapped them to 80, for a terminal that
  existed only in that request and that nobody was looking at.
- **80 columns cannot be drawn legibly on a phone.** `refit` stops shrinking at
  12px and pans instead, which is right — but at that size 80 columns is around
  580 physical pixels against a viewport of roughly 390. A third of every line
  sat off the right edge, reachable only by panning and **indistinguishable from
  output that was never sent**.

## The change

The requested size is derived from the viewport, measured at the same minimum
size `refit` will draw at, so the two cannot disagree: a pane that fits only at
a size this page refuses to render is a pane that does not fit.

Bounded at 40 columns, below which a terminal is not worth reading, and 200,
above which it is not worth asking a host to render.

Panning survives for a pane genuinely wider than the viewport — it is the
exception it was meant to be rather than what every phone got.

## Verification

- 202 harness assertions pass, including four new ones asserting the request
  follows the viewport rather than a constant.
- **I checked the new assertions fail with the old hardcoded size** — they
  report `FAIL: the size asked for is not a fixed 80x24`.
- The stub DOM grows a height so the rows can be checked, not only the columns.
- Full gates: fmt, check-docs, 422 tests, clippy `-D warnings`, plus the remote
  route and bridge harnesses.

The second commit follows a page test that pinned the 12px floor by matching the
literal `Math.max(12`; the floor did not move, it became a named constant
because the requested size now derives from the same number. The assertion
checks the constant, and gains one: the page must not ask for a fixed 80 columns
again.

## Not in this PR

The Send button appends `\r` to the line and sends both in **one**
`pane.input` write, which an agent TUI can read as a paste — inserting the
newline instead of submitting. Reported, diagnosed, deliberately unfixed here
until the diagnosis is confirmed on a real pane. Quick replies concatenate the
same way (`app.html:1158`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J