### PR TITLE
Release 0.7.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Tagged releases and their generated change lists are available on the
 The notes below retain upgrade and security information that should not be
 inferred from commit titles alone.
 
+## 0.7.25
+
+- Fixed the browser cutting off the right of every line on a phone. The page
+  subscribed with a fixed eighty columns, and the first subscriber to a pane
+  opens the route at the size it asks for — so a phone reshaped panes that were
+  fifty-four columns wide to eighty, then could not draw eighty columns legibly
+  on a phone-width screen. A third of each line sat off the edge, reachable only
+  by panning and indistinguishable from output that was never sent. The size
+  asked for now follows the viewport, measured at the same minimum font size the
+  page will draw at.
+- Fixed `--config <name>` with a bare file name failing every configuration
+  write, which meant a device could never pair against it. `Path::parent` of
+  such a path is the empty path rather than the current directory, and securing
+  the empty path fails; the daemon reported a configuration directory it could
+  not secure and named no directory. Adding a target and revoking a device
+  failed the same way.
+
 ## 0.7.24
 
 - Fixed the browser client stalling on any connection slower than a shared

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-herdr"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-herdr"
-version = "0.7.24"
+version = "0.7.25"
 edition = "2024"
 publish = false
 description = "A multi-host control plane for persistent Herdr coding-agent sessions"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To install one release without adding the repository at all, take its `.deb`
 from the releases page and let apt resolve the dependencies:
 
 ```sh
-version=0.7.24
+version=0.7.25
 arch=amd64 # or arm64
 package="super-herdr_${version}-1_${arch}.deb"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/v${version}/${package}"
@@ -84,7 +84,7 @@ sudo apt install "./${package}"
 On Linux without Homebrew or apt, take a prebuilt archive:
 
 ```sh
-tag=v0.7.24
+tag=v0.7.25
 target=x86_64-unknown-linux-gnu # or aarch64-unknown-linux-gnu
 archive="super-herdr-${tag}-${target}.tar.gz"
 curl -fLO "https://github.com/mikro-design/super-herdr/releases/download/${tag}/${archive}"


### PR DESCRIPTION
Version bump, changelog, and the README install examples that
`tools/check-docs.mjs` validates against the package version.

## What ships

- **Fixed (#40):** the browser cutting off the right of every line on a phone.
  The page asked for a fixed 80 columns, and the first subscriber to a pane
  opens the route at the size it asks for — so a phone reshaped 54-column panes
  to 80, then could not draw 80 columns legibly on a ~390px screen. A third of
  each line sat off the edge, indistinguishable from output never sent.
- **Fixed (#41):** `--config <bare name>` failing every configuration write, so
  a device could never pair against it. `Path::parent` of such a path is the
  empty path, not the current directory, and securing it fails with ENOENT.
  Adding a target and revoking a device failed the same way, and always had.

Both were found by using the thing rather than by reading it.

## Gates

`cargo fmt --check`, `node tools/check-docs.mjs` (examples now read 0.7.25),
`cargo test --locked` (423 passing), `cargo clippy --all-targets -- -D warnings`.

Tag `v0.7.25` goes on the merge commit, which triggers the publish job. The
Homebrew tap and the APT repository are updated after the release exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GckBsVtcNzaqhEsbbGL77J